### PR TITLE
Upgrade Maestro from 1.40.0 to 2.1.0

### DIFF
--- a/arbigent-cli/src/main/kotlin/CommonOptions.kt
+++ b/arbigent-cli/src/main/kotlin/CommonOptions.kt
@@ -111,7 +111,7 @@ fun createAi(aiType: AiConfig, aiApiLoggingEnabled: Boolean): ArbigentAi {
   }
 }
 
-fun connectDevice(os: String): ArbigentDevice {
+suspend fun connectDevice(os: String): ArbigentDevice {
   val deviceOs =
     ArbigentDeviceOs.entries.find { it.name.toLowerCasePreservingASCIIRules() == os.toLowerCasePreservingASCIIRules() }
       ?: throw IllegalArgumentException(

--- a/arbigent-cli/src/main/kotlin/RunCommand.kt
+++ b/arbigent-cli/src/main/kotlin/RunCommand.kt
@@ -182,7 +182,7 @@ class ArbigentRunCommand : CliktCommand(name = "run") {
       return
     }
 
-    device = connectDevice(os)
+    device = kotlinx.coroutines.runBlocking { connectDevice(os) }
     Runtime.getRuntime().addShutdownHook(object : Thread() {
       override fun run() {
         arbigentProject.cancel()

--- a/arbigent-cli/src/main/kotlin/RunTaskCommand.kt
+++ b/arbigent-cli/src/main/kotlin/RunTaskCommand.kt
@@ -61,7 +61,7 @@ class ArbigentRunTaskCommand : CliktCommand(name = "task") {
 
     val (resultDir, resultFile) = setupArbigentFiles(workingDirectory, logFile)
     val ai = createAi(aiType, aiApiLoggingEnabled)
-    val device = connectDevice(os)
+    val device = kotlinx.coroutines.runBlocking { connectDevice(os) }
 
     try {
       val scenarioContent = ArbigentScenarioContent(

--- a/arbigent-core/build.gradle.kts
+++ b/arbigent-core/build.gradle.kts
@@ -35,6 +35,7 @@ dependencies {
   implementation("dev.mobile:dadb:1.2.9")
   api(libs.maestro.ios)
   api(libs.maestro.ios.driver)
+  api(libs.maestro.web)
 
   api(project(":arbigent-core-model"))
   api(project(":arbigent-mcp-client"))

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -8,6 +8,7 @@ import maestro.UiElement.Companion.toUiElementOrNull
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.Orchestra
 import java.io.File
+import kotlinx.coroutines.runBlocking
 import kotlin.math.pow
 import kotlin.system.measureTimeMillis
 
@@ -206,7 +207,7 @@ public class MaestroDevice(
 
   @Volatile private var orchestra = Orchestra(
     maestro = maestro,
-    screenshotsDir = screenshotsDir,
+    screenshotsDir = screenshotsDir.toPath(),
   )
 
   override fun deviceName(): String {
@@ -236,7 +237,9 @@ public class MaestroDevice(
       } else {
         true
       }
-      orchestra.executeCommands(actions, shouldReinitJsEngine = shouldJsReinit)
+      runBlocking {
+        orchestra.executeCommands(actions, shouldReinitJsEngine = shouldJsReinit)
+      }
     }
   }
 
@@ -539,7 +542,8 @@ public class MaestroDevice(
             ),
           ) ?: throw MaestroException.ElementNotFound(
             "Element not found",
-            maestro.viewHierarchy().root
+            maestro.viewHierarchy().root,
+            "Element with id ${selector.id} not found"
           )
           val uiElement: UiElement = element.element
           uiElement
@@ -552,7 +556,8 @@ public class MaestroDevice(
             )
           ) ?: throw MaestroException.ElementNotFound(
             "Element not found",
-            maestro.viewHierarchy().root
+            maestro.viewHierarchy().root,
+            "Element with id containing ${selector.id} not found"
           )
           val uiElement: UiElement = element.element
           uiElement
@@ -569,7 +574,8 @@ public class MaestroDevice(
             ),
           ) ?: throw MaestroException.ElementNotFound(
             "Element not found",
-            maestro.viewHierarchy().root
+            maestro.viewHierarchy().root,
+            "Element with text ${selector.text} not found"
           )
           val uiElement: UiElement = element.element
           uiElement
@@ -582,7 +588,8 @@ public class MaestroDevice(
             )
           ) ?: throw MaestroException.ElementNotFound(
             "Element not found",
-            maestro.viewHierarchy().root
+            maestro.viewHierarchy().root,
+            "Element with text containing ${selector.text} not found"
           )
           val uiElement: UiElement = element.element
           uiElement
@@ -609,7 +616,7 @@ public class MaestroDevice(
   
   private fun updateConnection(newMaestro: Maestro) {
     this.maestro = newMaestro
-    this.orchestra = Orchestra(maestro = this.maestro, screenshotsDir = this.screenshotsDir)
+    this.orchestra = Orchestra(maestro = this.maestro, screenshotsDir = this.screenshotsDir.toPath())
   }
 
   private fun reconnectIfDisconnected() {
@@ -645,7 +652,7 @@ public class MaestroDevice(
 
         // Try to reconnect
         val newDevice = try {
-          availableDevice.connectToDevice()
+          runBlocking { availableDevice.connectToDevice() }
         } catch (e: Exception) {
           lastException = e
           arbigentInfoLog("Reconnection attempt $reconnectAttempts/$maxReconnectAttempts failed: ${e.message}")

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
@@ -1,16 +1,10 @@
 package io.github.takahirom.arbigent
 
 import dadb.Dadb
-import ios.LocalIOSDevice
-import ios.simctl.SimctlIOSDevice
-import ios.xctest.XCTestIOSDevice
 import maestro.Maestro
 import maestro.drivers.AndroidDriver
 import maestro.drivers.IOSDriver
 import util.SimctlList
-import util.XCRunnerCLIUtils
-import xcuitest.XCTestClient
-import xcuitest.XCTestDriverClient
 import xcuitest.installer.LocalXCTestInstaller
 
 public enum class ArbigentDeviceOs {
@@ -29,7 +23,7 @@ public sealed interface ArbigentAvailableDevice {
   public class Android(private val dadb: Dadb) : ArbigentAvailableDevice {
     override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Android
     override val name: String = dadb.toString()
-    override fun connectToDevice(): ArbigentDevice {
+    override suspend fun connectToDevice(): ArbigentDevice {
       val driver = AndroidDriver(
         dadb,
       )
@@ -52,53 +46,130 @@ public sealed interface ArbigentAvailableDevice {
 
   public class IOS(
     private val device: SimctlList.Device,
-    private val port: Int = 8080,
-    // local host
-    private val host: String = "[::1]",
+    private val port: Int = 22087,
+    // localhost (matches maestro-cli defaultXcTestPort)
+    private val host: String = "127.0.0.1",
   ) : ArbigentAvailableDevice {
     override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Ios
     override val name: String = device.name
-    override fun connectToDevice(): ArbigentDevice {
-      val port = port
-      val host = host
+    override suspend fun connectToDevice(): ArbigentDevice {
+      val iosDevice = createIOSDevice()
+      var iosDriver: IOSDriver? = null
+      var maestroCreated = false
 
-      val xcTestInstaller = LocalXCTestInstaller(
-        deviceId = device.udid, // Use the device's UDID
-        host = host,
-        defaultPort = port,
-        enableXCTestOutputFileLogging = true,
-      )
+      try {
+        iosDriver = IOSDriver(iosDevice = iosDevice)
+        val maestro = Maestro.ios(iosDriver)
+        maestroCreated = true
+        return MaestroDevice(maestro, availableDevice = this)
+      } catch (e: java.util.concurrent.TimeoutException) {
+        throw RuntimeException("Arbigent can not connect to iOS device in time. The likely reason why we can't connect is that you have multiple instance of Arbigent like UI and CLI of Arbigent", e)
+      } catch (e: Exception) {
+        throw RuntimeException("Failed to create iOS connection: ${e.message}", e)
+      } finally {
+        if (!maestroCreated) {
+          iosDriver?.close()
+          iosDevice.close()
+        }
+      }
+    }
 
-      val xcTestDriverClient = XCTestDriverClient(
-        installer = xcTestInstaller,
-        client = XCTestClient(host, port), // Use the same host and port as above
-      )
-
-      val xcTestDevice = XCTestIOSDevice(
+    private fun createIOSDevice(): device.IOSDevice {
+      return ios.xctest.XCTestIOSDevice(
         deviceId = device.udid,
-        client = xcTestDriverClient,
-        getInstalledApps = { XCRunnerCLIUtils.listApps(device.udid) },
+        client = createXCTestDriverClient(),
+        getInstalledApps = { emptySet() }
+      )
+    }
+
+    private fun createXCTestDriverClient(): xcuitest.XCTestDriverClient {
+      val installer = LocalXCTestInstaller(
+        deviceId = device.udid,
+        host = host,
+        deviceType = util.IOSDeviceType.SIMULATOR,
+        defaultPort = port,
+        iOSDriverConfig = createIOSDriverConfig(),
+        deviceController = createPlaceholderDevice()
       )
 
-      return MaestroDevice(
-        Maestro.ios(
-          IOSDriver(
-            LocalIOSDevice(
-              deviceId = device.udid,
-              xcTestDevice = xcTestDevice,
-              simctlIOSDevice = SimctlIOSDevice(device.udid)
-            )
+      return xcuitest.XCTestDriverClient(installer)
+    }
+
+    private fun createIOSDriverConfig(): LocalXCTestInstaller.IOSDriverConfig {
+      val customResourcesPath = System.getProperty("arbigent.maestro.resources.path")
+          ?: System.getenv("MAESTRO_RESOURCES_PATH")
+
+      return if (customResourcesPath != null) {
+          val resourceDir = java.io.File(customResourcesPath)
+          if (!resourceDir.exists()) {
+              throw IllegalStateException("Maestro resources directory not found: $customResourcesPath")
+          }
+
+          val requiredFiles = listOf("maestro-driver-ios.zip", "maestro-driver-iosUITests-Runner.zip")
+          requiredFiles.forEach { fileName ->
+              if (!java.io.File(resourceDir, fileName).exists()) {
+                  throw IllegalStateException("Required resource file not found: $fileName in $customResourcesPath")
+              }
+          }
+
+          LocalXCTestInstaller.IOSDriverConfig(
+              prebuiltRunner = true,
+              sourceDirectory = customResourcesPath,
+              context = xcuitest.installer.Context.CLI,
+              snapshotKeyHonorModalViews = null
           )
-        ),
-        availableDevice = this
-      )
+      } else {
+          LocalXCTestInstaller.IOSDriverConfig(
+              prebuiltRunner = false,
+              sourceDirectory = "driver-iPhoneSimulator",
+              context = xcuitest.installer.Context.CLI,
+              snapshotKeyHonorModalViews = null
+          )
+      }
+    }
+
+    private fun createPlaceholderDevice(): device.IOSDevice {
+      return object : device.IOSDevice {
+        override val deviceId: String = device.udid
+        override fun open() {}
+        override fun close() {}
+
+        private val error = { operation: String ->
+          throw IllegalStateException("Placeholder device used for operation '$operation'.")
+        }
+        override fun deviceInfo() = error("deviceInfo")
+        override fun viewHierarchy(excludeKeyboardElements: Boolean) = error("viewHierarchy")
+        override fun tap(x: Int, y: Int) = error("tap")
+        override fun longPress(x: Int, y: Int, durationMs: Long) = error("longPress")
+        override fun pressKey(name: String) = error("pressKey")
+        override fun pressButton(name: String) = error("pressButton")
+        override fun scroll(xStart: Double, yStart: Double, xEnd: Double, yEnd: Double, duration: Double) = error("scroll")
+        override fun input(text: String) = error("input")
+        override fun install(stream: java.io.InputStream) = error("install")
+        override fun uninstall(id: String) = error("uninstall")
+        override fun clearAppState(id: String) = error("clearAppState")
+        override fun clearKeychain() = error("clearKeychain")
+        override fun launch(id: String, launchArguments: Map<String, Any>) = error("launch")
+        override fun stop(id: String) = error("stop")
+        override fun isKeyboardVisible() = error("isKeyboardVisible")
+        override fun openLink(link: String) = error("openLink")
+        override fun takeScreenshot(out: okio.Sink, compressed: Boolean) = error("takeScreenshot")
+        override fun startScreenRecording(out: okio.Sink) = error("startScreenRecording")
+        override fun addMedia(path: String) = error("addMedia")
+        override fun setLocation(latitude: Double, longitude: Double) = error("setLocation")
+        override fun setOrientation(orientation: String) = error("setOrientation")
+        override fun isShutdown() = error("isShutdown")
+        override fun isScreenStatic() = error("isScreenStatic")
+        override fun setPermissions(id: String, permissions: Map<String, String>) = error("setPermissions")
+        override fun eraseText(charactersToErase: Int) = error("eraseText")
+      }
     }
   }
 
   public class Web : ArbigentAvailableDevice {
     override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Web
     override val name: String = "Chrome"
-    public override fun connectToDevice(): ArbigentDevice {
+    public override suspend fun connectToDevice(): ArbigentDevice {
       return MaestroDevice(
         Maestro.web(false, false),
         availableDevice = this
@@ -109,11 +180,11 @@ public sealed interface ArbigentAvailableDevice {
   public class Fake : ArbigentAvailableDevice {
     override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Android
     override val name: String = "Fake"
-    public override fun connectToDevice(): ArbigentDevice {
+    public override suspend fun connectToDevice(): ArbigentDevice {
       // This is not called
       throw UnsupportedOperationException("Fake device is not supported")
     }
   }
 
-  public fun connectToDevice(): ArbigentDevice
+  public suspend fun connectToDevice(): ArbigentDevice
 }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -18,7 +18,7 @@ class ArbigentAppStateHolder(
   private val aiFactory: () -> ArbigentAi,
   val deviceFactory: (ArbigentAvailableDevice) -> ArbigentDevice = { avaiableDevice ->
     ArbigentGlobalStatus.onConnect {
-      avaiableDevice.connectToDevice()
+      kotlinx.coroutines.runBlocking { avaiableDevice.connectToDevice() }
     }
   },
   val availableDeviceListFactory: (ArbigentDeviceOs) -> List<ArbigentAvailableDevice> = { os ->

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,7 @@ kotlinx-datetime = "0.7.1"
 kotlinx-io = "0.3.3"
 webpImageio = "0.3.3"
 identityJvm = "202411.1"
-maestro = "1.40.0"
+maestro = "2.1.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -48,6 +48,7 @@ maestro-orchestra = { module = "dev.mobile:maestro-orchestra", version.ref = "ma
 maestro-client = { module = "dev.mobile:maestro-client", version.ref = "maestro" }
 maestro-ios = { module = "dev.mobile:maestro-ios", version.ref = "maestro" }
 maestro-ios-driver = { module = "dev.mobile:maestro-ios-driver", version.ref = "maestro" }
+maestro-web = { module = "dev.mobile:maestro-web", version.ref = "maestro" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/sample-test/src/test/kotlin/RealArbigentTest.kt
+++ b/sample-test/src/test/kotlin/RealArbigentTest.kt
@@ -28,7 +28,7 @@ class RealArbigentTest {
       deviceFactory = {
         ArbigentAvailableDevice.Android(
           dadb = Dadb.discover()!!
-        ).connectToDevice()
+        ).let { kotlinx.coroutines.runBlocking { it.connectToDevice() } }
       },
       appSettings = DefaultArbigentAppSettings
     )


### PR DESCRIPTION
# What
Upgrade Maestro dependency from 1.40.0 to 2.1.0 and adapt to API changes including iOS support rewrite.

# Why
Maestro 2.x includes significant improvements. This upgrade brings the project up to date with the latest Maestro APIs.

Key changes:
- `Orchestra.screenshotsDir` now takes `Path` instead of `File`
- `Orchestra.executeCommands` is now a suspend function
- `ElementNotFound` requires a `debugMessage` parameter
- iOS connection rewritten for Maestro 2.x API (`LocalXCTestInstaller`, `XCTestDriverClient`, placeholder device pattern)
- iOS default port changed to 22087, host to 127.0.0.1
- `connectToDevice()` made suspend across all device types
- Added `maestro-web` dependency for Web support

# Known Issue: ktor version conflict (Web test CI failure)

`cli-e2e-web` CI fails with `NoClassDefFoundError: io/ktor/client/plugins/contentnegotiation/ContentNegotiation`.

**Root cause:** ktor 2.x vs 3.x classpath conflict.
- `maestro-web` (via `maestro-client`) is compiled against **ktor 2.3.6** — references `ContentNegotiation` as a class
- `arbigent` and MCP SDK (`io.modelcontextprotocol:kotlin-sdk:0.4.0`) depend on **ktor 3.x** — where `ContentNegotiation` is a top-level property, not a class
- Gradle resolves to ktor 3.x (highest version), so maestro-web's bytecode fails at runtime

**Cannot simply downgrade to ktor 2.x** because MCP SDK requires ktor 3.x (`ktor-client-cio:3.0.2`, `ktor-server-cio:3.0.2`, `ktor-server-sse:3.0.2`).

**Possible solutions:**
1. Exclude `maestro-web` from classpath (loses Web support)
2. Wait for Maestro to upgrade to ktor 3.x
3. Use classpath isolation (shadow/shade maestro-web)

Android and iOS tests pass. Only Web test is affected.