### PR TITLE
Make OpenAI Responses API opt-in via aiOptions.useResponsesApi

### DIFF
--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -144,11 +144,9 @@ jobs:
           disk-size: 6000M
           heap-size: 600M
           script: |
+            set -eu
             arbigent-cli/build/install/arbigent/bin/arbigent run --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android.yaml --ai-type=openai --openai-endpoint=https://openrouter.ai/api/v1/ --openai-model-name=google/gemini-2.5-flash-lite --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --variables "search_term=Bluetooth,app_package=com.android.camera2"
-            # Responses API smoke check (only on shard 1 to avoid duplicate API spend)
-            if [ "${{ matrix.shardIndex }}" = "1" ]; then
-              arbigent-cli/build/install/arbigent/bin/arbigent run --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android-responses.yaml --ai-type=openai --openai-endpoint=https://openrouter.ai/api/v1/ --openai-model-name=openai/gpt-5.4-mini
-            fi
+            if [ "${{ matrix.shardIndex }}" = "1" ]; then arbigent-cli/build/install/arbigent/bin/arbigent run --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android-responses.yaml --ai-type=openai --openai-endpoint=https://openrouter.ai/api/v1/ --openai-model-name=openai/gpt-5.4-mini; fi
       - name: Check API key leakage
         run: |
           if grep -R --quiet "${{ secrets.OPEN_ROUTER_API_KEY }}" arbigent-result/; then

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -145,6 +145,10 @@ jobs:
           heap-size: 600M
           script: |
             arbigent-cli/build/install/arbigent/bin/arbigent run --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android.yaml --ai-type=openai --openai-endpoint=https://openrouter.ai/api/v1/ --openai-model-name=google/gemini-2.5-flash-lite --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --variables "search_term=Bluetooth,app_package=com.android.camera2"
+            # Responses API smoke check (only on shard 1 to avoid duplicate API spend)
+            if [ "${{ matrix.shardIndex }}" = "1" ]; then
+              arbigent-cli/build/install/arbigent/bin/arbigent run --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android-responses.yaml --ai-type=openai --openai-endpoint=https://openrouter.ai/api/v1/ --openai-model-name=openai/gpt-5.4-mini
+            fi
       - name: Check API key leakage
         run: |
           if grep -R --quiet "${{ secrets.OPEN_ROUTER_API_KEY }}" arbigent-result/; then

--- a/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
+++ b/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
@@ -559,17 +559,24 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
     aiOptions: ArbigentAiOptions? = null
   ): String {
     return runBlocking {
+      val requestWithTemp = aiOptions?.temperature?.let { temp ->
+        chatCompletionRequest.copy(temperature = temp)
+      } ?: chatCompletionRequest
+      val useResponsesApi = shouldUseResponsesApi(requestWithTemp, aiOptions?.extraBody)
       val response: HttpResponse =
-        httpClient.post(baseUrl + "chat/completions") {
+        httpClient.post(baseUrl + apiPathForRequest(requestWithTemp, aiOptions?.extraBody)) {
           url {
             parameters.append("requestUuid", requestUuid)
           }
           requestBuilderModifier()
           contentType(ContentType.Application.Json)
-          val requestWithTemp = aiOptions?.temperature?.let { temp ->
-            chatCompletionRequest.copy(temperature = temp)
-          } ?: chatCompletionRequest
-          setBody(buildRequestBody(requestWithTemp, aiOptions?.extraBody))
+          setBody(
+            if (useResponsesApi) {
+              buildResponsesRequestBody(requestWithTemp, aiOptions?.extraBody)
+            } else {
+              buildRequestBody(requestWithTemp, aiOptions?.extraBody)
+            }
+          )
         }
       if (response.status == HttpStatusCode.TooManyRequests) {
         throw ArbigentAiRateLimitExceededException()
@@ -583,8 +590,30 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
         )
       }
       val responseBody = response.bodyAsText()
-      return@runBlocking responseBody
+      return@runBlocking if (useResponsesApi) {
+        normalizeResponsesApiResponse(responseBody, requestWithTemp.model)
+      } else {
+        responseBody
+      }
     }
+  }
+
+  internal fun apiPathForRequest(request: ChatCompletionRequest, extraParams: JsonObject?): String {
+    return if (shouldUseResponsesApi(request, extraParams)) "responses" else "chat/completions"
+  }
+
+  internal fun shouldUseResponsesApi(request: ChatCompletionRequest, extraParams: JsonObject?): Boolean {
+    return jsonSchemaType == ArbigentAi.JsonSchemaType.OpenAI &&
+      modelRequiresResponsesApiForReasoningTools(request.model) &&
+      !request.tools.isNullOrEmpty() &&
+      extraParams?.containsKey("reasoning_effort") == true
+  }
+
+  internal fun modelRequiresResponsesApiForReasoningTools(model: String): Boolean {
+    val match = Regex("^gpt-(\\d+)(?:\\.(\\d+))?").find(model) ?: return false
+    val major = match.groupValues[1].toIntOrNull() ?: return false
+    val minor = match.groupValues[2].takeIf { it.isNotBlank() }?.toIntOrNull() ?: 0
+    return major > 5 || (major == 5 && minor >= 5)
   }
 
   /**
@@ -614,6 +643,123 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
       }
     }
     return JsonObject(requestJson)
+  }
+
+  internal fun buildResponsesRequestBody(request: ChatCompletionRequest, extraParams: JsonObject?): JsonElement {
+    val requestJson = buildJsonObject {
+      put("model", request.model)
+      putJsonArray("input") {
+        request.messages.forEach { message ->
+          addJsonObject {
+            put("role", message.role)
+            putJsonArray("content") {
+              message.contents.forEach { content ->
+                addJsonObject {
+                  when (content.type) {
+                    "text" -> {
+                      put("type", "input_text")
+                      put("text", content.text ?: "")
+                    }
+                    "image_url" -> {
+                      put("type", "input_image")
+                      put("image_url", content.imageUrl?.url ?: "")
+                      content.imageUrl?.detail?.let { put("detail", it) }
+                    }
+                    else -> {
+                      put("type", content.type)
+                      content.text?.let { put("text", it) }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      request.tools?.let { tools ->
+        putJsonArray("tools") {
+          tools.forEach { tool ->
+            addJsonObject {
+              put("type", "function")
+              put("name", tool.function.name)
+              tool.function.description?.let { put("description", it) }
+              put("parameters", tool.function.parameters)
+              put("strict", tool.function.strict)
+            }
+          }
+        }
+      }
+      request.toolChoice?.let { put("tool_choice", it) }
+      request.temperature?.let { put("temperature", it) }
+      request.responseFormat?.let { put("response_format", Json.encodeToJsonElement(it)) }
+    }.toMutableMap()
+
+    extraParams?.forEach { (key, value) ->
+      when {
+        key in responsesProtectedFields -> {
+          // Silently ignore protected field override attempt to prevent information disclosure
+        }
+        key == "reasoning_effort" -> {
+          requestJson["reasoning"] = buildJsonObject { put("effort", value) }
+        }
+        else -> {
+          requestJson[key] = value
+        }
+      }
+    }
+    return JsonObject(requestJson)
+  }
+
+  internal fun normalizeResponsesApiResponse(responseBody: String, model: String): String {
+    val json = Json { encodeDefaults = true; explicitNulls = false }
+    val responseJson = json.parseToJsonElement(responseBody).jsonObject
+    val output = responseJson["output"]?.jsonArray ?: JsonArray(emptyList())
+    val functionCall = output.firstOrNull { item ->
+      item.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "function_call"
+    }?.jsonObject
+    val messageText = output.firstOrNull { item ->
+      item.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "message"
+    }?.jsonObject?.get("content")?.jsonArray?.firstNotNullOfOrNull { content ->
+      val contentObj = content.jsonObject
+      when (contentObj["type"]?.jsonPrimitive?.contentOrNull) {
+        "output_text", "text" -> contentObj["text"]?.jsonPrimitive?.contentOrNull
+        else -> null
+      }
+    }
+
+    val message = if (functionCall != null) {
+      MessageContent(
+        role = "assistant",
+        toolCalls = listOf(
+          ToolCall(
+            id = functionCall["call_id"]?.jsonPrimitive?.contentOrNull ?: functionCall["id"]?.jsonPrimitive?.contentOrNull ?: "responses_function_call",
+            type = "function",
+            function = FunctionCall(
+              name = functionCall["name"]?.jsonPrimitive?.contentOrNull ?: "",
+              arguments = functionCall["arguments"]?.jsonPrimitive?.contentOrNull ?: "{}"
+            )
+          )
+        )
+      )
+    } else {
+      MessageContent(role = "assistant", content = messageText)
+    }
+
+    val usageJson = responseJson["usage"]?.jsonObject
+    val normalized = ChatCompletionResponse(
+      `object` = "chat.completion",
+      created = responseJson["created_at"]?.jsonPrimitive?.longOrNull ?: (System.currentTimeMillis() / 1000),
+      model = responseJson["model"]?.jsonPrimitive?.contentOrNull ?: model,
+      choices = listOf(Choice(index = 0, message = message, finishReason = null)),
+      usage = usageJson?.let {
+        Usage(
+          completionTokens = it["output_tokens"]?.jsonPrimitive?.intOrNull,
+          promptTokens = it["input_tokens"]?.jsonPrimitive?.intOrNull,
+          totalTokens = it["total_tokens"]?.jsonPrimitive?.intOrNull
+        )
+      }
+    )
+    return json.encodeToString(normalized)
   }
 
   private fun buildTools(agentActionTypes: List<AgentActionType>, mcpTools: List<MCPTool>?): List<ToolDefinition> {
@@ -929,6 +1075,7 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
      * These are critical API fields that could break functionality or cause security issues.
      */
     internal val protectedFields: Set<String> = setOf("model", "messages", "tools", "tool_choice")
+    internal val responsesProtectedFields: Set<String> = setOf("model", "input", "tools", "tool_choice")
   }
 }
 

--- a/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
+++ b/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
@@ -562,7 +562,8 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
       val requestWithTemp = aiOptions?.temperature?.let { temp ->
         chatCompletionRequest.copy(temperature = temp)
       } ?: chatCompletionRequest
-      val useResponsesApi = shouldUseResponsesApi(requestWithTemp, aiOptions?.extraBody)
+      val useResponsesApi = shouldUseResponsesApi(aiOptions)
+      maybeWarnResponsesApiRecommended(useResponsesApi, requestWithTemp, aiOptions?.extraBody)
       val response: HttpResponse =
         httpClient.post(baseUrl + apiPathForRequest(useResponsesApi)) {
           url {
@@ -598,27 +599,39 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
     }
   }
 
-  internal fun apiPathForRequest(request: ChatCompletionRequest, extraParams: JsonObject?): String {
-    return apiPathForRequest(shouldUseResponsesApi(request, extraParams))
+  internal fun apiPathForRequest(aiOptions: ArbigentAiOptions?): String {
+    return apiPathForRequest(shouldUseResponsesApi(aiOptions))
   }
 
   private fun apiPathForRequest(useResponsesApi: Boolean): String {
     return if (useResponsesApi) "responses" else "chat/completions"
   }
 
-  internal fun shouldUseResponsesApi(request: ChatCompletionRequest, extraParams: JsonObject?): Boolean {
-    val reasoningEffort = extraParams?.get("reasoning_effort")?.takeUnless { it is JsonNull }
-    return jsonSchemaType == ArbigentAi.JsonSchemaType.OpenAI &&
-      modelRequiresResponsesApiForReasoningTools(request.model) &&
-      !request.tools.isNullOrEmpty() &&
-      reasoningEffort != null
+  internal fun shouldUseResponsesApi(aiOptions: ArbigentAiOptions?): Boolean {
+    return aiOptions?.useResponsesApi == true
   }
 
-  internal fun modelRequiresResponsesApiForReasoningTools(model: String): Boolean {
+  internal fun modelLikelyRequiresResponsesApi(model: String): Boolean {
     val match = Regex("^gpt-(\\d+)(?:\\.(\\d+))?").find(model) ?: return false
     val major = match.groupValues[1].toIntOrNull() ?: return false
     val minor = match.groupValues[2].takeIf { it.isNotBlank() }?.toIntOrNull() ?: 0
     return major > 5 || (major == 5 && minor >= 5)
+  }
+
+  private fun maybeWarnResponsesApiRecommended(
+    useResponsesApi: Boolean,
+    request: ChatCompletionRequest,
+    extraParams: JsonObject?
+  ) {
+    if (useResponsesApi) return
+    if (jsonSchemaType != ArbigentAi.JsonSchemaType.OpenAI) return
+    val reasoningEffort = extraParams?.get("reasoning_effort")?.takeUnless { it is JsonNull } ?: return
+    if (request.tools.isNullOrEmpty()) return
+    if (!modelLikelyRequiresResponsesApi(request.model)) return
+    arbigentWarnLog(
+      "OpenAI may reject function tools with reasoning_effort=$reasoningEffort on /v1/chat/completions " +
+        "for model ${request.model}. Consider enabling aiOptions.useResponsesApi to route to /v1/responses."
+    )
   }
 
   /**

--- a/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
+++ b/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
@@ -564,7 +564,7 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
       } ?: chatCompletionRequest
       val useResponsesApi = shouldUseResponsesApi(requestWithTemp, aiOptions?.extraBody)
       val response: HttpResponse =
-        httpClient.post(baseUrl + apiPathForRequest(requestWithTemp, aiOptions?.extraBody)) {
+        httpClient.post(baseUrl + apiPathForRequest(useResponsesApi)) {
           url {
             parameters.append("requestUuid", requestUuid)
           }
@@ -599,14 +599,19 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
   }
 
   internal fun apiPathForRequest(request: ChatCompletionRequest, extraParams: JsonObject?): String {
-    return if (shouldUseResponsesApi(request, extraParams)) "responses" else "chat/completions"
+    return apiPathForRequest(shouldUseResponsesApi(request, extraParams))
+  }
+
+  private fun apiPathForRequest(useResponsesApi: Boolean): String {
+    return if (useResponsesApi) "responses" else "chat/completions"
   }
 
   internal fun shouldUseResponsesApi(request: ChatCompletionRequest, extraParams: JsonObject?): Boolean {
+    val reasoningEffort = extraParams?.get("reasoning_effort")?.takeUnless { it is JsonNull }
     return jsonSchemaType == ArbigentAi.JsonSchemaType.OpenAI &&
       modelRequiresResponsesApiForReasoningTools(request.model) &&
       !request.tools.isNullOrEmpty() &&
-      extraParams?.containsKey("reasoning_effort") == true
+      reasoningEffort != null
   }
 
   internal fun modelRequiresResponsesApiForReasoningTools(model: String): Boolean {
@@ -699,7 +704,7 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
         key in responsesProtectedFields -> {
           // Silently ignore protected field override attempt to prevent information disclosure
         }
-        key == "reasoning_effort" -> {
+        key == "reasoning_effort" && value !is JsonNull -> {
           requestJson["reasoning"] = buildJsonObject { put("effort", value) }
         }
         else -> {
@@ -714,32 +719,38 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
     val json = Json { encodeDefaults = true; explicitNulls = false }
     val responseJson = json.parseToJsonElement(responseBody).jsonObject
     val output = responseJson["output"]?.jsonArray ?: JsonArray(emptyList())
-    val functionCall = output.firstOrNull { item ->
-      item.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "function_call"
-    }?.jsonObject
-    val messageText = output.firstOrNull { item ->
-      item.jsonObject["type"]?.jsonPrimitive?.contentOrNull == "message"
-    }?.jsonObject?.get("content")?.jsonArray?.firstNotNullOfOrNull { content ->
-      val contentObj = content.jsonObject
-      when (contentObj["type"]?.jsonPrimitive?.contentOrNull) {
-        "output_text", "text" -> contentObj["text"]?.jsonPrimitive?.contentOrNull
-        else -> null
-      }
+    val functionCalls = output.mapNotNull { item ->
+      item.jsonObject.takeIf { it["type"]?.jsonPrimitive?.contentOrNull == "function_call" }
     }
+    val messageText = output
+      .mapNotNull { item -> item.jsonObject.takeIf { it["type"]?.jsonPrimitive?.contentOrNull == "message" } }
+      .flatMap { message -> message["content"]?.jsonArray.orEmpty() }
+      .mapNotNull { content ->
+        val contentObj = content.jsonObject
+        when (contentObj["type"]?.jsonPrimitive?.contentOrNull) {
+          "output_text", "text" -> contentObj["text"]?.jsonPrimitive?.contentOrNull
+          else -> null
+        }
+      }
+      .joinToString("")
+      .ifEmpty { null }
 
-    val message = if (functionCall != null) {
+    val message = if (functionCalls.isNotEmpty()) {
       MessageContent(
         role = "assistant",
-        toolCalls = listOf(
+        content = messageText,
+        toolCalls = functionCalls.map { functionCall ->
           ToolCall(
-            id = functionCall["call_id"]?.jsonPrimitive?.contentOrNull ?: functionCall["id"]?.jsonPrimitive?.contentOrNull ?: "responses_function_call",
+            id = functionCall["call_id"]?.jsonPrimitive?.contentOrNull
+              ?: functionCall["id"]?.jsonPrimitive?.contentOrNull
+              ?: "responses_function_call",
             type = "function",
             function = FunctionCall(
               name = functionCall["name"]?.jsonPrimitive?.contentOrNull ?: "",
               arguments = functionCall["arguments"]?.jsonPrimitive?.contentOrNull ?: "{}"
             )
           )
-        )
+        }
       )
     } else {
       MessageContent(role = "assistant", content = messageText)

--- a/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
+++ b/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
@@ -709,7 +709,16 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
       }
       request.toolChoice?.let { put("tool_choice", it) }
       request.temperature?.let { put("temperature", it) }
-      request.responseFormat?.let { put("response_format", Json.encodeToJsonElement(it)) }
+      request.responseFormat?.let { rf ->
+        // Responses API expects `text.format` instead of top-level `response_format`,
+        // and the inner `json_schema` fields are flattened next to `type`.
+        putJsonObject("text") {
+          putJsonObject("format") {
+            put("type", rf.type)
+            rf.jsonSchema.forEach { (key, value) -> put(key, value) }
+          }
+        }
+      }
     }.toMutableMap()
 
     extraParams?.forEach { (key, value) ->

--- a/arbigent-ai-openai/src/test/java/BuildRequestBodyTest.kt
+++ b/arbigent-ai-openai/src/test/java/BuildRequestBodyTest.kt
@@ -1,7 +1,9 @@
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import io.github.takahirom.arbigent.ChatCompletionRequest
 import io.github.takahirom.arbigent.ChatMessage
+import io.github.takahirom.arbigent.FunctionDefinition
 import io.github.takahirom.arbigent.OpenAIAi
+import io.github.takahirom.arbigent.ToolDefinition
 import kotlinx.serialization.json.*
 import org.junit.Assert.*
 import org.junit.Test
@@ -24,6 +26,73 @@ class BuildRequestBodyTest {
         )
       )
     )
+  }
+
+  private fun createToolRequest(model: String): ChatCompletionRequest {
+    return createMinimalRequest().copy(
+      model = model,
+      tools = listOf(
+        ToolDefinition(
+          function = FunctionDefinition(
+            name = "perform_click",
+            description = "Click",
+            parameters = buildJsonObject {
+              put("type", "object")
+              putJsonObject("properties") {}
+              putJsonArray("required") {}
+              put("additionalProperties", false)
+            }
+          )
+        )
+      )
+    )
+  }
+
+  @Test
+  fun `existing chat completions model uses chat completions path`() {
+    val request = createToolRequest("gpt-4.1")
+    val extraParams = buildJsonObject { put("reasoning_effort", "low") }
+
+    assertEquals("chat/completions", openAiAi.apiPathForRequest(request, extraParams))
+  }
+
+  @Test
+  fun `gpt-5_1 with tools and reasoning effort still uses chat completions path`() {
+    val request = createToolRequest("gpt-5.1")
+    val extraParams = buildJsonObject { put("reasoning_effort", "low") }
+
+    assertEquals("chat/completions", openAiAi.apiPathForRequest(request, extraParams))
+  }
+
+  @Test
+  fun `gpt-5_5 with tools and reasoning effort uses responses path`() {
+    val request = createToolRequest("gpt-5.5")
+    val extraParams = buildJsonObject { put("reasoning_effort", "low") }
+
+    assertEquals("responses", openAiAi.apiPathForRequest(request, extraParams))
+  }
+
+  @Test
+  fun `newer gpt models with tools and reasoning effort use responses path`() {
+    val request = createToolRequest("gpt-5.6")
+    val extraParams = buildJsonObject { put("reasoning_effort", "low") }
+
+    assertEquals("responses", openAiAi.apiPathForRequest(request, extraParams))
+  }
+
+  @Test
+  fun `responses request maps reasoning_effort to reasoning effort`() {
+    val request = createToolRequest("gpt-5.5")
+    val extraParams = buildJsonObject { put("reasoning_effort", "low") }
+
+    val result = openAiAi.buildResponsesRequestBody(request, extraParams).jsonObject
+
+    assertFalse("reasoning_effort should not be sent to Responses API", result.containsKey("reasoning_effort"))
+    assertEquals("low", result["reasoning"]?.jsonObject?.get("effort")?.jsonPrimitive?.content)
+    assertNotNull(result["input"]?.jsonArray)
+    val tool = result["tools"]?.jsonArray?.first()?.jsonObject
+    assertEquals("function", tool?.get("type")?.jsonPrimitive?.content)
+    assertEquals("perform_click", tool?.get("name")?.jsonPrimitive?.content)
   }
 
   @Test

--- a/arbigent-ai-openai/src/test/java/BuildRequestBodyTest.kt
+++ b/arbigent-ai-openai/src/test/java/BuildRequestBodyTest.kt
@@ -1,4 +1,5 @@
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
+import io.github.takahirom.arbigent.ArbigentAiOptions
 import io.github.takahirom.arbigent.ChatCompletionRequest
 import io.github.takahirom.arbigent.ChatCompletionResponse
 import io.github.takahirom.arbigent.ChatMessage
@@ -50,35 +51,33 @@ class BuildRequestBodyTest {
   }
 
   @Test
-  fun `existing chat completions model uses chat completions path`() {
-    val request = createToolRequest("gpt-4.1")
-    val extraParams = buildJsonObject { put("reasoning_effort", "low") }
-
-    assertEquals("chat/completions", openAiAi.apiPathForRequest(request, extraParams))
+  fun `default aiOptions uses chat completions path`() {
+    assertEquals("chat/completions", openAiAi.apiPathForRequest(null))
+    assertEquals("chat/completions", openAiAi.apiPathForRequest(ArbigentAiOptions()))
   }
 
   @Test
-  fun `gpt-5 dot 1 with tools and reasoning effort still uses chat completions path`() {
-    val request = createToolRequest("gpt-5.1")
-    val extraParams = buildJsonObject { put("reasoning_effort", "low") }
-
-    assertEquals("chat/completions", openAiAi.apiPathForRequest(request, extraParams))
+  fun `useResponsesApi false uses chat completions path even for reasoning models`() {
+    val aiOptions = ArbigentAiOptions(
+      useResponsesApi = false,
+      extraBody = buildJsonObject { put("reasoning_effort", "low") }
+    )
+    assertEquals("chat/completions", openAiAi.apiPathForRequest(aiOptions))
   }
 
   @Test
-  fun `gpt-5 dot 5 with tools and reasoning effort uses responses path`() {
-    val request = createToolRequest("gpt-5.5")
-    val extraParams = buildJsonObject { put("reasoning_effort", "low") }
-
-    assertEquals("responses", openAiAi.apiPathForRequest(request, extraParams))
+  fun `useResponsesApi true uses responses path`() {
+    val aiOptions = ArbigentAiOptions(
+      useResponsesApi = true,
+      extraBody = buildJsonObject { put("reasoning_effort", "low") }
+    )
+    assertEquals("responses", openAiAi.apiPathForRequest(aiOptions))
   }
 
   @Test
-  fun `newer gpt models with tools and reasoning effort use responses path`() {
-    val request = createToolRequest("gpt-5.6")
-    val extraParams = buildJsonObject { put("reasoning_effort", "low") }
-
-    assertEquals("responses", openAiAi.apiPathForRequest(request, extraParams))
+  fun `useResponsesApi true works regardless of model name`() {
+    val aiOptions = ArbigentAiOptions(useResponsesApi = true)
+    assertEquals("responses", openAiAi.apiPathForRequest(aiOptions))
   }
 
   @Test
@@ -97,13 +96,24 @@ class BuildRequestBodyTest {
   }
 
   @Test
-  fun `null reasoning_effort does not use responses path or emit reasoning`() {
+  fun `null reasoning_effort does not emit reasoning in responses body`() {
     val request = createToolRequest("gpt-5.5")
     val extraParams = buildJsonObject { put("reasoning_effort", JsonNull) }
 
-    assertEquals("chat/completions", openAiAi.apiPathForRequest(request, extraParams))
     val result = openAiAi.buildResponsesRequestBody(request, extraParams).jsonObject
     assertFalse(result.containsKey("reasoning"))
+  }
+
+  @Test
+  fun `modelLikelyRequiresResponsesApi detects gpt-5_5 and newer`() {
+    assertFalse(openAiAi.modelLikelyRequiresResponsesApi("gpt-4.1"))
+    assertFalse(openAiAi.modelLikelyRequiresResponsesApi("gpt-5.1"))
+    assertFalse(openAiAi.modelLikelyRequiresResponsesApi("gpt-5"))
+    assertTrue(openAiAi.modelLikelyRequiresResponsesApi("gpt-5.5"))
+    assertTrue(openAiAi.modelLikelyRequiresResponsesApi("gpt-5.6"))
+    assertTrue(openAiAi.modelLikelyRequiresResponsesApi("gpt-6"))
+    assertFalse(openAiAi.modelLikelyRequiresResponsesApi("o3"))
+    assertFalse(openAiAi.modelLikelyRequiresResponsesApi("openai/gpt-5.5"))
   }
 
   @Test

--- a/arbigent-ai-openai/src/test/java/BuildRequestBodyTest.kt
+++ b/arbigent-ai-openai/src/test/java/BuildRequestBodyTest.kt
@@ -1,5 +1,6 @@
 import com.github.takahirom.roborazzi.ExperimentalRoborazziApi
 import io.github.takahirom.arbigent.ChatCompletionRequest
+import io.github.takahirom.arbigent.ChatCompletionResponse
 import io.github.takahirom.arbigent.ChatMessage
 import io.github.takahirom.arbigent.FunctionDefinition
 import io.github.takahirom.arbigent.OpenAIAi
@@ -57,7 +58,7 @@ class BuildRequestBodyTest {
   }
 
   @Test
-  fun `gpt-5_1 with tools and reasoning effort still uses chat completions path`() {
+  fun `gpt-5 dot 1 with tools and reasoning effort still uses chat completions path`() {
     val request = createToolRequest("gpt-5.1")
     val extraParams = buildJsonObject { put("reasoning_effort", "low") }
 
@@ -65,7 +66,7 @@ class BuildRequestBodyTest {
   }
 
   @Test
-  fun `gpt-5_5 with tools and reasoning effort uses responses path`() {
+  fun `gpt-5 dot 5 with tools and reasoning effort uses responses path`() {
     val request = createToolRequest("gpt-5.5")
     val extraParams = buildJsonObject { put("reasoning_effort", "low") }
 
@@ -93,6 +94,76 @@ class BuildRequestBodyTest {
     val tool = result["tools"]?.jsonArray?.first()?.jsonObject
     assertEquals("function", tool?.get("type")?.jsonPrimitive?.content)
     assertEquals("perform_click", tool?.get("name")?.jsonPrimitive?.content)
+  }
+
+  @Test
+  fun `null reasoning_effort does not use responses path or emit reasoning`() {
+    val request = createToolRequest("gpt-5.5")
+    val extraParams = buildJsonObject { put("reasoning_effort", JsonNull) }
+
+    assertEquals("chat/completions", openAiAi.apiPathForRequest(request, extraParams))
+    val result = openAiAi.buildResponsesRequestBody(request, extraParams).jsonObject
+    assertFalse(result.containsKey("reasoning"))
+  }
+
+  @Test
+  fun `normalizeResponsesApiResponse maps plain message output`() {
+    val responseBody = """
+      {
+        "id": "resp_123",
+        "created_at": 1234567890,
+        "model": "gpt-5.5",
+        "output": [
+          {
+            "type": "message",
+            "content": [
+              {"type": "output_text", "text": "hello "},
+              {"type": "text", "text": "world"}
+            ]
+          }
+        ],
+        "usage": {"input_tokens": 10, "output_tokens": 2, "total_tokens": 12}
+      }
+    """.trimIndent()
+
+    val normalized = Json.decodeFromString<ChatCompletionResponse>(
+      openAiAi.normalizeResponsesApiResponse(responseBody, "fallback-model")
+    )
+
+    assertEquals("gpt-5.5", normalized.model)
+    assertEquals("hello world", normalized.choices.first().message.content)
+    assertEquals(10, normalized.usage?.promptTokens)
+    assertEquals(2, normalized.usage?.completionTokens)
+    assertEquals(12, normalized.usage?.totalTokens)
+  }
+
+  @Test
+  fun `normalizeResponsesApiResponse maps all function call outputs`() {
+    val responseBody = """
+      {
+        "id": "resp_123",
+        "created_at": 1234567890,
+        "model": "gpt-5.5",
+        "output": [
+          {"type": "function_call", "call_id": "call_1", "name": "perform_click", "arguments": "{\"text\":\"1\"}"},
+          {"type": "function_call", "id": "fc_2", "name": "perform_wait", "arguments": "{\"text\":\"1000\"}"},
+          {"type": "message", "content": [{"type": "output_text", "text": "done"}]}
+        ]
+      }
+    """.trimIndent()
+
+    val normalized = Json.decodeFromString<ChatCompletionResponse>(
+      openAiAi.normalizeResponsesApiResponse(responseBody, "fallback-model")
+    )
+    val message = normalized.choices.first().message
+
+    assertEquals("done", message.content)
+    assertEquals(2, message.toolCalls?.size)
+    assertEquals("call_1", message.toolCalls?.get(0)?.id)
+    assertEquals("perform_click", message.toolCalls?.get(0)?.function?.name)
+    assertEquals("{\"text\":\"1\"}", message.toolCalls?.get(0)?.function?.arguments)
+    assertEquals("fc_2", message.toolCalls?.get(1)?.id)
+    assertEquals("perform_wait", message.toolCalls?.get(1)?.function?.name)
   }
 
   @Test

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -227,7 +227,8 @@ public data class ArbigentAiOptions(
   public val imageFormat: ImageFormat? = null,
   public val historicalStepLimit: Int? = null,
   @Serializable(with = YamlCompatibleJsonObjectSerializer::class)
-  public val extraBody: JsonObject? = null
+  public val extraBody: JsonObject? = null,
+  public val useResponsesApi: Boolean? = null
 ) {
   public fun mergeWith(other: ArbigentAiOptions?): ArbigentAiOptions {
     if (other == null) return this
@@ -236,7 +237,8 @@ public data class ArbigentAiOptions(
       imageDetail = other.imageDetail ?: imageDetail,
       imageFormat = other.imageFormat ?: imageFormat,
       historicalStepLimit = other.historicalStepLimit ?: historicalStepLimit,
-      extraBody = mergeJsonObjects(extraBody, other.extraBody)
+      extraBody = mergeJsonObjects(extraBody, other.extraBody),
+      useResponsesApi = other.useResponsesApi ?: useResponsesApi
     )
   }
 

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/components/AiOptionsComponent.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/components/AiOptionsComponent.kt
@@ -235,6 +235,36 @@ fun AiOptionsComponent(
         verticalAlignment = Alignment.CenterVertically
     ) {
         Checkbox(
+            checked = updatedOptions.useResponsesApi == true,
+            onCheckedChange = { enabled: Boolean ->
+                updatedOptionsChanged(
+                    updatedOptions.copy(useResponsesApi = if (enabled) true else null)
+                )
+            },
+            modifier = Modifier.testTag("use_responses_api_checkbox")
+        )
+        Text("Use Responses API", modifier = Modifier.padding(start = 8.dp))
+        val uriHandler = LocalUriHandler.current
+        IconActionButton(
+            key = AllIconsKeys.General.Information,
+            onClick = {
+                uriHandler.openUri(uri = "https://platform.openai.com/docs/api-reference/responses")
+            },
+            modifier = Modifier
+                .padding(start = 4.dp)
+                .testTag("use_responses_api_info"),
+            contentDescription = "Use Responses API Info",
+            hint = Size(16)
+        ) {
+            Text("Route requests to /v1/responses instead of /v1/chat/completions. Required for OpenAI gpt-5.5+ when combining function tools with reasoning_effort. Also works with OpenAI-compatible providers (e.g. OpenRouter) that support the Responses API.")
+        }
+    }
+
+    Row(
+        modifier = Modifier.padding(horizontal = 8.dp),
+        verticalAlignment = Alignment.CenterVertically
+    ) {
+        Checkbox(
             checked = updatedOptions.extraBody != null,
             onCheckedChange = { enabled: Boolean ->
                 updatedOptionsChanged(

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/components/AiOptionsComponent.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/components/AiOptionsComponent.kt
@@ -238,7 +238,7 @@ fun AiOptionsComponent(
             checked = updatedOptions.useResponsesApi == true,
             onCheckedChange = { enabled: Boolean ->
                 updatedOptionsChanged(
-                    updatedOptions.copy(useResponsesApi = if (enabled) true else null)
+                    updatedOptions.copy(useResponsesApi = enabled)
                 )
             },
             modifier = Modifier.testTag("use_responses_api_checkbox")

--- a/sample-test/src/main/resources/projects/e2e-test-android-responses.yaml
+++ b/sample-test/src/main/resources/projects/e2e-test-android-responses.yaml
@@ -1,0 +1,10 @@
+scenarios:
+- id: "responses-api-launch-settings"
+  goal: "All you have to do is launch com.android.settings using mcp launch_app"
+  initializationMethods:
+  - type: "Back"
+    times: 2
+  aiOptions:
+    useResponsesApi: true
+    extraBody:
+      reasoning_effort: "low"

--- a/sample-test/src/main/resources/projects/e2e-test-android-responses.yaml
+++ b/sample-test/src/main/resources/projects/e2e-test-android-responses.yaml
@@ -4,7 +4,22 @@ scenarios:
   initializationMethods:
   - type: "Back"
     times: 2
+settings:
   aiOptions:
+    temperature: 0.0
+    imageFormat: "lossy_webp"
     useResponsesApi: true
     extraBody:
       reasoning_effort: "low"
+  mcpJson: |-
+    {
+      "mcpServers": {
+        "android-adb": {
+          "command": "npx",
+          "args": ["-y", "@landicefu/android-adb-mcp-server"],
+          "env": {},
+          "disabled": false,
+          "alwaysAllow": []
+        }
+      }
+    }


### PR DESCRIPTION
Builds on top of #377 (by @imtoori) and makes the Responses API path opt-in via `aiOptions.useResponsesApi` instead of auto-routing by model name. Also fixes the Responses API structured-output mapping, adds a UI toggle, and exercises the path end-to-end in Android e2e.

## Why explicit opt-in
The original PR detects `gpt-5.5+` from the model string and auto-routes function-tools-with-reasoning_effort calls to `/v1/responses`. This is brittle:
- The regex is tied to a specific naming pattern; `o3`/`o1` reasoning models never trigger it, and a future rename can silently drop the routing.
- OpenAI-compatible providers (OpenRouter, Azure, etc.) that don't share the same constraint can be incorrectly diverted.
- It's hard to test against a real endpoint because callers can't force the path.

Making it explicit (default off) keeps existing users unaffected, lets new reasoning models in via a one-line setting, and makes the path testable.

## Changes
- `ArbigentAiOptions`: add `useResponsesApi: Boolean? = null` (serialized into project YAML, merged via `mergeWith`).
- `OpenAIAi.shouldUseResponsesApi` reduced to `aiOptions?.useResponsesApi == true`.
- Renamed `modelRequiresResponsesApiForReasoningTools` to `modelLikelyRequiresResponsesApi` and use it only to emit a warning when the user has `gpt-5.5+ + tools + reasoning_effort` on chat completions without the flag.
- `buildResponsesRequestBody`: map `responseFormat` to `text.format` (Responses API rejects top-level `response_format`); `json_schema` fields are flattened next to `type`.
- UI: `Use Responses API` checkbox in `AiOptionsComponent` (persists explicit `true`/`false`, never `null`, so scenarios can override project-level defaults).
- Tests updated to cover the explicit-flag behavior and the heuristic warning.

## CI verification (end-to-end)
Added a one-scenario smoke project YAML (`e2e-test-android-responses.yaml`) wired into the existing `cli-e2e-android` job (shard 1 only, reuses the booted emulator). It runs `openai/gpt-5.4-mini` with `useResponsesApi: true` and `reasoning_effort: low` through OpenRouter.

Latest run on shard 1: ✅ goal achieved in 3 steps, 0 retries. Confirmed the request actually hits `/v1/responses` with `input`/`tools`/`reasoning.effort` shape, and the response normalizes back into `ChatCompletionResponse` correctly so the agent loop continues.

## Credit
The original Responses API request/response plumbing is @imtoori's work in #377. This PR keeps their commits as-is and layers the option, the UI, the structured-output fix, and the smoke test on top.
