### PR TITLE
Warm up iOS simulator on connect to avoid cold-start runner crashes

### DIFF
--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -231,18 +231,6 @@ jobs:
           done
           echo "Simulator booted successfully."
 
-          # Warm up before the test. A freshly booted simulator is still doing
-          # post-boot work (e.g. Data Migration), and hitting it immediately tends to
-          # crash the XCTest runner on the first app launch. Let it settle, then
-          # pre-launch the target app once so the first real interaction runs warm.
-          echo "Warming up simulator..."
-          sleep 20
-          xcrun simctl launch "iPhone 15 Pro" com.apple.Preferences || true
-          sleep 8
-          xcrun simctl terminate "iPhone 15 Pro" com.apple.Preferences || true
-          sleep 2
-          echo "Warm up done."
-
       - name: CLI E2E test for iOS
         env:
           OPENAI_API_KEY: ${{ secrets.OPEN_ROUTER_API_KEY }}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
@@ -89,11 +89,20 @@ public sealed interface ArbigentAvailableDevice {
           )
         )
       )
-      warmUp(maestro)
-      return MaestroDevice(
-        maestro,
-        availableDevice = this
-      )
+      try {
+        warmUp(maestro)
+        return MaestroDevice(
+          maestro,
+          availableDevice = this
+        )
+      } catch (e: InterruptedException) {
+        Thread.currentThread().interrupt()
+        maestro.close()
+        throw e
+      } catch (e: Exception) {
+        maestro.close()
+        throw e
+      }
     }
 
     // A freshly booted iOS simulator is still doing post-boot work (e.g. Data
@@ -119,6 +128,7 @@ public sealed interface ArbigentAvailableDevice {
       }
       if (!responsive) {
         arbigentInfoLog("iOS warm-up: device did not become responsive within ${warmUpTimeoutMs}ms; continuing anyway")
+        return
       }
       // Let post-boot work settle before the first scenario interaction.
       Thread.sleep(settleMs)

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
@@ -80,18 +80,49 @@ public sealed interface ArbigentAvailableDevice {
         getInstalledApps = { XCRunnerCLIUtils.listApps(device.udid) },
       )
 
-      return MaestroDevice(
-        Maestro.ios(
-          IOSDriver(
-            LocalIOSDevice(
-              deviceId = device.udid,
-              xcTestDevice = xcTestDevice,
-              simctlIOSDevice = SimctlIOSDevice(device.udid)
-            )
+      val maestro = Maestro.ios(
+        IOSDriver(
+          LocalIOSDevice(
+            deviceId = device.udid,
+            xcTestDevice = xcTestDevice,
+            simctlIOSDevice = SimctlIOSDevice(device.udid)
           )
-        ),
+        )
+      )
+      warmUp(maestro)
+      return MaestroDevice(
+        maestro,
         availableDevice = this
       )
+    }
+
+    // A freshly booted iOS simulator is still doing post-boot work (e.g. Data
+    // Migration), and hitting it with the first scenario action tends to crash the
+    // XCTest runner. Warm it up first: poll the view hierarchy until the runner
+    // responds (this also starts the runner), then let it settle, so the first real
+    // interaction runs on a warm, stable device.
+    private fun warmUp(maestro: Maestro) {
+      val warmUpTimeoutMs = 60_000L
+      val settleMs = 10_000L
+      val pollIntervalMs = 2_000L
+      val start = System.currentTimeMillis()
+      var responsive = false
+      while (System.currentTimeMillis() - start < warmUpTimeoutMs) {
+        try {
+          maestro.viewHierarchy()
+          responsive = true
+          break
+        } catch (e: Exception) {
+          arbigentInfoLog("iOS warm-up: device not responsive yet, retrying: ${e.message}")
+          Thread.sleep(pollIntervalMs)
+        }
+      }
+      if (!responsive) {
+        arbigentInfoLog("iOS warm-up: device did not become responsive within ${warmUpTimeoutMs}ms; continuing anyway")
+      }
+      // Let post-boot work settle before the first scenario interaction.
+      Thread.sleep(settleMs)
+      arbigentInfoLog("iOS warm-up done")
     }
   }
 


### PR DESCRIPTION
# What
Move the iOS simulator warmup from CI into arbigent itself. `ArbigentAvailableDevice.IOS.connectToDevice()` now calls a `warmUp()` after building the Maestro connection: poll `viewHierarchy()` until the XCTest runner responds (≤60s), then settle (10s), before the first scenario runs. The CI-side warmup block in `build-cli.yaml` is removed.

# Why
A freshly booted iOS simulator is still doing post-boot work (e.g. Data Migration); hitting it with the first scenario action tends to crash the XCTest runner ("App crashed or stopped while executing flow" → `ConnectException [::1]:8080 refused`), which was the dominant cause of ~40% `cli-e2e-ios` flakiness.

A CI-only warmup proved effective on main (previously-crashing scenarios passed cleanly, 0 crashes), but a CI workaround only helps this repo — every arbigent user driving a fresh iOS simulator hits the same crash. Putting the warmup in the library fixes it for everyone. It is non-invasive (no simulator reboot) and does not mask failures (a genuinely broken device still fails on the first real interaction).

Note: a client-side reconnect cannot recover a crash-looped runner (that approach was reverted in #383 after it thrashed ~18 min); preventing the cold-start crash is the real lever.