### PR TITLE
Add ClickAtCoordinates AI action (opt-in via additionalActions)

### DIFF
--- a/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
+++ b/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
@@ -532,6 +532,19 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
         )
       }
 
+      ClickAtCoordinates -> {
+        val text = argumentsJsonData["text"]?.jsonPrimitive?.content ?: throw IllegalArgumentException("Text not found")
+        val parts = text.split(",").map { it.trim() }
+        if (parts.size != 2) {
+          throw IllegalArgumentException("text should be \"x,y\" for ${ClickAtCoordinates.actionName}, got: \"$text\"")
+        }
+        val x = parts[0].toIntOrNull()
+          ?: throw IllegalArgumentException("x is not an integer for ${ClickAtCoordinates.actionName}: \"${parts[0]}\"")
+        val y = parts[1].toIntOrNull()
+          ?: throw IllegalArgumentException("y is not an integer for ${ClickAtCoordinates.actionName}: \"${parts[1]}\"")
+        ClickAtCoordinates(x = x, y = y)
+      }
+
       BackPressAgentAction -> BackPressAgentAction()
 
       KeyPressAgentAction -> {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/AgentCommands.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/AgentCommands.kt
@@ -96,6 +96,42 @@ public data class ClickWithIndex(val index: Int) : ArbigentAgentAction {
 }
 
 @Serializable
+public data class ClickAtCoordinates(val x: Int, val y: Int) : ArbigentAgentAction {
+  override val actionName: String = Companion.actionName
+
+  override fun stepLogText(): String {
+    return "Click at coordinates: ($x, $y)"
+  }
+
+  override fun runDeviceAction(runInput: ArbigentAgentAction.RunInput) {
+    runInput.device.executeActions(
+      actions = listOf(
+        MaestroCommand(
+          tapOnPointV2Command = TapOnPointV2Command(
+            point = "$x,$y"
+          )
+        )
+      ),
+    )
+  }
+
+  public companion object : AgentActionType {
+    override val actionName: String = "ClickAtCoordinates"
+
+    override fun arguments(): List<AgentActionType.Argument> =
+      listOf(
+        AgentActionType.Argument(
+          name = "text",
+          type = "string",
+          description = "Raw screen coordinates to tap, formatted as \"x,y\" (e.g. \"195,760\"). Use this ONLY when a target element is visible in the screenshot but NOT present in the ELEMENTS/UI-tree list (typical for native iOS system dialogs like Sign in with Apple, permission prompts, etc.). Coordinates are in screen logical points starting at (0,0) top-left."
+        )
+      )
+
+    override fun actionDescription(): String = "Tap at raw screen coordinates. Use only when the target is not in the UI hierarchy."
+  }
+}
+
+@Serializable
 public data class ClickWithTextAgentAction(val textRegex: String) : ArbigentAgentAction {
   override val actionName: String = Companion.actionName
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -881,7 +881,6 @@ public fun defaultAgentActionTypesForVisualMode(): List<AgentActionType> {
 //    ClickWithIdAgentAction,
 //    ClickWithTextAgentAction,
     ClickWithIndex,
-    ClickAtCoordinates,
     InputTextAgentAction,
     BackPressAgentAction,
     KeyPressAgentAction,
@@ -917,6 +916,7 @@ public fun defaultAgentActionTypesForTvForVisualMode(): List<AgentActionType> {
 private fun getAgentActionTypeByName(actionName: String): AgentActionType? {
   return when (actionName) {
     "ClickWithText" -> ClickWithTextAgentAction
+    "ClickAtCoordinates" -> ClickAtCoordinates
     else -> null
   }
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -881,6 +881,7 @@ public fun defaultAgentActionTypesForVisualMode(): List<AgentActionType> {
 //    ClickWithIdAgentAction,
 //    ClickWithTextAgentAction,
     ClickWithIndex,
+    ClickAtCoordinates,
     InputTextAgentAction,
     BackPressAgentAction,
     KeyPressAgentAction,

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/AdditionalActionsConstants.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/AdditionalActionsConstants.kt
@@ -2,6 +2,7 @@ package io.github.takahirom.arbigent.ui
 
 object AdditionalActionsConstants {
   val AVAILABLE_ACTIONS = listOf(
-    "ClickWithText"
+    "ClickWithText",
+    "ClickAtCoordinates"
   )
 }

--- a/arbigent-ui/src/test/kotlin/AdditionalActionsTest.kt
+++ b/arbigent-ui/src/test/kotlin/AdditionalActionsTest.kt
@@ -131,7 +131,8 @@ class AdditionalActionsTest {
     @Test
     fun `AdditionalActionsConstants AVAILABLE_ACTIONS should contain all supported actions`() {
         val expectedActions = listOf(
-            "ClickWithText"
+            "ClickWithText",
+            "ClickAtCoordinates"
         )
 
         assertEquals(expectedActions, AdditionalActionsConstants.AVAILABLE_ACTIONS)


### PR DESCRIPTION
Brings #376 into the repo so CI can run on it, with a follow-up commit that switches the action from a default-on tool to opt-in via the existing `additionalActions` mechanism.

## Summary

- Cherry-picks @ibrahimtalabat's `ClickAtCoordinates` action from #376 (lets the model tap raw `x,y` screen coordinates parsed from the screenshot, for cases where the target button — Sign in with Apple sheet, AuthKitUIService, system permission prompts — is not in the UI hierarchy).
- Removes it from `defaultAgentActionTypesForVisualMode()` and registers it in `getAgentActionTypeByName()` so users opt in via `settings.additionalActions: ["ClickAtCoordinates"]`, matching how `ClickWithText` is exposed today.
- Adds it to `AdditionalActionsConstants.AVAILABLE_ACTIONS` so it appears in the UI picker.

## Why opt-in

Raw-coordinate taps are a fallback for a narrow set of native iOS dialogs — exposing the tool by default risks the model preferring it over indexed taps in the common case. Keeping it behind `additionalActions` matches the existing escape-hatch pattern.

## Usage

```yaml
settings:
  additionalActions:
    - ClickAtCoordinates
```

Then scenarios should include guidance like:

> Use `ClickAtCoordinates` with `text="x,y"` to tap raw coordinates when a visible button is missing from the indexed UI tree.

## Test plan

- [ ] CI compiles all modules
- [ ] Existing `additionalActions` tests still pass
- [ ] Manual verification against the iOS Sign in with Apple sheet (per #376)


---
_Generated by [Claude Code](https://claude.ai/code/session_01RiQux2MMDcBqQXVo4aF1eT)_