### PR TITLE
Limit additional actions to ClickWithText only

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -911,11 +911,6 @@ public fun defaultAgentActionTypesForTvForVisualMode(): List<AgentActionType> {
 private fun getAgentActionTypeByName(actionName: String): AgentActionType? {
   return when (actionName) {
     "ClickWithText" -> ClickWithTextAgentAction
-    "ClickWithId" -> ClickWithIdAgentAction
-    "ClickWithIndex" -> ClickWithIndex
-    "DpadTryAutoFocusById" -> DpadAutoFocusWithIdAgentAction
-    "DpadTryAutoFocusByText" -> DpadAutoFocusWithTextAgentAction
-    "DpadTryAutoFocusByIndex" -> DpadAutoFocusWithIndexAgentAction
     else -> null
   }
 }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/AdditionalActionsConstants.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/AdditionalActionsConstants.kt
@@ -2,10 +2,6 @@ package io.github.takahirom.arbigent.ui
 
 object AdditionalActionsConstants {
   val AVAILABLE_ACTIONS = listOf(
-    "ClickWithText",
-    "ClickWithId",
-    "DpadTryAutoFocusById",
-    "DpadTryAutoFocusByText",
-    "DpadTryAutoFocusByIndex"
+    "ClickWithText"
   )
 }

--- a/arbigent-ui/src/test/kotlin/AdditionalActionsTest.kt
+++ b/arbigent-ui/src/test/kotlin/AdditionalActionsTest.kt
@@ -131,11 +131,7 @@ class AdditionalActionsTest {
     @Test
     fun `AdditionalActionsConstants AVAILABLE_ACTIONS should contain all supported actions`() {
         val expectedActions = listOf(
-            "ClickWithText",
-            "ClickWithId",
-            "DpadTryAutoFocusById",
-            "DpadTryAutoFocusByText",
-            "DpadTryAutoFocusByIndex"
+            "ClickWithText"
         )
 
         assertEquals(expectedActions, AdditionalActionsConstants.AVAILABLE_ACTIONS)


### PR DESCRIPTION
# What
Simplified the additional actions feature to only expose ClickWithText.

# Why
Reduce maintenance cost by removing unused additional action types (ClickWithId, ClickWithIndex, DpadTryAutoFocus*). Only ClickWithText is actually needed based on current requirements.