### PR TITLE
Add tags to ArbigentScenarioResult in result.yml

### DIFF
--- a/arbigent-core-model/src/commonMain/kotlin/ArbigentResult.kt
+++ b/arbigent-core-model/src/commonMain/kotlin/ArbigentResult.kt
@@ -4,6 +4,7 @@ import com.charleskorn.kaml.PolymorphismStyle
 import com.charleskorn.kaml.Yaml
 import com.charleskorn.kaml.YamlComment
 import com.charleskorn.kaml.YamlConfiguration
+import io.github.takahirom.arbigent.ArbigentContentTags
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -53,6 +54,7 @@ public sealed interface StepFeedback: StepFeedbackEvent {
 public data class ArbigentScenarioResult(
   public val id: String,
   public val goal: String? = null,
+  public val tags: ArbigentContentTags = setOf(),
   public val executionStatus: String? = null,
   public val isSuccess: Boolean,
   public val histories: List<ArbigentAgentResults>,

--- a/arbigent-core-model/src/commonMain/kotlin/io/github/takahirom/arbigent/ArbigentContentTag.kt
+++ b/arbigent-core-model/src/commonMain/kotlin/io/github/takahirom/arbigent/ArbigentContentTag.kt
@@ -1,0 +1,10 @@
+package io.github.takahirom.arbigent
+
+import kotlinx.serialization.Serializable
+
+public typealias ArbigentContentTags = Set<ArbigentContentTag>
+
+@Serializable
+public data class ArbigentContentTag(
+  public val name: String
+)

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -61,13 +61,6 @@ public data class FixedScenario(
   public val yamlText: String
 )
 
-public typealias ArbigentContentTags = Set<ArbigentContentTag>
-
-@Serializable
-public data class ArbigentContentTag(
-  public val name: String
-)
-
 @Serializable
 public enum class ImageDetailLevel {
   @SerialName("high")

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioAssignment.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioAssignment.kt
@@ -12,6 +12,7 @@ public data class ArbigentScenarioAssignment(
     return ArbigentScenarioResult(
       id = scenario.id,
       goal = scenario.goal(),
+      tags = scenario.tags,
       executionStatus = scenarioExecutor.runningInfo()?.toString(),
       isSuccess = taskAssignmentsHistory.lastOrNull()?.all { it.agent.isGoalAchieved() } ?: false,
       histories = taskAssignmentsHistory.mapIndexed { index, taskAssignments ->


### PR DESCRIPTION
# What
Add `tags` field to `ArbigentScenarioResult` so that scenario tags are included in result.yml output.

# Why
Scenario tags defined in project.yml were not carried over to result.yml, making it harder to filter or categorize results by tag.