### PR TITLE
Document maestro 2.0.0 upgrade requirements

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ kotlinx-datetime = "0.7.1"
 kotlinx-io = "0.3.3"
 webpImageio = "0.3.3"
 identityJvm = "202411.1"
-maestro = "1.40.0"
+maestro = "1.40.0" # 2.0.0 available but requires API compatibility fixes
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }


### PR DESCRIPTION
# What
Add documentation comment about maestro 2.0.0 availability and upgrade requirements.

# Why
- Maestro 2.0.0 is available but contains significant API breaking changes
- Documents the upgrade blocker to prevent future confusion
- Provides context for future maintainers about version constraints

Technical details:
- Maestro 2.0.0 requires API compatibility fixes in Orchestra, executeCommands, iOS drivers, and element finding methods
- Current version (1.40.0) remains stable and working
- Future upgrade work can reference this documentation