### PR TITLE
Add support for real iOS devices (physical iPhones/iPads) in addition…

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
@@ -2,6 +2,9 @@ package io.github.takahirom.arbigent
 
 import dadb.Dadb
 import util.LocalSimulatorUtils
+import util.SimctlList
+import java.io.BufferedReader
+import java.io.InputStreamReader
 
 @ArbigentInternalApi
 public fun fetchAvailableDevicesByOs(deviceType: ArbigentDeviceOs): List<ArbigentAvailableDevice> {
@@ -11,17 +14,66 @@ public fun fetchAvailableDevicesByOs(deviceType: ArbigentDeviceOs): List<Arbigen
     }
 
     ArbigentDeviceOs.Ios -> {
-      LocalSimulatorUtils.list()
+      // Get simulators
+      val simulators = LocalSimulatorUtils.list()
         .devices
         .flatMap { runtime ->
           runtime.value
             .filter { it.isAvailable && it.state == "Booted" }
         }
         .map { ArbigentAvailableDevice.IOS(it) }
+
+      // Get real devices
+      val realDevices = getRealIOSDevices()
+
+      // Return combined list (real devices first, then simulators)
+      realDevices + simulators
     }
 
     else -> {
       listOf(ArbigentAvailableDevice.Web())
     }
+  }
+}
+
+@ArbigentInternalApi
+private fun getRealIOSDevices(): List<ArbigentAvailableDevice> {
+  return try {
+    val process = ProcessBuilder("xcrun", "xctrace", "list", "devices")
+      .redirectErrorStream(true)
+      .start()
+
+    val reader = BufferedReader(InputStreamReader(process.inputStream))
+    val devices = mutableListOf<ArbigentAvailableDevice>()
+    var inDevicesSection = false
+
+    reader.forEachLine { line ->
+      when {
+        line.startsWith("== Devices ==") -> {
+          inDevicesSection = true
+        }
+        line.startsWith("== Devices Offline ==") || line.startsWith("== Simulators ==") -> {
+          inDevicesSection = false
+        }
+        inDevicesSection && line.isNotBlank() -> {
+          // Parse real device line: "Qa test 15  (26.0.1) (00008130-001651342231001C)"
+          val devicePattern = """^(.+?)\s+\((.+?)\)\s+\(([A-F0-9-]+)\)$""".toRegex()
+          devicePattern.find(line.trim())?.let { match ->
+            val (name, version, udid) = match.destructured
+            devices.add(ArbigentAvailableDevice.RealIOS(
+              deviceName = name.trim(),
+              udid = udid
+            ))
+          }
+        }
+      }
+    }
+
+    process.waitFor()
+    arbigentInfoLog("Found ${devices.size} real iOS device(s): ${devices.map { it.name }}")
+    devices
+  } catch (e: Exception) {
+    arbigentInfoLog("Failed to detect real iOS devices: ${e.message}")
+    emptyList()
   }
 }


### PR DESCRIPTION
  Add support for real iOS devices (physical iPhones/iPads) in addition to existing simulator support. This enables testing on actual hardware via the maestro-ios-device daemon.

  Inspired by: https://github.com/devicelab-dev/maestro-ios-device

  Changes

  - New RealIOS device class (ArbigentDeviceOs.kt:98-164): Implements connection to real iOS devices through maestro-ios-device daemon running on port 6001
  - Passthrough XCTestInstaller: Creates a lightweight installer that connects to existing maestro-ios-device XCTest server rather than managing its own installation
  - Real device detection (DeviceFinder.kt:40-77): New getRealIOSDevices() function uses xcrun xctrace list devices to automatically detect connected physical iOS devices
  - Unified device discovery: fetchAvailableDevicesByOs() now returns both real devices and simulators for iOS, with real devices prioritized first

  Technical Details

  - Real devices connect via IPv6 localhost [::1] on port 6001 (maestro-ios-device default)
  - Uses passthrough approach to leverage existing maestro-ios-device server without managing lifecycle
  - Note: simctl operations (clearState, addMedia, etc.) are not supported on real devices
  - Device detection parses xctrace output to identify connected physical devices by UDID

Verified Test Cases

  - Verify simulators continue to work as before
  - Connect a physical iOS device and ensure it's detected
  - Run test scenarios on real device via arbigent run
  - Confirm real devices appear before simulators in device list
