### PR TITLE
Fix MCP tool action log ambiguity

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentContextHolder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentContextHolder.kt
@@ -46,7 +46,9 @@ public class ArbigentContextHolder(
         imageDescription?.let { append("image description: $it\n") }
         memo?.let { append("memo: $it\n") }
         feedback?.let { append("feedback: $it\n") }
-        agentAction?.let { append("action done: ${it.stepLogText()}\n") }
+        if (feedback == null) {
+          agentAction?.let { append("action done: ${it.stepLogText()}\n") }
+        }
       }
     }
 

--- a/sample-test/src/main/resources/projects/e2e-test-android.yaml
+++ b/sample-test/src/main/resources/projects/e2e-test-android.yaml
@@ -14,8 +14,7 @@ scenarios:
   imageAssertions:
   - assertionPrompt: "The screen should display the \"About emulated device\" page."
 - id: "open-model-page"
-  goal: "Scroll and open \"Model\" page in \"About emulated device\" page. Be careful\
-    \ not to open other pages"
+  goal: "First click on 'About emulated device' to enter the page, then scroll down and open \"Model\" page in \"About emulated device\" page. Be careful not to open other pages"
   dependency: "f9c17741-093e-49f0-ad45-8311ba68c1a6"
   tags:
   - name: "Settings"


### PR DESCRIPTION
Fixes MCP tool feedback ambiguity where action logs appeared twice.

When MCP tools execute, they now show:
- Step 1: action done (execution)  
- Step 2: feedback only (result)

This prevents AI from thinking the same action executed twice.

Fixes #334