### PR TITLE
Revert iOS reconnect-retry; warm up the simulator instead

### DIFF
--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -231,6 +231,18 @@ jobs:
           done
           echo "Simulator booted successfully."
 
+          # Warm up before the test. A freshly booted simulator is still doing
+          # post-boot work (e.g. Data Migration), and hitting it immediately tends to
+          # crash the XCTest runner on the first app launch. Let it settle, then
+          # pre-launch the target app once so the first real interaction runs warm.
+          echo "Warming up simulator..."
+          sleep 20
+          xcrun simctl launch "iPhone 15 Pro" com.apple.Preferences || true
+          sleep 8
+          xcrun simctl terminate "iPhone 15 Pro" com.apple.Preferences || true
+          sleep 2
+          echo "Warm up done."
+
       - name: CLI E2E test for iOS
         env:
           OPENAI_API_KEY: ${{ secrets.OPEN_ROUTER_API_KEY }}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -213,47 +213,6 @@ public class MaestroDevice(
     return maestro.deviceName
   }
 
-  private val maxOperationRecoveries = 3
-
-  // A device/runner can crash mid-flow (e.g. the iOS XCTest runner dies, leaving the
-  // port refused). Such errors are recoverable by reconnecting, unlike a real
-  // assertion/logic failure which must surface. Only connection/crash signatures qualify.
-  private fun isRecoverableDeviceError(error: Throwable): Boolean {
-    var cause: Throwable? = error
-    while (cause != null) {
-      if (cause is java.net.ConnectException) return true
-      val message = cause.message ?: ""
-      if (message.contains("App crashed or stopped", ignoreCase = true) ||
-        message.contains("Connection refused", ignoreCase = true) ||
-        message.contains("Failed to connect", ignoreCase = true)
-      ) {
-        return true
-      }
-      cause = cause.cause
-    }
-    return false
-  }
-
-  // Run a device operation, recovering from a mid-flow crash/disconnect by reconnecting
-  // (which reinstalls the runner and waits with backoff) and retrying. Non-recoverable
-  // errors are rethrown immediately so genuine failures are not masked.
-  private fun <T> withDeviceRecovery(operation: () -> T): T {
-    var lastError: Exception? = null
-    for (attempt in 0 until maxOperationRecoveries) {
-      try {
-        return operation()
-      } catch (e: Exception) {
-        if (!isRecoverableDeviceError(e)) throw e
-        lastError = e
-        arbigentInfoLog(
-          "Recoverable device error during operation (recovery ${attempt + 1}/$maxOperationRecoveries): ${e.message}. Reconnecting and retrying."
-        )
-        reconnectIfDisconnected()
-      }
-    }
-    throw RuntimeException("Device operation failed after $maxOperationRecoveries recovery attempts", lastError)
-  }
-
   @Synchronized
   private fun ensureConnected() {
     // Try a simple operation to check connection
@@ -267,19 +226,17 @@ public class MaestroDevice(
   }
 
   override fun executeActions(actions: List<MaestroCommand>) {
-    withDeviceRecovery {
-      ensureConnected()
-      ArbigentGlobalStatus.onDevice(actions.joinToString { it.toString() }) {
-        // If the jsEngine is already initialized, we don't need to reinitialize it
-        val shouldJsReinit = if (orchestra::class.java.getDeclaredField("jsEngine").apply {
-            isAccessible = true
-          }.get(orchestra) != null) {
-          false
-        } else {
-          true
-        }
-        orchestra.executeCommands(actions, shouldReinitJsEngine = shouldJsReinit)
+    ensureConnected()
+    ArbigentGlobalStatus.onDevice(actions.joinToString { it.toString() }) {
+      // If the jsEngine is already initialized, we don't need to reinitialize it
+      val shouldJsReinit = if (orchestra::class.java.getDeclaredField("jsEngine").apply {
+          isAccessible = true
+        }.get(orchestra) != null) {
+        false
+      } else {
+        true
       }
+      orchestra.executeCommands(actions, shouldReinitJsEngine = shouldJsReinit)
     }
   }
 
@@ -288,44 +245,41 @@ public class MaestroDevice(
     maestro.waitForAppToSettle(appId = appId)
   }
 
-  override fun elements(): ArbigentElementList = withDeviceRecovery {
+  override fun elements(): ArbigentElementList {
     ensureConnected()
-    var elementList: ArbigentElementList? = null
     for (it in 0..2) {
       try {
         val viewHierarchy = maestro.viewHierarchy(false)
         val deviceInfo = maestro.cachedDeviceInfo
-        elementList = ArbigentElementList.from(viewHierarchy, deviceInfo)
-        break
+        val elementList = ArbigentElementList.from(viewHierarchy, deviceInfo)
+        return elementList
       } catch (e: ArbigentElementList.NodeInBoundsNotFoundException) {
         arbigentDebugLog("NodeInBoundsNotFoundException. Retry $it")
         Thread.sleep(1000)
       }
     }
-    elementList ?: ArbigentElementList(emptyList(), maestro.cachedDeviceInfo.widthPixels)
+    return ArbigentElementList(emptyList(), maestro.cachedDeviceInfo.widthPixels)
   }
 
 
-  override fun viewTreeString(): ArbigentUiTreeStrings = withDeviceRecovery {
+  override fun viewTreeString(): ArbigentUiTreeStrings {
     ensureConnected()
-    var treeStrings: ArbigentUiTreeStrings? = null
     for (it in 0..2) {
       try {
         val viewHierarchy = maestro.viewHierarchy(false)
-        treeStrings = ArbigentUiTreeStrings(
+        return ArbigentUiTreeStrings(
           allTreeString = viewHierarchy.toString(),
           optimizedTreeString = viewHierarchy.toOptimizedString(
             deviceInfo = maestro.cachedDeviceInfo
           ),
           aiHints = viewHierarchy.root.findAllAiHints()
         )
-        break
       } catch (e: ArbigentElementList.NodeInBoundsNotFoundException) {
         arbigentDebugLog("NodeInBoundsNotFoundException. Retry $it")
         Thread.sleep(1000)
       }
     }
-    treeStrings ?: ArbigentUiTreeStrings(
+    return ArbigentUiTreeStrings(
       allTreeString = "",
       optimizedTreeString = ""
     )
@@ -702,26 +656,6 @@ public class MaestroDevice(
           newDevice.close()
           lastException = IllegalStateException("Unexpected device type after reconnection: ${newDevice.javaClass}")
           continue // Try again
-        }
-
-        // Verify the reconnected device is actually responsive before adopting it.
-        // connectToDevice() only builds the driver objects; it does not confirm that
-        // the underlying XCTest runner / simulator is alive. Probing the view hierarchy
-        // both validates liveness and lets the driver (re)install and relaunch a crashed
-        // runner. Without this probe a dead connection is silently treated as a
-        // successful reconnect, the exponential backoff never engages, and we keep
-        // looping against a refused port.
-        try {
-          newDevice.maestro.viewHierarchy()
-        } catch (e: Exception) {
-          lastException = e
-          arbigentInfoLog("Reconnection attempt $reconnectAttempts/$maxReconnectAttempts connected but device is not responsive: ${e.message}")
-          try {
-            newDevice.close()
-          } catch (_: Exception) {
-            // Ignore close errors, device might already be disconnected
-          }
-          continue // Try again with backoff
         }
 
         // Update to new connection

--- a/arbigent-core/src/test/java/MaestroDeviceReconnectionTest.kt
+++ b/arbigent-core/src/test/java/MaestroDeviceReconnectionTest.kt
@@ -50,77 +50,6 @@ class MaestroDeviceReconnectionTest {
     }
 
     @Test
-    fun testReconnectFailsWhenLivenessProbeNeverPasses() = runTest {
-        // A connection that establishes but is never responsive (e.g. a crashed
-        // XCTest runner on a refused port) must NOT be treated as a successful
-        // reconnect. It should keep retrying with backoff and finally fail.
-        val device = TestMaestroDeviceWithRetryLimit(probePasses = false)
-
-        val exception = assertFailsWith<RuntimeException> {
-            device.simulateReconnectionWithLivenessProbe()
-        }
-
-        assertTrue(exception.message?.contains("Failed to reconnect after 6 attempts") == true)
-    }
-
-    @Test
-    fun testReconnectSucceedsWhenLivenessProbePasses() = runTest {
-        // When the reconnected device responds to the liveness probe, the reconnect
-        // succeeds and the attempt counter is reset.
-        val device = TestMaestroDeviceWithRetryLimit(probePasses = true)
-
-        device.simulateReconnectionWithLivenessProbe()
-
-        assertEquals(0, device.currentAttempts(), "Counter should reset on a verified reconnect")
-    }
-
-    @Test
-    fun testRecoverableErrorClassification() {
-        val recovery = DeviceRecoveryMimic()
-        // Connection/crash signatures are recoverable.
-        assertTrue(recovery.isRecoverable(java.net.ConnectException("Connection refused")))
-        assertTrue(recovery.isRecoverable(RuntimeException("App crashed or stopped while executing flow")))
-        assertTrue(recovery.isRecoverable(RuntimeException("Failed to connect to /[0:0:0:0:0:0:0:1]:8080")))
-        // Wrapped causes are detected too.
-        assertTrue(recovery.isRecoverable(RuntimeException("wrapper", java.net.ConnectException("boom"))))
-        // A real assertion/logic failure is NOT recoverable.
-        assertTrue(!recovery.isRecoverable(AssertionError("expected X but was Y")))
-        assertTrue(!recovery.isRecoverable(IllegalStateException("invalid scenario")))
-    }
-
-    @Test
-    fun testRecoveryRetriesThenSucceeds() {
-        val recovery = DeviceRecoveryMimic()
-        var calls = 0
-        val result = recovery.withRecovery {
-            calls++
-            if (calls < 3) throw java.net.ConnectException("Connection refused")
-            "ok"
-        }
-        assertEquals("ok", result)
-        assertEquals(3, calls)
-        assertEquals(2, recovery.reconnectCalls, "should reconnect once per recoverable failure")
-    }
-
-    @Test
-    fun testRecoveryRethrowsNonRecoverableImmediately() {
-        val recovery = DeviceRecoveryMimic()
-        assertFailsWith<AssertionError> {
-            recovery.withRecovery { throw AssertionError("real failure") }
-        }
-        assertEquals(0, recovery.reconnectCalls, "must not reconnect on a non-recoverable error")
-    }
-
-    @Test
-    fun testRecoveryGivesUpAfterMaxAttempts() {
-        val recovery = DeviceRecoveryMimic()
-        assertFailsWith<RuntimeException> {
-            recovery.withRecovery { throw java.net.ConnectException("Connection refused") }
-        }
-        assertEquals(3, recovery.reconnectCalls, "should attempt recovery up to the max")
-    }
-
-    @Test
     fun testThreadSafetyOfReconnection() = runTest {
         // Test that reconnection is thread-safe
         val device = TestMaestroDeviceWithRetryLimit()
@@ -146,77 +75,15 @@ class MaestroDeviceReconnectionTest {
 
 
     /**
-     * Mirrors MaestroDevice.isRecoverableDeviceError / withDeviceRecovery so the
-     * recovery semantics are covered without a real Maestro device.
-     */
-    private class DeviceRecoveryMimic {
-        private val maxOperationRecoveries = 3
-        var reconnectCalls = 0
-
-        fun isRecoverable(error: Throwable): Boolean {
-            var cause: Throwable? = error
-            while (cause != null) {
-                if (cause is java.net.ConnectException) return true
-                val message = cause.message ?: ""
-                if (message.contains("App crashed or stopped", ignoreCase = true) ||
-                    message.contains("Connection refused", ignoreCase = true) ||
-                    message.contains("Failed to connect", ignoreCase = true)
-                ) {
-                    return true
-                }
-                cause = cause.cause
-            }
-            return false
-        }
-
-        fun <T> withRecovery(operation: () -> T): T {
-            var lastError: Exception? = null
-            for (attempt in 0 until maxOperationRecoveries) {
-                try {
-                    return operation()
-                } catch (e: Exception) {
-                    if (!isRecoverable(e)) throw e
-                    lastError = e
-                    reconnectCalls++
-                }
-            }
-            throw RuntimeException("Device operation failed after $maxOperationRecoveries recovery attempts", lastError)
-        }
-    }
-
-    /**
      * Test implementation simulating MaestroDevice reconnection logic.
      * This mimics the actual implementation's behavior for testing.
      */
     private class TestMaestroDeviceWithRetryLimit(
-        private val hasAvailableDevice: Boolean = true,
-        private val probePasses: Boolean = true
+        private val hasAvailableDevice: Boolean = true
     ) {
         private var reconnectAttempts = 0
         private val maxReconnectAttempts = 6
         private val reconnectLock = Any()
-
-        fun currentAttempts(): Int = reconnectAttempts
-
-        // Mirrors reconnectIfDisconnected(): a fresh connection is only adopted when
-        // the liveness probe passes; a failed probe counts as a failed attempt and
-        // keeps the backoff loop going until maxReconnectAttempts is exhausted.
-        fun simulateReconnectionWithLivenessProbe() {
-            synchronized(reconnectLock) {
-                var lastException: Exception? = null
-                while (reconnectAttempts < maxReconnectAttempts) {
-                    reconnectAttempts++
-                    // connectToDevice() succeeds (builds driver objects), then probe.
-                    if (probePasses) {
-                        reconnectAttempts = 0
-                        return
-                    }
-                    lastException = RuntimeException("device not responsive")
-                }
-                reconnectAttempts = 0
-                throw RuntimeException("Failed to reconnect after $maxReconnectAttempts attempts", lastException)
-            }
-        }
 
         fun simulateFailedReconnectionAttempts() {
             synchronized(reconnectLock) {


### PR DESCRIPTION
# What
- Revert the iOS device reconnect-retry recovery added in #382 (`withDeviceRecovery`, the execution-path wrappers, and the liveness probe). `ArbigentDevice` and its reconnection test are restored to their pre-#382 state. (The #382 UI-test settle change is kept.)
- Instead, **warm up the iOS simulator** in CI before the E2E run: after boot, let post-boot work (e.g. Data Migration) settle and pre-launch the target app once so the first real interaction runs warm.

# Why
On main, the #382 recovery proved net-negative. CI log of the failing `cli-e2e-ios` run showed: 1 initial runner crash → **36 recovery cycles / 74 reconnects over ~18 minutes**, the liveness probe passing every time (false positive — the runner comes up for a moment then dies on real work), `Operation completed`/`Goal achieved` zero times, then still failing. A client-side reconnect cannot un-wedge a crash-looping iOS XCTest runner; only a simulator reboot (intentionally not done in a library) or preventing the crash works. The recovery just turned a fast failure into an 18-minute thrash.

The crash is triggered by hitting a freshly booted, still-settling simulator on the first app launch. Warming up the simulator first attacks that trigger directly, which is the real stability lever here — without masking failures via retries.