### PR TITLE
Fix Options section scroll positioning

### DIFF
--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/Scenario.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/Scenario.kt
@@ -182,14 +182,15 @@ fun Scenario(
       }
     }
     BoxWithConstraints {
+      val maxHeightValue = maxHeight
       ExpandableSection(
         title = "Options",
         modifier = Modifier.fillMaxWidth()
-          .heightIn(max = maxHeight * 0.7f)
-          .verticalScroll(rememberScrollState())
       ) {
         Column(
           modifier = Modifier.testTag("scenario_options")
+            .heightIn(max = maxHeightValue * 0.7f)
+            .verticalScroll(rememberScrollState())
             .wrapContentHeight(unbounded = true)
         ) {
           ScenarioOptions(scenarioStateHolder, scenarioCountById, dependencyScenarioMenu, onShowFixedScenariosDialog, getFixedScenarioById)


### PR DESCRIPTION
# What
Fixed Options section to remain at the top without scrolling when expanded/collapsed.

# Why
The Options section was scrolling when toggled, making it inconvenient for users. Now only the content inside Options scrolls while the header stays fixed at the top.