### PR TITLE
Fix ResourceFileSystem path error on Windows

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReportHtml.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReportHtml.kt
@@ -122,8 +122,9 @@ public class ArbigentHtmlReport {
 
     val resourceFileSystem = this::class.java.classLoader
       .asResourceFileSystem()
+    // Use "/" explicitly instead of File.separator because ResourceFileSystem always uses Unix-style paths.
     resourceFileSystem
-      .list((File.separator + "arbigent-core-web-report-resources").toPath()).forEach { path: Path ->
+      .list("/arbigent-core-web-report-resources".toPath()).forEach { path: Path ->
         resourceFileSystem.source(path)
           .use { fromSource ->
             // Copy to File(outputDir, path.name)

--- a/arbigent-ui/src/test/kotlin/UiTests.kt
+++ b/arbigent-ui/src/test/kotlin/UiTests.kt
@@ -591,15 +591,17 @@ class TestRobot(
 
   @OptIn(ExperimentalCoroutinesApi::class)
   fun waitUntilScenarioRunning() {
-    // Wait for scenario_running tag to disappear (scenario has finished)
-    // 10 second timeout for image assertion processing
+    // Wait for scenario_running tag to disappear (scenario has finished).
+    // Advance time before each check to ensure Compose recomposition and
+    // coroutine scheduling have a chance to process, even on slower CI.
     repeat(100) {
+      testScope.advanceTimeBy(100)
+      testScope.advanceUntilIdle()
+      composeUiTest.waitForIdle()
       val nodes = composeUiTest.onAllNodes(hasTestTag("scenario_running"), useUnmergedTree = true).fetchSemanticsNodes()
       if (nodes.isEmpty()) {
         return  // Element disappeared, scenario finished
       }
-      testScope.advanceTimeBy(100)
-      testScope.advanceUntilIdle()
     }
     kotlin.test.fail("Scenario did not finish within 10 seconds")
   }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,6 @@
 pluginManagement {
     repositories {
-        maven("https://maven.pkg.jetbrains.space/public/p/compose/dev")
+        maven("https://redirector.kotlinlang.org/maven/compose-dev")
         google {
             content {
                 includeGroupByRegex("com\\.android.*")


### PR DESCRIPTION
# What
Use literal `/` instead of `File.separator` for okio ResourceFileSystem path.

# Why
On Windows, `File.separator` is `\`, which creates a path with a different root than ResourceFileSystem expects (Unix-style `/`). This causes `IllegalArgumentException: Paths of different roots cannot be relative to each other` when generating HTML reports.