### PR TITLE
Fix iOS CI Xcode compatibility

### DIFF
--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -160,7 +160,9 @@ jobs:
           retention-days: 120
 
   cli-e2e-ios:
-    runs-on: macos-latest
+    # Use macOS 14 as it has Xcode 15.4 pre-installed at /Applications/Xcode_15.4.app
+    # macOS 15 (macos-latest) does not include Xcode 15.4 by default
+    runs-on: macos-14
     concurrency:
       group: ${{ github.workflow }}-cli-e2e-ios-${{ github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
# What
Fix iOS CI failure by using macOS 14 runner which has Xcode 15.4 pre-installed

# Why
The CI was failing with xcode-select error because macos-latest is transitioning to macOS 15 which does not have Xcode 15.4 pre-installed