### PR TITLE
Switch CLI E2E model to gemma-4-31b-it

### DIFF
--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -145,7 +145,7 @@ jobs:
           heap-size: 600M
           script: |
             set -eu
-            arbigent-cli/build/install/arbigent/bin/arbigent run --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android.yaml --ai-type=openai --openai-endpoint=https://openrouter.ai/api/v1/ --openai-model-name=google/gemini-2.5-flash-lite --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --variables "search_term=Bluetooth,app_package=com.android.camera2"
+            arbigent-cli/build/install/arbigent/bin/arbigent run --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android.yaml --ai-type=openai --openai-endpoint=https://openrouter.ai/api/v1/ --openai-model-name=google/gemma-4-31b-it --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }} --variables "search_term=Bluetooth,app_package=com.android.camera2"
             if [ "${{ matrix.shardIndex }}" = "1" ]; then arbigent-cli/build/install/arbigent/bin/arbigent run --os=android --project-file=sample-test/src/main/resources/projects/e2e-test-android-responses.yaml --ai-type=openai --openai-endpoint=https://openrouter.ai/api/v1/ --openai-model-name=openai/gpt-5.4-mini; fi
       - name: Check API key leakage
         run: |
@@ -235,7 +235,7 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPEN_ROUTER_API_KEY }}
         run: |
-          arbigent-cli/build/install/arbigent/bin/arbigent run --os=ios --project-file=sample-test/src/main/resources/projects/e2e-test-ios.yaml --ai-type=openai --openai-endpoint=https://openrouter.ai/api/v1/ --openai-model-name=google/gemini-2.5-flash-lite
+          arbigent-cli/build/install/arbigent/bin/arbigent run --os=ios --project-file=sample-test/src/main/resources/projects/e2e-test-ios.yaml --ai-type=openai --openai-endpoint=https://openrouter.ai/api/v1/ --openai-model-name=google/gemma-4-31b-it
       - name: Check API key leakage
         run: |
           if grep -R --quiet "${{ secrets.OPEN_ROUTER_API_KEY }}" arbigent-result/; then


### PR DESCRIPTION
# What
Switch the model used by the CLI E2E test jobs (Android + iOS) in `build-cli.yaml` from `google/gemini-2.5-flash-lite` to `google/gemma-4-31b-it`.

# Why
The E2E jobs have been flaky. Inspecting the uploaded `result.yml` artifacts showed the failures were caused by weak UI-state recognition rather than a code regression: e.g. for the "Just open camera app" scenario the camera viewfinder was already shown (goal physically achieved), but `gemini-2.5-flash-lite` kept tapping the shutter and never emitted GoalAchieved, exhausting retries. The iOS "Open About" flow failed the same way via its dependency scenario. `gemma-4-31b-it` is the largest Gemma 4 (31B dense) multimodal variant with stronger grounding, at comparable cost.