### PR TITLE
Add shard option to enable parallel execution

### DIFF
--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -73,8 +73,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shardIndex: [ 1, 2, 3, 4 ]
-        shardTotal: [ 4 ]
+        shard: [ 1/4, 2/4, 3/4, 4/4 ]
     steps:
       - name: Delete unnecessary tools 🔧
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -127,7 +126,7 @@ jobs:
           disk-size: 6000M
           heap-size: 600M
           script: |
-            arbigent-cli/build/install/arbigent/bin/arbigent --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android.yaml --ai-type=gemini --gemini-model-name=gemini-2.0-flash-exp --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+            arbigent-cli/build/install/arbigent/bin/arbigent --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android.yaml --ai-type=gemini --gemini-model-name=gemini-2.0-flash-exp --shard=${{ matrix.shard }}
 
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         if: ${{ always() }}

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -73,7 +73,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [ 1/4, 2/4, 3/4, 4/4 ]
+        shardIndex: [ 1, 2, 3, 4 ]
+        shardTotal: [ 4 ]
     steps:
       - name: Delete unnecessary tools 🔧
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -126,12 +127,12 @@ jobs:
           disk-size: 6000M
           heap-size: 600M
           script: |
-            arbigent-cli/build/install/arbigent/bin/arbigent --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android.yaml --ai-type=gemini --gemini-model-name=gemini-2.0-flash-exp --shard=${{ matrix.shard }}
+            arbigent-cli/build/install/arbigent/bin/arbigent --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android.yaml --ai-type=gemini --gemini-model-name=gemini-2.0-flash-exp --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         if: ${{ always() }}
         with:
-          name: cli-report-android-${{ matrix.shard }}
+          name: cli-report-android-${{ matrix.shardIndex }}-${{ matrix.shardTotal }}
           path: |
             arbigent-result/*
           retention-days: 120

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -132,7 +132,7 @@ jobs:
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         if: ${{ always() }}
         with:
-          name: cli-report-android
+          name: cli-report-android-${{ matrix.shardIndex }}-${{ matrix.shardTotal }}
           path: |
             arbigent-result/*
           retention-days: 120

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -131,7 +131,7 @@ jobs:
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         if: ${{ always() }}
         with:
-          name: cli-report-android-${{ matrix.shardIndex }}-${{ matrix.shardTotal }}
+          name: cli-report-android-${{ matrix.shard }}
           path: |
             arbigent-result/*
           retention-days: 120

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -70,6 +70,11 @@ jobs:
 
   cli-e2e-android:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shardIndex: [ 1, 2, 3, 4 ]
+        shardTotal: [ 4 ]
     steps:
       - name: Delete unnecessary tools 🔧
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -122,7 +127,7 @@ jobs:
           disk-size: 6000M
           heap-size: 600M
           script: |
-            arbigent-cli/build/install/arbigent/bin/arbigent --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android.yaml --ai-type=gemini --gemini-model-name=gemini-2.0-flash-exp
+            arbigent-cli/build/install/arbigent/bin/arbigent --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android.yaml --ai-type=gemini --gemini-model-name=gemini-2.0-flash-exp --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
 
       - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
         if: ${{ always() }}

--- a/arbigent-cli/src/main/kotlin/main.kt
+++ b/arbigent-cli/src/main/kotlin/main.kt
@@ -5,13 +5,12 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.core.main
 import com.github.ajalt.clikt.parameters.groups.OptionGroup
 import com.github.ajalt.clikt.parameters.groups.defaultByName
 import com.github.ajalt.clikt.parameters.groups.groupChoice
-import com.github.ajalt.clikt.parameters.options.default
-import com.github.ajalt.clikt.parameters.options.option
-import com.github.ajalt.clikt.parameters.options.prompt
+import com.github.ajalt.clikt.parameters.options.*
 import com.github.ajalt.clikt.parameters.types.choice
 import com.jakewharton.mosaic.layout.background
 import com.jakewharton.mosaic.layout.padding
@@ -81,6 +80,28 @@ class ArbigentCli : CliktCommand() {
     .choice("debug", "info", "warn", "error")
     .default("info")
 
+  private val shard by option("--shard", help = "Shard specification (e.g., 1/5)")
+    .convert { input ->
+      val regex = """(\d+)/(\d+)""".toRegex()
+      val match = regex.matchEntire(input)
+        ?: throw CliktError("Invalid shard format. Use `<current>/<total>` (e.g., 1/5)")
+
+      val (currentStr, totalStr) = match.destructured
+      val current = currentStr.toIntOrNull()
+        ?: throw CliktError("Shard number must be an integer")
+      val total = totalStr.toIntOrNull()
+        ?: throw CliktError("Total shards must be an integer")
+
+      when {
+        total < 1 -> throw CliktError("Total shards must be at least 1")
+        current < 1 -> throw CliktError("Shard number must be at least 1")
+        current > total -> throw CliktError("Shard number ($current) exceeds total ($total)")
+      }
+
+      current - 1 to total
+    }
+    .default(0 to 1)
+
   @OptIn(ArbigentInternalApi::class)
   override fun run() {
     val resultDir = File("arbigent-result")
@@ -124,11 +145,12 @@ class ArbigentCli : CliktCommand() {
           }")
     val device = fetchAvailableDevicesByOs(os).firstOrNull()?.connectToDevice()
       ?: throw IllegalArgumentException("No available device found")
-    arbigentLogLevel = ArbigentLogLevel.entries.find { it.name.toLowerCasePreservingASCIIRules() == logLevel.toLowerCasePreservingASCIIRules() }
-      ?: throw IllegalArgumentException(
-        "Invalid log level. The log level should be one of ${
-          ArbigentLogLevel.values().joinToString(", ") { it.name.toLowerCasePreservingASCIIRules() }
-        }")
+    arbigentLogLevel =
+      ArbigentLogLevel.entries.find { it.name.toLowerCasePreservingASCIIRules() == logLevel.toLowerCasePreservingASCIIRules() }
+        ?: throw IllegalArgumentException(
+          "Invalid log level. The log level should be one of ${
+            ArbigentLogLevel.values().joinToString(", ") { it.name.toLowerCasePreservingASCIIRules() }
+          }")
 
     val arbigentProject = ArbigentProject(
       file = File(projectFile),
@@ -146,7 +168,7 @@ class ArbigentCli : CliktCommand() {
 
     runNoRawMosaicBlocking {
       LaunchedEffect(Unit) {
-        arbigentProject.execute()
+        arbigentProject.executeShard(shard.first, shard.second)
         // Show the result
         delay(100)
         if (arbigentProject.isAllLeafScenariosSuccessful()) {

--- a/arbigent-cli/src/main/kotlin/main.kt
+++ b/arbigent-cli/src/main/kotlin/main.kt
@@ -181,7 +181,6 @@ class ArbigentCli : CliktCommand() {
       }
       Column {
         val assignments by arbigentProject.scenarioAssignmentsFlow.collectAsState(arbigentProject.scenarioAssignments())
-        println("shard: $shard")
         assignments
           .filter { it.scenario.isLeaf }
           .shard(shard)

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
@@ -6,7 +6,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import java.io.File
-import kotlin.math.ceil
 import kotlin.math.min
 
 public class FailedToArchiveException(message: String) : RuntimeException(message)
@@ -134,18 +133,18 @@ public data class ArbigentScenario(
 }
 
 /**
- * [current] starts from 1
+ * [index] starts from 1
  */
-public data class ArbigentShard(val current: Int, val total: Int) {
+public data class ArbigentShard(val index: Int, val total: Int) {
   init {
     require(total >= 1) { "Total shards must be at least 1" }
-    require(current >= 1) { "Shard number must be at least 1" }
-    require(current <= total) { "Shard number ($current) exceeds total ($total)" }
+    require(index >= 1) { "Shard number must be at least 1" }
+    require(index <= total) { "Shard number ($index) exceeds total ($total)" }
   }
 
   override fun toString(): String {
     if (total == 1) return ""
-    return "Shard($current/$total)"
+    return "Shard($index/$total)"
   }
 }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
@@ -144,6 +144,7 @@ public data class ArbigentShard(val current: Int, val total: Int) {
   }
 
   override fun toString(): String {
+    if (total == 1) return ""
     return "Shard($current/$total)"
   }
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
@@ -134,7 +134,7 @@ public data class ArbigentScenario(
 }
 
 /**
- * @current starts from 1
+ * [current] starts from 1
  */
 public data class ArbigentShard(val current: Int, val total: Int) {
   init {
@@ -154,9 +154,30 @@ public fun <T> List<T>.shard(
 ): List<T> {
   val (current, total) = shard
 
-  val shardSize = ceil(size.toDouble() / total).toInt()
-  val start = (current - 1) * shardSize
-  val end = min(start + shardSize, size)
+  if (current > total || total <= 0 || current <= 0) {
+    return emptyList()
+  }
 
-  return subList(start, end)
+  val size = this.size
+  if (size == 0) return emptyList()
+
+  val baseShardSize = size / total
+  val remainder = size % total
+
+  val shardSize = if (current <= remainder) baseShardSize + 1 else baseShardSize
+
+  val start = if (current <= remainder) {
+    (current - 1) * (baseShardSize + 1)
+  } else {
+    remainder * (baseShardSize + 1) + (current - 1 - remainder) * baseShardSize
+  }
+
+  if (start >= size) {
+    return emptyList()
+  }
+
+  val end = start + shardSize
+  val adjustedEnd = min(end, size)
+
+  return subList(start, adjustedEnd)
 }

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentShardTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentShardTest.kt
@@ -1,0 +1,27 @@
+package io.github.takahirom.arbigent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ArbigentShardTest {
+  @Test
+  fun shard() {
+    class TestCase(val input: List<Int>, val shard: ArbigentShard, val expected: List<Int>)
+    listOf(
+      TestCase(listOf(1, 2), ArbigentShard(1, 2), listOf(1)),
+      TestCase(listOf(1, 2), ArbigentShard(2, 2), listOf(2)),
+      TestCase(listOf(1), ArbigentShard(1, 2), listOf(1)),
+      TestCase(listOf(1), ArbigentShard(2, 2), listOf()),
+      TestCase(listOf(1, 2), ArbigentShard(4, 4), listOf()),
+      TestCase(listOf(1, 2, 3), ArbigentShard(1, 2), listOf(1, 2)),
+      TestCase(listOf(1, 2, 3), ArbigentShard(2, 2), listOf(3)),
+      TestCase(listOf(1, 2, 3, 4), ArbigentShard(1, 3), listOf(1, 2)),
+      TestCase(listOf(1, 2, 3, 4), ArbigentShard(2, 3), listOf(3)),
+      TestCase(listOf(1, 2, 3, 4), ArbigentShard(3, 3), listOf(4)),
+      TestCase(listOf(1, 2, 3, 4), ArbigentShard(1, 2), listOf(1, 2)),
+      TestCase(listOf(1, 2, 3, 4), ArbigentShard(2, 2), listOf(3, 4)),
+    ).forEach {
+      assertEquals(it.expected, it.input.shard(it.shard), "input: ${it.input}, shard: ${it.shard}")
+    }
+  }
+}


### PR DESCRIPTION
```yaml
  cli-e2e-android:
    runs-on: ubuntu-latest
    strategy:
      fail-fast: false
      matrix:
        shardIndex: [ 1, 2, 3, 4 ]
        shardTotal: [ 4 ]
    steps:
...
      - name: CLI E2E test
        uses: reactivecircus/android-emulator-runner@v2
        env:
          GEMINI_API_KEY: ${{ secrets.GEMINI_FREE_API_KEY }}
        with:
...
          script: |
            arbigent --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android.yaml --ai-type=gemini --gemini-model-name=gemini-2.0-flash-exp
...

      - uses: actions/upload-artifact@b4b15b8c7c6ac21ea08fcf65892d2ee8f75cf882 # v4
        if: ${{ always() }}
        with:
          name: cli-report-android-${{ matrix.shardIndex }}-${{ matrix.shardTotal }}
          path: |
            arbigent-result/*
          retention-days: 90
```