### PR TITLE
Move maestro dependencies to version catalog

### DIFF
--- a/arbigent-core/build.gradle.kts
+++ b/arbigent-core/build.gradle.kts
@@ -30,11 +30,11 @@ buildConfig {
 
 dependencies {
   implementation(project(":arbigent-core-web-report"))
-  api("dev.mobile:maestro-orchestra:1.40.0")
-  api("dev.mobile:maestro-client:1.40.0")
+  api(libs.maestro.orchestra)
+  api(libs.maestro.client)
   implementation("dev.mobile:dadb:1.2.9")
-  api("dev.mobile:maestro-ios:1.40.0")
-  api("dev.mobile:maestro-ios-driver:1.40.0")
+  api(libs.maestro.ios)
+  api(libs.maestro.ios.driver)
 
   api(project(":arbigent-core-model"))
   api(project(":arbigent-mcp-client"))

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ kotlinx-datetime = "0.7.1"
 kotlinx-io = "0.3.3"
 webpImageio = "0.3.3"
 identityJvm = "202411.1"
+maestro = "1.40.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -42,6 +43,11 @@ ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", 
 kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
 identity-jvm = { group = "com.android.identity", name = "identity-jvm", version.ref = "identityJvm" }
 webp-imageio = { module = "io.github.darkxanter:webp-imageio", version.ref = "webpImageio" }
+
+maestro-orchestra = { module = "dev.mobile:maestro-orchestra", version.ref = "maestro" }
+maestro-client = { module = "dev.mobile:maestro-client", version.ref = "maestro" }
+maestro-ios = { module = "dev.mobile:maestro-ios", version.ref = "maestro" }
+maestro-ios-driver = { module = "dev.mobile:maestro-ios-driver", version.ref = "maestro" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/sample-test/build.gradle.kts
+++ b/sample-test/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation(project(":arbigent-core"))
     implementation(project(":arbigent-ai-openai"))
     // maestro client
-    api("dev.mobile:maestro-client:1.40.0")
+    api(libs.maestro.client)
     testImplementation(kotlin("test"))
     // coroutine test
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.2")


### PR DESCRIPTION
# What
Migrate maestro dependencies from hardcoded versions in build.gradle.kts files to centralized version catalog management.

# Why
- Centralizes version management for maestro dependencies
- Follows Gradle version catalog best practices  
- Easier to maintain and update maestro versions across modules

Changes:
- Added maestro version (1.40.0) to libs.versions.toml
- Added maestro library definitions to libs.versions.toml  
- Updated arbigent-core and sample-test modules to use version catalog references