### PR TITLE
Add Android Studio Journeys XML import support to CLI

### DIFF
--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -195,7 +195,9 @@ jobs:
           # Check Xcode version
           xcodebuild -version
       - name: Install applesimutils
-        run: brew tap wix/brew && brew install applesimutils
+        # `brew trust` is required since Homebrew started refusing untrusted third-party taps;
+        # `|| true` keeps this working on older Homebrew versions without the trust command.
+        run: brew tap wix/brew && (brew trust wix/brew || true) && brew install applesimutils
       - name: Start iOS Simulator with Custom Timeout
         run: |
           # List available devices

--- a/README.md
+++ b/README.md
@@ -211,6 +211,25 @@ This enables you to:
 - Reuse existing Maestro test automation assets
 - Combine precise setup sequences with AI-driven testing
 
+### Android Studio Journeys XML Import
+
+Arbigent can run [Android Studio Journeys](https://developer.android.com/studio/gemini/journeys) test files (`*.journey.xml` / `*_journey.xml`) directly, so existing journey files work without converting them to project YAML:
+
+```bash
+# Run a single journey file
+arbigent run --project-file app/src/journeysTest/weather.journey.xml
+
+# Run all journey files under a directory (one scenario per file)
+arbigent run --project-file app/src/journeysTest/
+```
+
+Each journey is imported as one scenario: the `<description>` and ordered `<action>` steps become the scenario goal, and the scenario id is derived from the file name (e.g. `weather.journey.xml` → `weather`), which you can use with `--scenario-ids`.
+
+Notes:
+- The AI follows the actions as an ordered hint within a single goal rather than executing them as strict discrete steps
+- Journey scenarios have no tags, so `--tags` cannot be used with journey sources
+- Export from Arbigent back to journey XML is not supported
+
 ### Test Execution
 
 Run tests either directly through the UI or programmatically via the code interface or CLI.

--- a/arbigent-cli/src/main/kotlin/CommonOptions.kt
+++ b/arbigent-cli/src/main/kotlin/CommonOptions.kt
@@ -111,6 +111,47 @@ fun createAi(aiType: AiConfig, aiApiLoggingEnabled: Boolean): ArbigentAi {
   }
 }
 
+/**
+ * Returns true when [projectFile] points to an Android Studio Journeys source: a single
+ * `*.journey.xml` / `*_journey.xml` file, or a directory that contains such files.
+ */
+fun isJourneyProjectSource(projectFile: String): Boolean {
+  val file = File(projectFile)
+  if (!file.exists()) return false
+  if (file.isDirectory) {
+    return file.walkTopDown().any { it.isFile && ArbigentJourneyXmlImporter.isJourneyFile(it) }
+  }
+  return ArbigentJourneyXmlImporter.isJourneyFile(file)
+}
+
+/**
+ * Builds an [ArbigentProject] from [projectFile], loading Journeys XML when the path is a
+ * journey source and falling back to the normal YAML loader otherwise.
+ */
+fun loadArbigentProject(
+  projectFile: String,
+  aiFactory: () -> ArbigentAi,
+  deviceFactory: () -> ArbigentDevice,
+  appSettings: ArbigentAppSettings,
+): ArbigentProject {
+  return if (isJourneyProjectSource(projectFile)) {
+    val projectFileContent = ArbigentJourneyXmlImporter.loadProjectContent(File(projectFile))
+    ArbigentProject(
+      projectFileContent = projectFileContent,
+      aiFactory = aiFactory,
+      deviceFactory = deviceFactory,
+      appSettings = appSettings,
+    )
+  } else {
+    ArbigentProject(
+      file = File(projectFile),
+      aiFactory = aiFactory,
+      deviceFactory = deviceFactory,
+      appSettings = appSettings,
+    )
+  }
+}
+
 fun connectDevice(os: String): ArbigentDevice {
   val deviceOs =
     ArbigentDeviceOs.entries.find { it.name.toLowerCasePreservingASCIIRules() == os.toLowerCasePreservingASCIIRules() }

--- a/arbigent-cli/src/main/kotlin/CommonOptions.kt
+++ b/arbigent-cli/src/main/kotlin/CommonOptions.kt
@@ -112,16 +112,23 @@ fun createAi(aiType: AiConfig, aiApiLoggingEnabled: Boolean): ArbigentAi {
 }
 
 /**
- * Returns true when [projectFile] points to an Android Studio Journeys source: a single
- * `*.journey.xml` / `*_journey.xml` file, or a directory that contains such files.
+ * Returns the non-null project file path, or fails with the same CLI error every command shows
+ * when `--project-file` is missing.
+ */
+fun requireProjectFile(projectFile: String?): String =
+  projectFile
+    ?: throw CliktError("Missing option '--project-file'. Please provide a project file path via command line argument or in .arbigent/settings.local.yml")
+
+/**
+ * Returns true when [projectFile] points to an Android Studio Journeys source: a
+ * `*.journey.xml` / `*_journey.xml` file, or a directory (directories are only valid as journey
+ * sources — the YAML loader requires a file — so the journey loader owns them and reports a clear
+ * error when no journey files are found).
  */
 fun isJourneyProjectSource(projectFile: String): Boolean {
   val file = File(projectFile)
   if (!file.exists()) return false
-  if (file.isDirectory) {
-    return file.walkTopDown().any { it.isFile && ArbigentJourneyXmlImporter.isJourneyFile(it) }
-  }
-  return ArbigentJourneyXmlImporter.isJourneyFile(file)
+  return file.isDirectory || ArbigentJourneyXmlImporter.isJourneyFile(file)
 }
 
 /**

--- a/arbigent-cli/src/main/kotlin/RunCommand.kt
+++ b/arbigent-cli/src/main/kotlin/RunCommand.kt
@@ -144,8 +144,8 @@ class ArbigentRunCommand : CliktCommand(name = "run") {
       path = path,
       variables = variables
     )
-    val arbigentProject = ArbigentProject(
-      file = File(projectFile),
+    val arbigentProject = loadArbigentProject(
+      projectFile = projectFile!!,
       aiFactory = { ai },
       deviceFactory = { device ?: throw UnsupportedOperationException("Device not available in dry-run mode") },
       appSettings = appSettings

--- a/arbigent-cli/src/main/kotlin/RunCommand.kt
+++ b/arbigent-cli/src/main/kotlin/RunCommand.kt
@@ -116,8 +116,9 @@ class ArbigentRunCommand : CliktCommand(name = "run") {
     if (currentContext.invokedSubcommand != null) return
 
     // Check that project-file is provided either via CLI args or settings file
-    if (projectFile == null) {
-      throw CliktError("Missing option '--project-file'. Please provide a project file path via command line argument or in .arbigent/settings.local.yml")
+    val projectFilePath = requireProjectFile(projectFile)
+    if (tags.isNotEmpty() && isJourneyProjectSource(projectFilePath)) {
+      throw CliktError("--tags is not supported for Journeys XML projects because journey scenarios have no tags")
     }
 
     validateAiConfig(aiType)
@@ -145,7 +146,7 @@ class ArbigentRunCommand : CliktCommand(name = "run") {
       variables = variables
     )
     val arbigentProject = loadArbigentProject(
-      projectFile = projectFile!!,
+      projectFile = projectFilePath,
       aiFactory = { ai },
       deviceFactory = { device ?: throw UnsupportedOperationException("Device not available in dry-run mode") },
       appSettings = appSettings

--- a/arbigent-cli/src/main/kotlin/ScenariosCommand.kt
+++ b/arbigent-cli/src/main/kotlin/ScenariosCommand.kt
@@ -26,8 +26,11 @@ class ArbigentScenariosCommand : CliktCommand(name = "scenarios") {
     arbigentDebugLog("  ai-type: Not applicable for scenarios command")
     arbigentDebugLog("  Note: ai-type from global would be 'global-openai' if this command used it")
     arbigentDebugLog("==========================================")
-    val arbigentProject = ArbigentProject(
-      file = File(projectFile),
+    if (projectFile == null) {
+      throw IllegalArgumentException("Missing option '--project-file'. Please provide a project file path via command line argument or in .arbigent/settings.local.yml")
+    }
+    val arbigentProject = loadArbigentProject(
+      projectFile = projectFile!!,
       aiFactory = { throw UnsupportedOperationException("AI not needed for listing") },
       deviceFactory = { throw UnsupportedOperationException("Device not needed for listing") },
       appSettings = CliAppSettings(

--- a/arbigent-cli/src/main/kotlin/ScenariosCommand.kt
+++ b/arbigent-cli/src/main/kotlin/ScenariosCommand.kt
@@ -4,7 +4,6 @@ package io.github.takahirom.arbigent.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
 import io.github.takahirom.arbigent.*
-import java.io.File
 
 class ArbigentScenariosCommand : CliktCommand(name = "scenarios") {
   // Same common options as run command
@@ -26,11 +25,8 @@ class ArbigentScenariosCommand : CliktCommand(name = "scenarios") {
     arbigentDebugLog("  ai-type: Not applicable for scenarios command")
     arbigentDebugLog("  Note: ai-type from global would be 'global-openai' if this command used it")
     arbigentDebugLog("==========================================")
-    if (projectFile == null) {
-      throw IllegalArgumentException("Missing option '--project-file'. Please provide a project file path via command line argument or in .arbigent/settings.local.yml")
-    }
     val arbigentProject = loadArbigentProject(
-      projectFile = projectFile!!,
+      projectFile = requireProjectFile(projectFile),
       aiFactory = { throw UnsupportedOperationException("AI not needed for listing") },
       deviceFactory = { throw UnsupportedOperationException("Device not needed for listing") },
       appSettings = CliAppSettings(

--- a/arbigent-cli/src/main/kotlin/TagsCommand.kt
+++ b/arbigent-cli/src/main/kotlin/TagsCommand.kt
@@ -18,8 +18,11 @@ class ArbigentTagsCommand : CliktCommand(name = "tags") {
       ArbigentLogLevel.entries.find { it.name.lowercase() == logLevel.lowercase() }
         ?: throw IllegalArgumentException("Invalid log level: $logLevel")
     
-    val arbigentProject = ArbigentProject(
-      file = File(projectFile),
+    if (projectFile == null) {
+      throw IllegalArgumentException("Missing option '--project-file'. Please provide a project file path via command line argument or in .arbigent/settings.local.yml")
+    }
+    val arbigentProject = loadArbigentProject(
+      projectFile = projectFile!!,
       aiFactory = { throw UnsupportedOperationException("AI not needed for listing") },
       deviceFactory = { throw UnsupportedOperationException("Device not needed for listing") },
       appSettings = CliAppSettings(

--- a/arbigent-cli/src/main/kotlin/TagsCommand.kt
+++ b/arbigent-cli/src/main/kotlin/TagsCommand.kt
@@ -4,7 +4,6 @@ package io.github.takahirom.arbigent.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
 import io.github.takahirom.arbigent.*
-import java.io.File
 
 class ArbigentTagsCommand : CliktCommand(name = "tags") {
   // Same common options as run command
@@ -18,11 +17,8 @@ class ArbigentTagsCommand : CliktCommand(name = "tags") {
       ArbigentLogLevel.entries.find { it.name.lowercase() == logLevel.lowercase() }
         ?: throw IllegalArgumentException("Invalid log level: $logLevel")
     
-    if (projectFile == null) {
-      throw IllegalArgumentException("Missing option '--project-file'. Please provide a project file path via command line argument or in .arbigent/settings.local.yml")
-    }
     val arbigentProject = loadArbigentProject(
-      projectFile = projectFile!!,
+      projectFile = requireProjectFile(projectFile),
       aiFactory = { throw UnsupportedOperationException("AI not needed for listing") },
       deviceFactory = { throw UnsupportedOperationException("Device not needed for listing") },
       appSettings = CliAppSettings(

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentJourneyXmlImporter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentJourneyXmlImporter.kt
@@ -1,0 +1,189 @@
+package io.github.takahirom.arbigent
+
+import org.w3c.dom.Element
+import org.w3c.dom.Node
+import java.io.File
+import javax.xml.parsers.DocumentBuilderFactory
+
+/**
+ * Intermediate DTO representing an Android Studio Journeys `*.journey.xml` file.
+ */
+public data class ArbigentJourney(
+  val name: String,
+  val description: String,
+  val actions: List<String>,
+)
+
+/**
+ * Imports Android Studio Journeys `*.journey.xml` / `*_journey.xml` files and converts
+ * them into Arbigent's project model so they can be run by the CLI.
+ *
+ * See tmp/journeys.md for the source format. This is an import-only MVP: verify actions are
+ * kept inside the goal (not promoted to imageAssertions) and launch actions are not promoted to
+ * initializationMethods.
+ */
+public object ArbigentJourneyXmlImporter {
+  private val JOURNEY_FILE_SUFFIXES = listOf(".journey.xml", "_journey.xml")
+
+  /**
+   * Returns true when [file] name looks like a Journeys XML file.
+   */
+  public fun isJourneyFile(file: File): Boolean {
+    val name = file.name.lowercase()
+    return JOURNEY_FILE_SUFFIXES.any { name.endsWith(it) }
+  }
+
+  /**
+   * Parses a single `*.journey.xml` file into an [ArbigentJourney].
+   */
+  public fun parse(file: File): ArbigentJourney {
+    if (!file.exists()) {
+      throw IllegalArgumentException("Journey file does not exist: ${file.absolutePath}")
+    }
+    val document = try {
+      val factory = DocumentBuilderFactory.newInstance().apply {
+        // XXE hardening: disable DTDs and external entity resolution.
+        setFeature("http://apache.org/xml/features/disallow-doctype-decl", true)
+        setFeature("http://xml.org/sax/features/external-general-entities", false)
+        setFeature("http://xml.org/sax/features/external-parameter-entities", false)
+        setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false)
+        isXIncludeAware = false
+        isExpandEntityReferences = false
+        isNamespaceAware = true
+      }
+      factory.newDocumentBuilder().parse(file)
+    } catch (e: Exception) {
+      throw IllegalArgumentException(
+        "Failed to parse journey XML file ${file.absolutePath}: ${e.message}",
+        e
+      )
+    }
+
+    val root = document.documentElement
+      ?: throw IllegalArgumentException("Journey file has no root element: ${file.absolutePath}")
+    if (root.localName != "journey" && root.tagName != "journey") {
+      throw IllegalArgumentException(
+        "Journey file root element must be <journey> but was <${root.tagName}>: ${file.absolutePath}"
+      )
+    }
+
+    val name = root.getAttribute("name").trim().ifBlank { file.name.substringBefore(".") }
+
+    val description = childElements(root)
+      .firstOrNull { it.localOrTagName() == "description" }
+      ?.textContent
+      ?.trim()
+      .orEmpty()
+
+    val actionsContainer = childElements(root)
+      .firstOrNull { it.localOrTagName() == "actions" }
+    val actions: List<String> = actionsContainer
+      ?.let { childElements(it) }
+      ?.filter { it.localOrTagName() == "action" }
+      ?.map { it.textContent.trim() }
+      ?.filter { it.isNotEmpty() }
+      .orEmpty()
+
+    if (actions.isEmpty()) {
+      throw IllegalArgumentException(
+        "Journey file must contain at least one <action> under <actions>: ${file.absolutePath}"
+      )
+    }
+
+    return ArbigentJourney(
+      name = name,
+      description = description,
+      actions = actions,
+    )
+  }
+
+  /**
+   * Converts an [ArbigentJourney] into an [ArbigentScenarioContent].
+   *
+   * @param idHint preferred scenario id (typically the file name stem). Falls back to a sanitized name.
+   */
+  public fun toScenarioContent(journey: ArbigentJourney, idHint: String? = null): ArbigentScenarioContent {
+    val id = idHint?.takeIf { it.isNotBlank() } ?: sanitizeId(journey.name)
+    val numberedActions = journey.actions
+      .mapIndexed { index, action -> "${index + 1}. $action" }
+      .joinToString("\n")
+    val goal = buildString {
+      if (journey.description.isNotBlank()) {
+        append(journey.description)
+        append("\n\n")
+      }
+      append("Follow these steps in order:\n")
+      append(numberedActions)
+    }
+    val maxStep = maxOf(10, journey.actions.size * 2 + 2)
+    return ArbigentScenarioContent(
+      id = id,
+      goal = goal,
+      maxStep = maxStep,
+    )
+  }
+
+  /**
+   * Loads a journey source (a single file or a directory containing journey files) into an
+   * [ArbigentProjectFileContent] with one scenario per journey file.
+   */
+  public fun loadProjectContent(fileOrDirectory: File): ArbigentProjectFileContent {
+    if (!fileOrDirectory.exists()) {
+      throw IllegalArgumentException("Journey path does not exist: ${fileOrDirectory.absolutePath}")
+    }
+    val files = if (fileOrDirectory.isDirectory) {
+      fileOrDirectory.walkTopDown()
+        .filter { it.isFile && isJourneyFile(it) }
+        .sortedBy { it.absolutePath }
+        .toList()
+        .ifEmpty {
+          throw IllegalArgumentException(
+            "No journey files (*.journey.xml / *_journey.xml) found under directory: ${fileOrDirectory.absolutePath}"
+          )
+        }
+    } else {
+      listOf(fileOrDirectory)
+    }
+
+    val scenarioContents = files.map { file ->
+      val journey = parse(file)
+      val idHint = journeyIdHint(file)
+      toScenarioContent(journey, idHint)
+    }
+
+    return ArbigentProjectFileContent(scenarioContents = scenarioContents)
+  }
+
+  private fun journeyIdHint(file: File): String {
+    var name = file.name
+    for (suffix in JOURNEY_FILE_SUFFIXES) {
+      if (name.lowercase().endsWith(suffix)) {
+        name = name.substring(0, name.length - suffix.length)
+        break
+      }
+    }
+    return name
+  }
+
+  private fun sanitizeId(name: String): String {
+    val sanitized = name.trim()
+      .lowercase()
+      .replace(Regex("[^a-z0-9]+"), "-")
+      .trim('-')
+    return sanitized.ifBlank { "journey" }
+  }
+
+  private fun childElements(node: Node): List<Element> {
+    val result = mutableListOf<Element>()
+    val children = node.childNodes
+    for (i in 0 until children.length) {
+      val child = children.item(i)
+      if (child is Element) {
+        result.add(child)
+      }
+    }
+    return result
+  }
+
+  private fun Element.localOrTagName(): String = localName ?: tagName
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentJourneyXmlImporter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentJourneyXmlImporter.kt
@@ -61,13 +61,13 @@ public object ArbigentJourneyXmlImporter {
 
     val root = document.documentElement
       ?: throw IllegalArgumentException("Journey file has no root element: ${file.absolutePath}")
-    if (root.localName != "journey" && root.tagName != "journey") {
+    if (root.localOrTagName() != "journey") {
       throw IllegalArgumentException(
         "Journey file root element must be <journey> but was <${root.tagName}>: ${file.absolutePath}"
       )
     }
 
-    val name = root.getAttribute("name").trim().ifBlank { file.name.substringBefore(".") }
+    val name = root.getAttribute("name").trim().ifBlank { journeyIdHint(file) }
 
     val description = childElements(root)
       .firstOrNull { it.localOrTagName() == "description" }
@@ -77,12 +77,18 @@ public object ArbigentJourneyXmlImporter {
 
     val actionsContainer = childElements(root)
       .firstOrNull { it.localOrTagName() == "actions" }
-    val actions: List<String> = actionsContainer
+    val actionTexts = actionsContainer
       ?.let { childElements(it) }
       ?.filter { it.localOrTagName() == "action" }
       ?.map { it.textContent.trim() }
-      ?.filter { it.isNotEmpty() }
       .orEmpty()
+    val blankActionCount = actionTexts.count { it.isEmpty() }
+    if (blankActionCount > 0) {
+      arbigentWarnLog(
+        "Ignoring $blankActionCount blank <action> element(s) in ${file.absolutePath}"
+      )
+    }
+    val actions: List<String> = actionTexts.filter { it.isNotEmpty() }
 
     if (actions.isEmpty()) {
       throw IllegalArgumentException(
@@ -100,10 +106,11 @@ public object ArbigentJourneyXmlImporter {
   /**
    * Converts an [ArbigentJourney] into an [ArbigentScenarioContent].
    *
-   * @param idHint preferred scenario id (typically the file name stem). Falls back to a sanitized name.
+   * @param idHint preferred scenario id source (typically the file name stem). Falls back to the
+   * journey name. Either way the id is sanitized to a lowercase-dash form.
    */
   public fun toScenarioContent(journey: ArbigentJourney, idHint: String? = null): ArbigentScenarioContent {
-    val id = idHint?.takeIf { it.isNotBlank() } ?: sanitizeId(journey.name)
+    val id = sanitizeId(idHint?.takeIf { it.isNotBlank() } ?: journey.name)
     val numberedActions = journey.actions
       .mapIndexed { index, action -> "${index + 1}. $action" }
       .joinToString("\n")
@@ -145,13 +152,23 @@ public object ArbigentJourneyXmlImporter {
       listOf(fileOrDirectory)
     }
 
-    val scenarioContents = files.map { file ->
+    val fileToContent = files.map { file ->
       val journey = parse(file)
       val idHint = journeyIdHint(file)
-      toScenarioContent(journey, idHint)
+      file to toScenarioContent(journey, idHint)
     }
 
-    return ArbigentProjectFileContent(scenarioContents = scenarioContents)
+    val duplicates = fileToContent.groupBy { it.second.id }.filterValues { it.size > 1 }
+    if (duplicates.isNotEmpty()) {
+      val details = duplicates.entries.joinToString("; ") { (id, entries) ->
+        "'$id' from ${entries.joinToString(", ") { it.first.absolutePath }}"
+      }
+      throw IllegalArgumentException(
+        "Duplicate scenario ids derived from journey files: $details"
+      )
+    }
+
+    return ArbigentProjectFileContent(scenarioContents = fileToContent.map { it.second })
   }
 
   private fun journeyIdHint(file: File): String {

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentJourneyXmlImporterTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentJourneyXmlImporterTest.kt
@@ -101,6 +101,43 @@ class ArbigentJourneyXmlImporterTest {
   }
 
   @Test
+  fun missingNameStripsUnderscoreJourneySuffix() {
+    val journey = ArbigentJourneyXmlImporter.parse(
+      tempJourney(
+        "checkout_journey.xml",
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <journey>
+            <actions>
+                <action>Tap "Go"</action>
+            </actions>
+        </journey>
+        """.trimIndent()
+      )
+    )
+    assertEquals("checkout", journey.name)
+  }
+
+  @Test
+  fun blankActionsAreIgnored() {
+    val journey = ArbigentJourneyXmlImporter.parse(
+      tempJourney(
+        "blank.journey.xml",
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <journey name="Blank actions">
+            <actions>
+                <action>Tap "Go"</action>
+                <action>   </action>
+            </actions>
+        </journey>
+        """.trimIndent()
+      )
+    )
+    assertEquals(listOf("Tap \"Go\""), journey.actions)
+  }
+
+  @Test
   fun zeroActionsThrows() {
     val e = assertFailsWith<IllegalArgumentException> {
       ArbigentJourneyXmlImporter.parse(
@@ -217,6 +254,43 @@ class ArbigentJourneyXmlImporterTest {
     assertEquals(2, content.scenarioContents.size)
     // Sorted by absolute path -> alpha before beta.
     assertEquals(listOf("alpha", "beta"), content.scenarioContents.map { it.id })
+  }
+
+  @Test
+  fun loadProjectContentSanitizesFileNameDerivedIds() {
+    val file = tempJourney(
+      "My Flow.journey.xml",
+      """
+      <?xml version="1.0" encoding="utf-8"?>
+      <journey name="My Flow">
+          <actions>
+              <action>Tap "Go"</action>
+          </actions>
+      </journey>
+      """.trimIndent()
+    )
+    val content = ArbigentJourneyXmlImporter.loadProjectContent(file)
+    assertEquals("my-flow", content.scenarioContents.single().id)
+  }
+
+  @Test
+  fun loadProjectContentDuplicateIdsThrow() {
+    val journeyXml = """
+      <?xml version="1.0" encoding="utf-8"?>
+      <journey name="Foo">
+          <actions>
+              <action>Tap "Go"</action>
+          </actions>
+      </journey>
+    """.trimIndent()
+    val first = tempJourney("foo.journey.xml", journeyXml)
+    File(first.parentFile, "foo_journey.xml").writeText(journeyXml)
+    val e = assertFailsWith<IllegalArgumentException> {
+      ArbigentJourneyXmlImporter.loadProjectContent(first.parentFile)
+    }
+    assertTrue(e.message!!.contains("Duplicate scenario ids"))
+    assertTrue(e.message!!.contains("foo.journey.xml"))
+    assertTrue(e.message!!.contains("foo_journey.xml"))
   }
 
   @Test

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentJourneyXmlImporterTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentJourneyXmlImporterTest.kt
@@ -1,0 +1,234 @@
+package io.github.takahirom.arbigent
+
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ArbigentJourneyXmlImporterTest {
+
+  private fun resourceFile(path: String): File {
+    val url = requireNotNull(javaClass.getResource(path)) { "Resource not found: $path" }
+    return File(url.toURI())
+  }
+
+  private fun tempJourney(fileName: String, content: String): File {
+    val dir = File.createTempFile("journey-test", "").let {
+      it.delete()
+      it.mkdirs()
+      it
+    }
+    val file = File(dir, fileName)
+    file.writeText(content)
+    return file
+  }
+
+  @Test
+  fun parseMinimalJourney() {
+    val journey = ArbigentJourneyXmlImporter.parse(resourceFile("/journeys/weather.journey.xml"))
+    assertEquals("Weather screen", journey.name)
+    assertEquals("Verify that the Weather screen displays correctly when navigated to", journey.description)
+    assertEquals(
+      listOf(
+        "Tap \"Weather\"",
+        "Verify that the Weather screen is displayed and shows the current temperature"
+      ),
+      journey.actions
+    )
+  }
+
+  @Test
+  fun xmlSpacePreserveTrimsToSameResult() {
+    val preserve = ArbigentJourneyXmlImporter.parse(resourceFile("/journeys/smart_paste.journey.xml"))
+    val noPreserve = ArbigentJourneyXmlImporter.parse(
+      tempJourney(
+        "smart.journey.xml",
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <journey name="Smart Paste from Clipboard">
+            <description>Verify that pasting multi-line text from the clipboard splits it into multiple items.</description>
+            <actions>
+                <action>Open Google Keep</action>
+                <action>Long press the body text to select all content within.</action>
+                <action>Tap "Copy" in the context menu to place the text into the system clipboard.</action>
+                <action>Launch the grocery application</action>
+                <action>Verify that the app automatically splits the text into three separate list items: "Carrots", "Potatoes", and "Onions"</action>
+            </actions>
+        </journey>
+        """.trimIndent()
+      )
+    )
+    assertEquals(preserve, noPreserve)
+    assertEquals(5, preserve.actions.size)
+  }
+
+  @Test
+  fun missingDescriptionFallsBackToEmpty() {
+    val journey = ArbigentJourneyXmlImporter.parse(
+      tempJourney(
+        "nodesc.journey.xml",
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <journey name="No description">
+            <actions>
+                <action>Tap "Go"</action>
+            </actions>
+        </journey>
+        """.trimIndent()
+      )
+    )
+    assertEquals("", journey.description)
+    assertEquals(listOf("Tap \"Go\""), journey.actions)
+  }
+
+  @Test
+  fun missingNameFallsBackToFileStem() {
+    val journey = ArbigentJourneyXmlImporter.parse(
+      tempJourney(
+        "my-flow.journey.xml",
+        """
+        <?xml version="1.0" encoding="utf-8"?>
+        <journey>
+            <actions>
+                <action>Tap "Go"</action>
+            </actions>
+        </journey>
+        """.trimIndent()
+      )
+    )
+    assertEquals("my-flow", journey.name)
+  }
+
+  @Test
+  fun zeroActionsThrows() {
+    val e = assertFailsWith<IllegalArgumentException> {
+      ArbigentJourneyXmlImporter.parse(
+        tempJourney(
+          "empty.journey.xml",
+          """
+          <?xml version="1.0" encoding="utf-8"?>
+          <journey name="Empty">
+              <actions>
+              </actions>
+          </journey>
+          """.trimIndent()
+        )
+      )
+    }
+    assertTrue(e.message!!.contains("at least one <action>"))
+  }
+
+  @Test
+  fun malformedXmlThrows() {
+    val e = assertFailsWith<IllegalArgumentException> {
+      ArbigentJourneyXmlImporter.parse(
+        tempJourney(
+          "broken.journey.xml",
+          "<journey name=\"Broken\"><actions><action>Tap</action>"
+        )
+      )
+    }
+    assertTrue(e.message!!.contains("Failed to parse"))
+  }
+
+  @Test
+  fun wrongRootThrows() {
+    val e = assertFailsWith<IllegalArgumentException> {
+      ArbigentJourneyXmlImporter.parse(
+        tempJourney(
+          "wrongroot.journey.xml",
+          """
+          <?xml version="1.0" encoding="utf-8"?>
+          <scenario name="Wrong">
+              <actions>
+                  <action>Tap</action>
+              </actions>
+          </scenario>
+          """.trimIndent()
+        )
+      )
+    }
+    assertTrue(e.message!!.contains("must be <journey>"))
+  }
+
+  @Test
+  fun toScenarioContentAssemblesGoalIdAndMaxStep() {
+    val journey = ArbigentJourney(
+      name = "Weather screen",
+      description = "Verify that the Weather screen displays correctly when navigated to",
+      actions = listOf(
+        "Tap \"Weather\"",
+        "Verify that the Weather screen is displayed and shows the current temperature"
+      )
+    )
+    val content = ArbigentJourneyXmlImporter.toScenarioContent(journey, idHint = "weather")
+    assertEquals("weather", content.id)
+    assertEquals(
+      """
+      Verify that the Weather screen displays correctly when navigated to
+
+      Follow these steps in order:
+      1. Tap "Weather"
+      2. Verify that the Weather screen is displayed and shows the current temperature
+      """.trimIndent(),
+      content.goal
+    )
+    // max(10, 2 * 2 + 2) = 10
+    assertEquals(10, content.maxStep)
+  }
+
+  @Test
+  fun toScenarioContentMaxStepScalesWithActions() {
+    val journey = ArbigentJourney(
+      name = "Big",
+      description = "desc",
+      actions = (1..6).map { "Step $it" }
+    )
+    val content = ArbigentJourneyXmlImporter.toScenarioContent(journey, idHint = "big")
+    // max(10, 6 * 2 + 2) = 14
+    assertEquals(14, content.maxStep)
+  }
+
+  @Test
+  fun toScenarioContentSanitizesNameWhenNoIdHint() {
+    val journey = ArbigentJourney(
+      name = "Weather screen!",
+      description = "",
+      actions = listOf("Tap")
+    )
+    val content = ArbigentJourneyXmlImporter.toScenarioContent(journey)
+    assertEquals("weather-screen", content.id)
+    // No description -> goal starts directly with the steps header.
+    assertTrue(content.goal.startsWith("Follow these steps in order:"))
+  }
+
+  @Test
+  fun loadProjectContentSingleFile() {
+    val content = ArbigentJourneyXmlImporter.loadProjectContent(resourceFile("/journeys/weather.journey.xml"))
+    assertEquals(1, content.scenarioContents.size)
+    assertEquals("weather", content.scenarioContents.first().id)
+  }
+
+  @Test
+  fun loadProjectContentDirectoryCollectsBothNamingPatternsDeterministically() {
+    val dir = resourceFile("/journeys/dir")
+    val content = ArbigentJourneyXmlImporter.loadProjectContent(dir)
+    assertEquals(2, content.scenarioContents.size)
+    // Sorted by absolute path -> alpha before beta.
+    assertEquals(listOf("alpha", "beta"), content.scenarioContents.map { it.id })
+  }
+
+  @Test
+  fun loadProjectContentEmptyDirectoryThrows() {
+    val emptyDir = File.createTempFile("empty-journeys", "").let {
+      it.delete()
+      it.mkdirs()
+      it
+    }
+    val e = assertFailsWith<IllegalArgumentException> {
+      ArbigentJourneyXmlImporter.loadProjectContent(emptyDir)
+    }
+    assertTrue(e.message!!.contains("No journey files"))
+  }
+}

--- a/arbigent-core/src/test/resources/journeys/dir/alpha.journey.xml
+++ b/arbigent-core/src/test/resources/journeys/dir/alpha.journey.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<journey name="Alpha journey">
+    <description>Alpha description</description>
+    <actions xml:space="preserve">
+        <action>Tap "Alpha"</action>
+    </actions>
+</journey>

--- a/arbigent-core/src/test/resources/journeys/dir/beta_journey.xml
+++ b/arbigent-core/src/test/resources/journeys/dir/beta_journey.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<journey name="Beta journey">
+    <description>Beta description</description>
+    <actions xml:space="preserve">
+        <action>Tap "Beta"</action>
+    </actions>
+</journey>

--- a/arbigent-core/src/test/resources/journeys/smart_paste.journey.xml
+++ b/arbigent-core/src/test/resources/journeys/smart_paste.journey.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<journey name="Smart Paste from Clipboard">
+    <description>Verify that pasting multi-line text from the clipboard splits it into multiple items.</description>
+    <actions xml:space="preserve">
+        <action>Open Google Keep</action>
+        <action>Long press the body text to select all content within.</action>
+        <action>Tap "Copy" in the context menu to place the text into the system clipboard.</action>
+        <action>Launch the grocery application</action>
+        <action>Verify that the app automatically splits the text into three separate list items: "Carrots", "Potatoes", and "Onions"</action>
+    </actions>
+</journey>

--- a/arbigent-core/src/test/resources/journeys/weather.journey.xml
+++ b/arbigent-core/src/test/resources/journeys/weather.journey.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<journey name="Weather screen">
+    <description>Verify that the Weather screen displays correctly when navigated to</description>
+    <actions xml:space="preserve">
+        <action>Tap "Weather"</action>
+        <action>Verify that the Weather screen is displayed and shows the current temperature</action>
+    </actions>
+</journey>


### PR DESCRIPTION
# What
Support running Android Studio Journeys files (`*.journey.xml` / `*_journey.xml`) directly with `arbigent run --project-file <file-or-directory>`. A new `ArbigentJourneyXmlImporter` in arbigent-core converts each journey (name / description / actions) into an Arbigent scenario whose goal embeds the steps as an ordered list, and the CLI (`run` / `scenarios` / `tags`) auto-detects the format and falls back to the normal YAML loader otherwise.

# Why
Journeys and Arbigent share the same natural-language E2E testing idea, so existing journey files should be runnable by Arbigent without manual conversion to project YAML.