### PR TITLE
Add ClickAtCoordinates AI action for raw screen taps

### DIFF
--- a/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
+++ b/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
@@ -532,6 +532,19 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
         )
       }
 
+      ClickAtCoordinates -> {
+        val text = argumentsJsonData["text"]?.jsonPrimitive?.content ?: throw IllegalArgumentException("Text not found")
+        val parts = text.split(",").map { it.trim() }
+        if (parts.size != 2) {
+          throw IllegalArgumentException("text should be \"x,y\" for ${ClickAtCoordinates.actionName}, got: \"$text\"")
+        }
+        val x = parts[0].toIntOrNull()
+          ?: throw IllegalArgumentException("x is not an integer for ${ClickAtCoordinates.actionName}: \"${parts[0]}\"")
+        val y = parts[1].toIntOrNull()
+          ?: throw IllegalArgumentException("y is not an integer for ${ClickAtCoordinates.actionName}: \"${parts[1]}\"")
+        ClickAtCoordinates(x = x, y = y)
+      }
+
       BackPressAgentAction -> BackPressAgentAction()
 
       KeyPressAgentAction -> {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/AgentCommands.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/AgentCommands.kt
@@ -96,6 +96,42 @@ public data class ClickWithIndex(val index: Int) : ArbigentAgentAction {
 }
 
 @Serializable
+public data class ClickAtCoordinates(val x: Int, val y: Int) : ArbigentAgentAction {
+  override val actionName: String = Companion.actionName
+
+  override fun stepLogText(): String {
+    return "Click at coordinates: ($x, $y)"
+  }
+
+  override fun runDeviceAction(runInput: ArbigentAgentAction.RunInput) {
+    runInput.device.executeActions(
+      actions = listOf(
+        MaestroCommand(
+          tapOnPointV2Command = TapOnPointV2Command(
+            point = "$x,$y"
+          )
+        )
+      ),
+    )
+  }
+
+  public companion object : AgentActionType {
+    override val actionName: String = "ClickAtCoordinates"
+
+    override fun arguments(): List<AgentActionType.Argument> =
+      listOf(
+        AgentActionType.Argument(
+          name = "text",
+          type = "string",
+          description = "Raw screen coordinates to tap, formatted as \"x,y\" (e.g. \"195,760\"). Use this ONLY when a target element is visible in the screenshot but NOT present in the ELEMENTS/UI-tree list (typical for native iOS system dialogs like Sign in with Apple, permission prompts, etc.). Coordinates are in screen logical points starting at (0,0) top-left."
+        )
+      )
+
+    override fun actionDescription(): String = "Tap at raw screen coordinates. Use only when the target is not in the UI hierarchy."
+  }
+}
+
+@Serializable
 public data class ClickWithTextAgentAction(val textRegex: String) : ArbigentAgentAction {
   override val actionName: String = Companion.actionName
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -881,6 +881,7 @@ public fun defaultAgentActionTypesForVisualMode(): List<AgentActionType> {
 //    ClickWithIdAgentAction,
 //    ClickWithTextAgentAction,
     ClickWithIndex,
+    ClickAtCoordinates,
     InputTextAgentAction,
     BackPressAgentAction,
     KeyPressAgentAction,


### PR DESCRIPTION
## Summary

Adds a new `ClickAtCoordinates` AI action that lets the model tap raw `x,y` screen coordinates parsed from the screenshot it's already reasoning about.

## Motivation

The existing tap tools — `ClickWithIndex`, `ClickWithText`, `ClickWithId` — all require the target element to appear in the accessibility/UI hierarchy. Native iOS system dialogs that are rendered by separate iOS processes don't expose elements to Maestro's view tree, so the AI literally cannot reach those buttons. Concrete cases I hit recently while building a social-login agent against a physical iPhone:

- **Sign in with Apple** sheet — the "Continue with Touch ID / Password" button is not in the UI tree.
- **AuthKitUIService** Apple Account password entry — the password field and Sign In button are not in the UI tree.
- **System permission prompts** (notifications, location, tracking) often render outside the host app's hierarchy.

In all three cases the buttons are clearly visible in the screenshot the AI already receives, but with no tool surface for raw coordinates the AI's only fallback is to keep tapping indexed elements that don't help.

## Implementation

- `AgentCommands.kt` — new `ClickAtCoordinates(x, y)` data class with companion `AgentActionType`. Dispatches to `MaestroCommand(tapOnPointV2Command = TapOnPointV2Command(point = "$x,$y"))`, the same primitive used internally by other tap actions.
- `ArbigentAgent.kt` — added to `defaultAgentActionTypesForVisualMode()` right after `ClickWithIndex`.
- `OpenAIAi.kt` — added dispatch case parsing the `text="x,y"` argument into integer coordinates with clear error messages on malformed input.

Tool arg follows the existing single-`text`-string convention used by other commands (e.g. `text="195,760"`).

## Prompt guidance

To make the AI actually fall back to it, scenarios should include something like:

> Use the tool `ClickAtCoordinates` with `text="x,y"` to tap raw coordinates when a visible button is missing from the indexed UI tree.

Happy to add a short note to the README or a sample scenario file if you'd like.

## Test plan

- [x] Cherry-picked cleanly onto current `main` (`d7297d6`).
- [x] Built via `./gradlew :arbigent-cli:installDist`.
- [x] Verified on a physical iPhone 14 (iOS 26.3) against the Talabat app: agent successfully tapped the Sign in with Apple sheet button and the Apple Account password screen — both previously unreachable.
- [ ] No new unit tests yet — happy to add coverage for the OpenAIAi parser branch if you'd like a specific style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)