### PR TITLE
Prevent Legal information scenario from opening Third-party licenses

### DIFF
--- a/sample-test/src/main/resources/projects/e2e-test-android.yaml
+++ b/sample-test/src/main/resources/projects/e2e-test-android.yaml
@@ -22,7 +22,9 @@ scenarios:
     temperature: 0.7
     imageFormat: "png"
 - id: "5f221744-6a45-4ff2-a980-eaba77049dc6"
-  goal: "Just open Legal information"
+  goal: "Just open Legal information page. If you can see 'Legal information' title\
+    \ at the top of the screen, the goal is achieved. Do NOT open Third-party licenses\
+    \ or any sub-items."
   dependency: "f9c17741-093e-49f0-ad45-8311ba68c1a6"
   tags:
   - name: "Settings"


### PR DESCRIPTION
# What
Update the Legal information scenario goal to stop at the Legal information page without opening sub-items like Third-party licenses.

# Why
The AI agent was navigating into the Third-party licenses page, which lists thousands of library licenses. This caused the view hierarchy to balloon to ~30MB, exceeding Maestro's 4MB gRPC message size limit and crashing subsequent scenarios with RESOURCE_EXHAUSTED.