### PR TITLE
Fix UI element detection for checked and selected elements

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -162,7 +162,12 @@ public data class ArbigentElementList(
           (clickable == true || focused == true
             || attributes["clickable"] == "true"
             || attributes["focused"] == "true"
-            || attributes["focusable"] == "true")
+            || attributes["focusable"] == "true"
+            || checked == true
+            || attributes["checked"] == "true"
+            || selected == true
+            || attributes["selected"] == "true"
+          )
         } else {
           isMeaningfulView()
         }


### PR DESCRIPTION
Fix UI element detection to include elements with checked=true or selected=true states. This resolves issue #340 where interactive elements like radio buttons were being filtered out from AI prompts.