### PR TITLE
Support Responses API for OpenAI reasoning tools

### DIFF
--- a/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
+++ b/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
@@ -559,17 +559,24 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
     aiOptions: ArbigentAiOptions? = null
   ): String {
     return runBlocking {
+      val requestWithTemp = aiOptions?.temperature?.let { temp ->
+        chatCompletionRequest.copy(temperature = temp)
+      } ?: chatCompletionRequest
+      val useResponsesApi = shouldUseResponsesApi(requestWithTemp, aiOptions?.extraBody)
       val response: HttpResponse =
-        httpClient.post(baseUrl + "chat/completions") {
+        httpClient.post(baseUrl + apiPathForRequest(requestWithTemp, aiOptions?.extraBody)) {
           url {
             parameters.append("requestUuid", requestUuid)
           }
           requestBuilderModifier()
           contentType(ContentType.Application.Json)
-          val requestWithTemp = aiOptions?.temperature?.let { temp ->
-            chatCompletionRequest.copy(temperature = temp)
-          } ?: chatCompletionRequest
-          setBody(buildRequestBody(requestWithTemp, aiOptions?.extraBody))
+          setBody(
+            if (useResponsesApi) {
+              buildResponsesRequestBody(requestWithTemp, aiOptions?.extraBody)
+            } else {
+              buildRequestBody(requestWithTemp, aiOptions?.extraBody)
+            }
+          )
         }
       if (response.status == HttpStatusCode.TooManyRequests) {
         throw ArbigentAiRateLimitExceededException()
@@ -583,8 +590,30 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
         )
       }
       val responseBody = response.bodyAsText()
-      return@runBlocking responseBody
+      return@runBlocking if (useResponsesApi) {
+        normalizeResponsesApiResponse(responseBody, requestWithTemp.model)
+      } else {
+        responseBody
+      }
     }
+  }
+
+  internal fun apiPathForRequest(request: ChatCompletionRequest, extraParams: JsonObject?): String {
+    return if (shouldUseResponsesApi(request, extraParams)) "responses" else "chat/completions"
+  }
+
+  internal fun shouldUseResponsesApi(request: ChatCompletionRequest, extraParams: JsonObject?): Boolean {
+    return jsonSchemaType == ArbigentAi.JsonSchemaType.OpenAI &&
+      modelRequiresResponsesApiForReasoningTools(request.model) &&
+      !request.tools.isNullOrEmpty() &&
+      extraParams?.containsKey("reasoning_effort") == true
+  }
+
+  internal fun modelRequiresResponsesApiForReasoningTools(model: String): Boolean {
+    val match = Regex("^gpt-(\\d+)(?:\\.(\\d+))?").find(model) ?: return false
+    val major = match.groupValues[1].toIntOrNull() ?: return false
+    val minor = match.groupValues[2].takeIf { it.isNotBlank() }?.toIntOrNull() ?: 0
+    return major > 5 || (major == 5 && minor >= 5)
   }
 
   /**
@@ -614,6 +643,123 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
       }
     }
     return JsonObject(requestJson)
+  }
+
+  internal fun buildResponsesRequestBody(request: ChatCompletionRequest, extraParams: JsonObject?): JsonElement {
+    val requestJson = buildJsonObject {
+      put("model", request.model)
+      putJsonArray("input") {
+        request.messages.forEach { message ->
+          addJsonObject {
+            put("role", message.role)
+            putJsonArray("content") {
+              message.contents.forEach { content ->
+                addJsonObject {
+                  when (content.type) {
+                    "text" -> {
+                      put("type", "input_text")
+                      put("text", content.text ?: "")
+                    }
+                    "image_url" -> {
+                      put("type", "input_image")
+                      put("image_url", content.imageUrl?.url ?: "")
+                      content.imageUrl?.detail?.let { put("detail", it) }
+                    }
+                    else -> {
+                      put("type", content.type)
+                      content.text?.let { put("text", it) }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      request.tools?.let { tools ->
+        putJsonArray("tools") {
+          tools.forEach { tool ->
+            addJsonObject {
+              put("type", "function")
+              put("name", tool.function.name)
+              tool.function.description?.let { put("description", it) }
+              put("parameters", tool.function.parameters)
+              put("strict", tool.function.strict)
+            }
+          }
+        }
+      }
+      request.toolChoice?.let { put("tool_choice", it) }
+      request.temperature?.let { put("temperature", it) }
+      request.responseFormat?.let { put("response_format", Json.encodeToJsonElement(it)) }
+    }.toMutableMap()
+
+    extraParams?.forEach { (key, value) ->
+      when {
+        key in responsesProtectedFields -> {
+          // Silently ignore protected field override attempt to prevent information disclosure
+        }
+        key == "reasoning_effort" -> {
+          requestJson["reasoning"] = buildJsonObject { put("effort", value) }
+        }
+        else -> {
+          requestJson[key] = value
+        }
+      }
+    }
+    return JsonObject(requestJson)
+  }
+
+  internal fun normalizeResponsesApiResponse(responseBody: String, model: String): String {
+    val json = Json { encodeDefaults = true; explicitNulls = false }
+    val responseJson = json.parseToJsonElement(responseBody).jsonObject
+    val output = responseJson["output"]?.jsonArray ?: JsonArray(emptyList())
+    val functionCall = output.firstOrNull { item ->
+      item.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "function_call"
+    }?.jsonObject
+    val messageText = output.firstOrNull { item ->
+      item.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "message"
+    }?.jsonObject?.get("content")?.jsonArray?.firstNotNullOfOrNull { content ->
+      val contentObj = content.jsonObject
+      when (contentObj["type"]?.jsonPrimitive?.contentOrNull) {
+        "output_text", "text" -> contentObj["text"]?.jsonPrimitive?.contentOrNull
+        else -> null
+      }
+    }
+
+    val message = if (functionCall != null) {
+      MessageContent(
+        role = "assistant",
+        toolCalls = listOf(
+          ToolCall(
+            id = functionCall["call_id"]?.jsonPrimitive?.contentOrNull ?: functionCall["id"]?.jsonPrimitive?.contentOrNull ?: "responses_function_call",
+            type = "function",
+            function = FunctionCall(
+              name = functionCall["name"]?.jsonPrimitive?.contentOrNull ?: "",
+              arguments = functionCall["arguments"]?.jsonPrimitive?.contentOrNull ?: "{}"
+            )
+          )
+        )
+      )
+    } else {
+      MessageContent(role = "assistant", content = messageText)
+    }
+
+    val usageJson = responseJson["usage"]?.jsonObject
+    val normalized = ChatCompletionResponse(
+      `object` = "chat.completion",
+      created = responseJson["created_at"]?.jsonPrimitive?.longOrNull ?: (System.currentTimeMillis() / 1000),
+      model = responseJson["model"]?.jsonPrimitive?.contentOrNull ?: model,
+      choices = listOf(Choice(index = 0, message = message, finishReason = null)),
+      usage = usageJson?.let {
+        Usage(
+          completionTokens = it["output_tokens"]?.jsonPrimitive?.intOrNull,
+          promptTokens = it["input_tokens"]?.jsonPrimitive?.intOrNull,
+          totalTokens = it["total_tokens"]?.jsonPrimitive?.intOrNull
+        )
+      }
+    )
+    return json.encodeToString(normalized)
   }
 
   private fun buildTools(agentActionTypes: List<AgentActionType>, mcpTools: List<MCPTool>?): List<ToolDefinition> {
@@ -929,6 +1075,7 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
      * These are critical API fields that could break functionality or cause security issues.
      */
     internal val protectedFields: Set<String> = setOf("model", "messages", "tools", "tool_choice")
+    internal val responsesProtectedFields: Set<String> = setOf("model", "input", "tools", "tool_choice")
   }
 }
 

--- a/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
+++ b/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
@@ -564,7 +564,7 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
       } ?: chatCompletionRequest
       val useResponsesApi = shouldUseResponsesApi(requestWithTemp, aiOptions?.extraBody)
       val response: HttpResponse =
-        httpClient.post(baseUrl + apiPathForRequest(requestWithTemp, aiOptions?.extraBody)) {
+        httpClient.post(baseUrl + apiPathForRequest(useResponsesApi)) {
           url {
             parameters.append("requestUuid", requestUuid)
           }
@@ -599,14 +599,19 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
   }
 
   internal fun apiPathForRequest(request: ChatCompletionRequest, extraParams: JsonObject?): String {
-    return if (shouldUseResponsesApi(request, extraParams)) "responses" else "chat/completions"
+    return apiPathForRequest(shouldUseResponsesApi(request, extraParams))
+  }
+
+  private fun apiPathForRequest(useResponsesApi: Boolean): String {
+    return if (useResponsesApi) "responses" else "chat/completions"
   }
 
   internal fun shouldUseResponsesApi(request: ChatCompletionRequest, extraParams: JsonObject?): Boolean {
+    val reasoningEffort = extraParams?.get("reasoning_effort")?.takeUnless { it is JsonNull }
     return jsonSchemaType == ArbigentAi.JsonSchemaType.OpenAI &&
       modelRequiresResponsesApiForReasoningTools(request.model) &&
       !request.tools.isNullOrEmpty() &&
-      extraParams?.containsKey("reasoning_effort") == true
+      reasoningEffort != null
   }
 
   internal fun modelRequiresResponsesApiForReasoningTools(model: String): Boolean {
@@ -699,7 +704,7 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
         key in responsesProtectedFields -> {
           // Silently ignore protected field override attempt to prevent information disclosure
         }
-        key == "reasoning_effort" -> {
+        key == "reasoning_effort" && value !is JsonNull -> {
           requestJson["reasoning"] = buildJsonObject { put("effort", value) }
         }
         else -> {
@@ -714,32 +719,38 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
     val json = Json { encodeDefaults = true; explicitNulls = false }
     val responseJson = json.parseToJsonElement(responseBody).jsonObject
     val output = responseJson["output"]?.jsonArray ?: JsonArray(emptyList())
-    val functionCall = output.firstOrNull { item ->
-      item.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "function_call"
-    }?.jsonObject
-    val messageText = output.firstOrNull { item ->
-      item.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "message"
-    }?.jsonObject?.get("content")?.jsonArray?.firstNotNullOfOrNull { content ->
-      val contentObj = content.jsonObject
-      when (contentObj["type"]?.jsonPrimitive?.contentOrNull) {
-        "output_text", "text" -> contentObj["text"]?.jsonPrimitive?.contentOrNull
-        else -> null
-      }
+    val functionCalls = output.mapNotNull { item ->
+      item.jsonObject.takeIf { it["type"]?.jsonPrimitive?.contentOrNull == "function_call" }
     }
+    val messageText = output
+      .mapNotNull { item -> item.jsonObject.takeIf { it["type"]?.jsonPrimitive?.contentOrNull == "message" } }
+      .flatMap { message -> message["content"]?.jsonArray.orEmpty() }
+      .mapNotNull { content ->
+        val contentObj = content.jsonObject
+        when (contentObj["type"]?.jsonPrimitive?.contentOrNull) {
+          "output_text", "text" -> contentObj["text"]?.jsonPrimitive?.contentOrNull
+          else -> null
+        }
+      }
+      .joinToString("")
+      .ifEmpty { null }
 
-    val message = if (functionCall != null) {
+    val message = if (functionCalls.isNotEmpty()) {
       MessageContent(
         role = "assistant",
-        toolCalls = listOf(
+        content = messageText,
+        toolCalls = functionCalls.map { functionCall ->
           ToolCall(
-            id = functionCall["call_id"]?.jsonPrimitive?.contentOrNull ?: functionCall["id"]?.jsonPrimitive?.contentOrNull ?: "responses_function_call",
+            id = functionCall["call_id"]?.jsonPrimitive?.contentOrNull
+              ?: functionCall["id"]?.jsonPrimitive?.contentOrNull
+              ?: "responses_function_call",
             type = "function",
             function = FunctionCall(
               name = functionCall["name"]?.jsonPrimitive?.contentOrNull ?: "",
               arguments = functionCall["arguments"]?.jsonPrimitive?.contentOrNull ?: "{}"
             )
           )
-        )
+        }
       )
     } else {
       MessageContent(role = "assistant", content = messageText)

--- a/arbigent-ai-openai/src/test/java/BuildRequestBodyTest.kt
+++ b/arbigent-ai-openai/src/test/java/BuildRequestBodyTest.kt
@@ -1,7 +1,9 @@
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import io.github.takahirom.arbigent.ChatCompletionRequest
 import io.github.takahirom.arbigent.ChatMessage
+import io.github.takahirom.arbigent.FunctionDefinition
 import io.github.takahirom.arbigent.OpenAIAi
+import io.github.takahirom.arbigent.ToolDefinition
 import kotlinx.serialization.json.*
 import org.junit.Assert.*
 import org.junit.Test
@@ -24,6 +26,73 @@ class BuildRequestBodyTest {
         )
       )
     )
+  }
+
+  private fun createToolRequest(model: String): ChatCompletionRequest {
+    return createMinimalRequest().copy(
+      model = model,
+      tools = listOf(
+        ToolDefinition(
+          function = FunctionDefinition(
+            name = "perform_click",
+            description = "Click",
+            parameters = buildJsonObject {
+              put("type", "object")
+              putJsonObject("properties") {}
+              putJsonArray("required") {}
+              put("additionalProperties", false)
+            }
+          )
+        )
+      )
+    )
+  }
+
+  @Test
+  fun `existing chat completions model uses chat completions path`() {
+    val request = createToolRequest("gpt-4.1")
+    val extraParams = buildJsonObject { put("reasoning_effort", "low") }
+
+    assertEquals("chat/completions", openAiAi.apiPathForRequest(request, extraParams))
+  }
+
+  @Test
+  fun `gpt-5_1 with tools and reasoning effort still uses chat completions path`() {
+    val request = createToolRequest("gpt-5.1")
+    val extraParams = buildJsonObject { put("reasoning_effort", "low") }
+
+    assertEquals("chat/completions", openAiAi.apiPathForRequest(request, extraParams))
+  }
+
+  @Test
+  fun `gpt-5_5 with tools and reasoning effort uses responses path`() {
+    val request = createToolRequest("gpt-5.5")
+    val extraParams = buildJsonObject { put("reasoning_effort", "low") }
+
+    assertEquals("responses", openAiAi.apiPathForRequest(request, extraParams))
+  }
+
+  @Test
+  fun `newer gpt models with tools and reasoning effort use responses path`() {
+    val request = createToolRequest("gpt-5.6")
+    val extraParams = buildJsonObject { put("reasoning_effort", "low") }
+
+    assertEquals("responses", openAiAi.apiPathForRequest(request, extraParams))
+  }
+
+  @Test
+  fun `responses request maps reasoning_effort to reasoning effort`() {
+    val request = createToolRequest("gpt-5.5")
+    val extraParams = buildJsonObject { put("reasoning_effort", "low") }
+
+    val result = openAiAi.buildResponsesRequestBody(request, extraParams).jsonObject
+
+    assertFalse("reasoning_effort should not be sent to Responses API", result.containsKey("reasoning_effort"))
+    assertEquals("low", result["reasoning"]?.jsonObject?.get("effort")?.jsonPrimitive?.content)
+    assertNotNull(result["input"]?.jsonArray)
+    val tool = result["tools"]?.jsonArray?.first()?.jsonObject
+    assertEquals("function", tool?.get("type")?.jsonPrimitive?.content)
+    assertEquals("perform_click", tool?.get("name")?.jsonPrimitive?.content)
   }
 
   @Test

--- a/arbigent-ai-openai/src/test/java/BuildRequestBodyTest.kt
+++ b/arbigent-ai-openai/src/test/java/BuildRequestBodyTest.kt
@@ -1,5 +1,6 @@
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import io.github.takahirom.arbigent.ChatCompletionRequest
+import io.github.takahirom.arbigent.ChatCompletionResponse
 import io.github.takahirom.arbigent.ChatMessage
 import io.github.takahirom.arbigent.FunctionDefinition
 import io.github.takahirom.arbigent.OpenAIAi
@@ -57,7 +58,7 @@ class BuildRequestBodyTest {
   }
 
   @Test
-  fun `gpt-5_1 with tools and reasoning effort still uses chat completions path`() {
+  fun `gpt-5 dot 1 with tools and reasoning effort still uses chat completions path`() {
     val request = createToolRequest("gpt-5.1")
     val extraParams = buildJsonObject { put("reasoning_effort", "low") }
 
@@ -65,7 +66,7 @@ class BuildRequestBodyTest {
   }
 
   @Test
-  fun `gpt-5_5 with tools and reasoning effort uses responses path`() {
+  fun `gpt-5 dot 5 with tools and reasoning effort uses responses path`() {
     val request = createToolRequest("gpt-5.5")
     val extraParams = buildJsonObject { put("reasoning_effort", "low") }
 
@@ -93,6 +94,76 @@ class BuildRequestBodyTest {
     val tool = result["tools"]?.jsonArray?.first()?.jsonObject
     assertEquals("function", tool?.get("type")?.jsonPrimitive?.content)
     assertEquals("perform_click", tool?.get("name")?.jsonPrimitive?.content)
+  }
+
+  @Test
+  fun `null reasoning_effort does not use responses path or emit reasoning`() {
+    val request = createToolRequest("gpt-5.5")
+    val extraParams = buildJsonObject { put("reasoning_effort", JsonNull) }
+
+    assertEquals("chat/completions", openAiAi.apiPathForRequest(request, extraParams))
+    val result = openAiAi.buildResponsesRequestBody(request, extraParams).jsonObject
+    assertFalse(result.containsKey("reasoning"))
+  }
+
+  @Test
+  fun `normalizeResponsesApiResponse maps plain message output`() {
+    val responseBody = """
+      {
+        "id": "resp_123",
+        "created_at": 1234567890,
+        "model": "gpt-5.5",
+        "output": [
+          {
+            "type": "message",
+            "content": [
+              {"type": "output_text", "text": "hello "},
+              {"type": "text", "text": "world"}
+            ]
+          }
+        ],
+        "usage": {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12}
+      }
+    """.trimIndent()
+
+    val normalized = Json.decodeFromString<ChatCompletionResponse>(
+      openAiAi.normalizeResponsesApiResponse(responseBody, "fallback-model")
+    )
+
+    assertEquals("gpt-5.5", normalized.model)
+    assertEquals("hello world", normalized.choices.first().message.content)
+    assertEquals(10, normalized.usage?.promptTokens)
+    assertEquals(2, normalized.usage?.completionTokens)
+    assertEquals(12, normalized.usage?.totalTokens)
+  }
+
+  @Test
+  fun `normalizeResponsesApiResponse maps all function call outputs`() {
+    val responseBody = """
+      {
+        "id": "resp_123",
+        "created_at": 1234567890,
+        "model": "gpt-5.5",
+        "output": [
+          {"type": "function_call", "call_id": "call_1", "name": "perform_click", "arguments": "{\"text\":\"1\"}"},
+          {"type": "function_call", "id": "fc_2", "name": "perform_wait", "arguments": "{\"text\":\"1000\"}"},
+          {"type": "message", "content": [{"type": "output_text", "text": "done"}]}
+        ]
+      }
+    """.trimIndent()
+
+    val normalized = Json.decodeFromString<ChatCompletionResponse>(
+      openAiAi.normalizeResponsesApiResponse(responseBody, "fallback-model")
+    )
+    val message = normalized.choices.first().message
+
+    assertEquals("done", message.content)
+    assertEquals(2, message.toolCalls?.size)
+    assertEquals("call_1", message.toolCalls?.get(0)?.id)
+    assertEquals("perform_click", message.toolCalls?.get(0)?.function?.name)
+    assertEquals("{\"text\":\"1\"}", message.toolCalls?.get(0)?.function?.arguments)
+    assertEquals("fc_2", message.toolCalls?.get(1)?.id)
+    assertEquals("perform_wait", message.toolCalls?.get(1)?.function?.name)
   }
 
   @Test


### PR DESCRIPTION
 Fixes OpenAI `gpt-5.5` Android e2e failures when Arbigent sends function tools with `reasoning_effort`.

 OpenAI rejects this combination on `/v1/chat/completions`:

 > Function tools with reasoning_effort are not supported for gpt-5.5 in /v1/chat/completions. Please use
 > /v1/responses instead.

 This PR adds a minimal Responses API path for OpenAI models/options that require it, while preserving existing
 chat completions behavior for older compatible models.

 ## Changes

 - Keep `/v1/chat/completions` as the default OpenAI path.
 - Route to `/v1/responses` only when:
     - provider is OpenAI
     - function tools are present
     - `extraBody.reasoning_effort` is set
     - model is `gpt-5.5` or newer
 - Convert chat-style request fields to Responses API fields:
     - `messages` → `input`
     - function tools → Responses function tools
     - `reasoning_effort` → `reasoning.effort`
 - Normalize Responses API output back into the existing chat completion response shape so downstream parsing
   remains unchanged.

 ## Tests

 Added tests covering:

 - existing chat completions models still use /v1/chat/completions
 - `gpt-5.1` remains on chat completions
 - `gpt-5.5` + tools + `reasoning_effort` uses `/v1/responses`
 - newer GPT models also use`/v1/responses`
 - `reasoning_effort` maps correctly to `reasoning.effort`

 Validation:

 ```bash
   mise exec java@zulu-17.66.19.0 -- ./gradlew :arbigent-ai-openai:test --tests BuildRequestBodyTest
 ``

Related to #209, but this does not fully implement OpenAI Computer Use. It adds a minimal Responses API path needed for function tools with reasoning_effort.