### PR TITLE
Add tests for variable substitution feature

### DIFF
--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -144,7 +144,7 @@ jobs:
           disk-size: 6000M
           heap-size: 600M
           script: |
-            arbigent-cli/build/install/arbigent/bin/arbigent run --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android.yaml --ai-type=gemini --gemini-model-name=gemini-2.5-flash-lite-preview-06-17 --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
+            arbigent-cli/build/install/arbigent/bin/arbigent run --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android.yaml --ai-type=gemini --gemini-model-name=gemini-2.5-flash-lite-preview-06-17 --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --variables "search_term=Bluetooth,app_package=com.android.camera2"
       - name: Check API key leakage
         run: |
           if grep -R --quiet "${{ secrets.GEMINI_FREE_API_KEY }}" arbigent-result/; then

--- a/sample-test/src/main/resources/projects/e2e-test-android.yaml
+++ b/sample-test/src/main/resources/projects/e2e-test-android.yaml
@@ -45,6 +45,33 @@ scenarios:
   goal: "All you have to do is launch com.android.settings using mcp launch_app"
   initializationMethods:
   - type: "Back"
+- id: "variable-substitution-test"
+  goal: "Search for {{search_term}} in the Settings app and verify it appears in search results"
+  initializationMethods:
+  - type: "Back"
+    times: 5
+  - type: "LaunchApp"
+    packageName: "com.android.settings"
+  tags:
+  - name: "VariableSubstitution"
+  - name: "Settings"
+  - name: "Search"
+- id: "variable-app-launch-test"
+  goal: "Launch the {{app_package}} app using the launch_app tool"
+  initializationMethods:
+  - type: "Back"
+    times: 3
+  tags:
+  - name: "VariableSubstitution"
+  - name: "AppLaunch"
+- id: "escaped-variable-test"
+  goal: "Open Settings and search for the literal text '\\{{search_term}}' (including the curly braces). This tests that escaped variables are preserved as-is. The search should find no results since '\\{{search_term}}' is not a real setting."
+  initializationMethods:
+  - type: "LaunchApp"
+    packageName: "com.android.settings"
+  tags:
+  - name: "EscapedVariable"
+  - name: "Settings"
 fixedScenarios:
 - id: "3c441e6f-6178-4b4f-b2a2-fbdbf8fa4266"
   title: "launch setting by maestro"


### PR DESCRIPTION
## Summary
This PR adds a variable substitution feature to Arbigent, allowing users to use `{{variable_name}}` placeholders in goals that get replaced with runtime values.

## Changes
- Added `GoalVariableResolver` for handling variable substitution with security validation
- Added `--variables` option to CLI for passing key=value pairs
- Added variables field to UI App Settings
- Support for escaped variables using `\{{variable_name}}` syntax
- Added comprehensive unit tests and E2E test scenarios
- Updated CI workflow to test variable substitution

## Test plan
- [x] Unit tests pass for GoalVariableResolver
- [x] E2E test scenarios added for variable substitution
- [x] CI workflow updated to run tests with variables
- [ ] Manual testing of variable substitution in UI and CLI