### PR TITLE
Add reusable scenarios (uses/with/inputs) with GUI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,44 @@ This enables you to:
 - Reuse existing Maestro test automation assets
 - Combine precise setup sequences with AI-driven testing
 
+### Reusable Scenarios
+
+Arbigent lets you define AI scenario parts once at the project level and call them from any scenario with parameters — modeled after GitHub Actions reusable workflows (`uses` / `with` / `inputs`):
+
+```yaml
+scenarios:
+# A scenario can be a call to a reusable scenario instead of having a goal.
+- id: "premium-content-with-paid-user"
+  steps:
+  - uses: "login"
+    with: { user: "paid" }
+  - uses: "play-premium-content"
+
+# Ordinary and reusable nodes mix freely along a dependency chain.
+- id: "become-paid-user"
+  dependency: "launch-app"
+  uses: "login"
+  with: { user: "paid" }
+
+reusableScenarios:
+- id: "login"
+  inputs:
+    user:
+      required: true
+  goal: "Log in with the {{inputs.user}} account"
+- id: "play-premium-content"
+  goal: "Open and play any premium content"
+  maxStep: 15
+```
+
+Key points:
+- A scenario (or reusable scenario) is either a **leaf** (has `goal` plus the full option set: `initializationMethods`, `mcpOptions`, `maxStep`, image assertions, …) or a **call** (`uses` + `with`, or a `steps` list of calls). `uses` is sugar for a single-entry `steps`.
+- Reusable scenarios declare their parameters via `inputs` (`required` / `default`) and reference them as `{{inputs.name}}` in the goal — bare `{{name}}` still resolves project variables. `{{inputs.*}}` also works inside Maestro YAML referenced from a reusable scenario's initialization methods, and combined with `type: Execution` this gives deterministic, parameterized steps with zero AI calls.
+- Composites can call other composites; unknown references, cycles, undeclared `with` keys and missing required inputs are all rejected when the project loads.
+- In the GUI, choose the "Reusable steps" scenario type to build calls, manage the library in the Reusable Scenarios dialog, and use "Make this reusable" to extract an existing scenario into the library without breaking scenarios that depend on it.
+
+See [arbigent-reusable-scenarios-specification.md](arbigent-reusable-scenarios-specification.md) for the full specification.
+
 ### Android Studio Journeys XML Import
 
 Arbigent can run [Android Studio Journeys](https://developer.android.com/studio/gemini/journeys) test files (`*.journey.xml` / `*_journey.xml`) directly, so existing journey files work without converting them to project YAML:

--- a/arbigent-core-model/src/commonMain/kotlin/ArbigentResult.kt
+++ b/arbigent-core-model/src/commonMain/kotlin/ArbigentResult.kt
@@ -76,6 +76,9 @@ public data class ArbigentAgentResults(
 @Serializable
 public data class ArbigentAgentResult(
   public val goal: String,
+  // Call chain like "scenario-id › reusable-id (user=paid)" when this task was expanded
+  // from a reusable scenario; null for ordinary goal-based tasks.
+  public val callBreadcrumb: String? = null,
   public val maxStep: Int = 10,
   public val deviceFormFactor: ArbigentScenarioDeviceFormFactor = ArbigentScenarioDeviceFormFactor.Unspecified,
   public val isGoalAchieved: Boolean,

--- a/arbigent-core-web-report/src/jsMain/kotlin/Main.kt
+++ b/arbigent-core-web-report/src/jsMain/kotlin/Main.kt
@@ -217,6 +217,11 @@ private fun AgentResultView(taskIndex: Int, agentResult: ArbigentAgentResult) {
     Div {
       Text("Task($taskIndex) Goal: ${agentResult.goal}")
     }
+    agentResult.callBreadcrumb?.let { breadcrumb ->
+      Div {
+        Text("Called via: $breadcrumb")
+      }
+    }
     Div {
       Text("Max Steps: ${agentResult.maxStep}")
     }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -683,21 +683,22 @@ public fun AgentConfigBuilder(
             device: ArbigentDevice,
             chain: ArbigentInitializerInterceptor.Chain
           ) {
-            // Look up the YAML content from the fixed scenarios
-            val fixedScenario = fixedScenarios.find { it.id == initializeMethod.scenarioId }
-            if (fixedScenario == null) {
+            // Prefer inline yamlContent (set when {{inputs.*}} were substituted for a reusable
+            // scenario), otherwise look up the YAML content from the fixed scenarios.
+            val yamlText = initializeMethod.yamlContent
+              ?: fixedScenarios.find { it.id == initializeMethod.scenarioId }?.yamlText
+            if (yamlText == null) {
               arbigentErrorLog("Fixed scenario with id ${initializeMethod.scenarioId} not found")
               chain.proceed(device)
               return
             }
-            // Use the YAML content from the fixed scenario
             device.executeActions(
               MaestroFlowParser.parseFlow(
                 flowPath = Path(ArbigentFiles.parentDir),
-                flow = fixedScenario.yamlText
+                flow = yamlText
               )
             )
-            arbigentDebugLog("Executing Maestro YAML for scenario: ${fixedScenario.title}")
+            arbigentDebugLog("Executing Maestro YAML for scenario: ${initializeMethod.scenarioId}")
             chain.proceed(device)
           }
         })

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgentTask.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgentTask.kt
@@ -10,4 +10,7 @@ public data class ArbigentAgentTask(
   val deviceFormFactor: ArbigentScenarioDeviceFormFactor = ArbigentScenarioDeviceFormFactor.Mobile,
   val additionalActions: List<String> = emptyList(),
   val mcpOptions: ArbigentMcpOptions? = null,
+  // Call chain like "scenario-id › reusable-id (user=paid)" when this task was expanded
+  // from a reusable scenario; null for ordinary goal-based tasks.
+  val callBreadcrumb: String? = null,
 )

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
@@ -141,7 +141,8 @@ public fun ArbigentProject(
         deviceFactory = deviceFactory,
         aiDecisionCache = projectFileContent.settings.cacheStrategy.aiDecisionCacheStrategy.toCache(),
         appSettings = appSettings,
-        fixedScenarios = projectFileContent.fixedScenarios
+        fixedScenarios = projectFileContent.fixedScenarios,
+        reusableScenarios = projectFileContent.reusableScenarios
       )
     },
     appSettings = appSettings

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -436,7 +436,8 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
     }
     val defaults = reusable.inputs.mapNotNull { (name, input) -> input.default?.let { name to it } }.toMap()
     val bindings = defaults + resolvedWith
-    val crumb = breadcrumb + ReusableInputsResolver.breadcrumbLabel(reusable.id, resolvedWith)
+    // Label with the effective bindings (including defaults) so reports show the full snapshot.
+    val crumb = breadcrumb + ReusableInputsResolver.breadcrumbLabel(reusable.id, bindings)
     if (reusable.isCallForm()) {
       reusable.callSteps().forEach {
         expandStep(taskScenarioId, it, bindings, crumb, expansionStack + step.uses)

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -46,6 +46,7 @@ public interface FileSystem {
 public class ArbigentProjectFileContent(
   @SerialName("scenarios")
   public val scenarioContents: List<ArbigentScenarioContent>,
+  public val reusableScenarios: List<ArbigentScenarioContent> = emptyList(),
   public val fixedScenarios: List<FixedScenario> = emptyList(),
   public val settings: ArbigentProjectSettings = ArbigentProjectSettings(),
 )
@@ -313,19 +314,18 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
   deviceFactory: () -> ArbigentDevice,
   aiDecisionCache: ArbigentAiDecisionCache,
   appSettings: ArbigentAppSettings = DefaultArbigentAppSettings,
-  fixedScenarios: List<FixedScenario> = emptyList()
+  fixedScenarios: List<FixedScenario> = emptyList(),
+  reusableScenarios: List<ArbigentScenarioContent> = emptyList()
 ): ArbigentScenario {
   val visited = mutableSetOf<ArbigentScenarioContent>()
   val result = mutableListOf<ArbigentAgentTask>()
-  fun dfs(nodeScenario: ArbigentScenarioContent) {
-    if (visited.contains(nodeScenario)) {
-      return
-    }
-    visited.add(nodeScenario)
-    nodeScenario.dependencyId?.let { dependency ->
-      val dependencyScenario = first { it.id == dependency }
-      dfs(dependencyScenario)
-    }
+
+  fun addLeafTask(
+    taskScenarioId: String,
+    nodeScenario: ArbigentScenarioContent,
+    inputBindings: Map<String, String>?,
+    callBreadcrumb: String?
+  ) {
     // Determine which device form factor to use
     val effectiveDeviceFormFactor = if (nodeScenario.deviceFormFactor is ArbigentScenarioDeviceFormFactor.Unspecified) {
       if (projectSettings.deviceFormFactor is ArbigentScenarioDeviceFormFactor.Unspecified) {
@@ -346,19 +346,41 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
     // Merge additionalActions from project and scenario
     val mergedAdditionalActions = (projectSettings.additionalActions.orEmpty() + nodeScenario.additionalActions.orEmpty()).distinct()
 
+    val goal = if (inputBindings != null) {
+      ReusableInputsResolver.resolve(nodeScenario.goal, inputBindings)
+    } else {
+      nodeScenario.goal
+    }
+    val initializationMethods = nodeScenario.initializationMethods.ifEmpty { listOf(nodeScenario.initializeMethods) }
+      .map { method ->
+        // Resolve {{inputs.*}} inside referenced Maestro YAML for reusable leaves so the
+        // initializer can run the substituted flow (it prefers yamlContent when present).
+        if (inputBindings != null && method is ArbigentScenarioContent.InitializationMethod.MaestroYaml) {
+          val yamlText = fixedScenarios.firstOrNull { it.id == method.scenarioId }?.yamlText
+          if (yamlText != null && ReusableInputsResolver.containsInputPlaceholder(yamlText)) {
+            method.copy(yamlContent = ReusableInputsResolver.resolve(yamlText, inputBindings))
+          } else {
+            method
+          }
+        } else {
+          method
+        }
+      }
+
     result.add(
       ArbigentAgentTask(
-        scenarioId = nodeScenario.id,
-        goal = nodeScenario.goal,
+        scenarioId = taskScenarioId,
+        goal = goal,
         maxStep = nodeScenario.maxStep,
         deviceFormFactor = effectiveDeviceFormFactor,
         additionalActions = mergedAdditionalActions,
         mcpOptions = nodeScenario.mcpOptions,
+        callBreadcrumb = callBreadcrumb,
         agentConfig = AgentConfigBuilder(
           prompt = projectSettings.prompt,
           scenarioType = nodeScenario.type,
           deviceFormFactor = effectiveDeviceFormFactor,
-          initializationMethods = nodeScenario.initializationMethods.ifEmpty { listOf(nodeScenario.initializeMethods) },
+          initializationMethods = initializationMethods,
           imageAssertions = ArbigentImageAssertions(
             nodeScenario.imageAssertions,
             nodeScenario.imageAssertionHistoryCount
@@ -379,6 +401,56 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
         }.build(),
       )
     )
+  }
+
+  fun expandStep(
+    taskScenarioId: String,
+    step: ArbigentScenarioContent.ReusableStep,
+    parentBindings: Map<String, String>,
+    breadcrumb: List<String>,
+    expansionStack: List<String>
+  ) {
+    if (expansionStack.contains(step.uses)) {
+      throw ArbigentProjectValidationException(
+        "Cyclic reusable scenario reference detected: ${(expansionStack + step.uses).joinToString(" -> ")}"
+      )
+    }
+    val reusable = reusableScenarios.firstOrNull { it.id == step.uses }
+      ?: throw ArbigentProjectValidationException(
+        "Reusable scenario '${step.uses}' referenced from '${breadcrumb.lastOrNull() ?: taskScenarioId}' is not defined in reusableScenarios"
+      )
+    // Explicit propagation: with-values may reference the caller's own inputs via {{inputs.*}}.
+    val resolvedWith = step.withValues.mapValues { (_, value) ->
+      ReusableInputsResolver.resolve(value, parentBindings)
+    }
+    val defaults = reusable.inputs.mapNotNull { (name, input) -> input.default?.let { name to it } }.toMap()
+    val bindings = defaults + resolvedWith
+    val crumb = breadcrumb + ReusableInputsResolver.breadcrumbLabel(reusable.id, resolvedWith)
+    if (reusable.isCallForm()) {
+      reusable.callSteps().forEach {
+        expandStep(taskScenarioId, it, bindings, crumb, expansionStack + step.uses)
+      }
+    } else {
+      addLeafTask(taskScenarioId, reusable, bindings, crumb.joinToString(" › "))
+    }
+  }
+
+  fun dfs(nodeScenario: ArbigentScenarioContent) {
+    if (visited.contains(nodeScenario)) {
+      return
+    }
+    visited.add(nodeScenario)
+    nodeScenario.dependencyId?.let { dependency ->
+      val dependencyScenario = first { it.id == dependency }
+      dfs(dependencyScenario)
+    }
+    if (nodeScenario.isCallForm()) {
+      nodeScenario.callSteps().forEach { step ->
+        expandStep(nodeScenario.id, step, emptyMap(), listOf(nodeScenario.id), emptyList())
+      }
+    } else {
+      addLeafTask(nodeScenario.id, nodeScenario, null, null)
+    }
   }
   dfs(scenario)
   arbigentDebugLog("Built scenario ${scenario.id} with ${result.size} tasks: ${result.map { it.scenarioId }}")
@@ -430,10 +502,17 @@ public sealed interface ArbigentScenarioType {
 public class ArbigentScenarioContent @OptIn(ExperimentalUuidApi::class) constructor(
   public val id: String = Uuid.random().toString(),
   @YamlMultiLineStringStyle(MultiLineStringStyle.Literal)
-  public val goal: String,
+  public val goal: String = "",
   public val type: ArbigentScenarioType = ArbigentScenarioType.Scenario,
   @SerialName("dependency")
   public val dependencyId: String? = null,
+  // Call form: reference a reusable scenario by id ("uses" is sugar for a single-entry "steps").
+  public val uses: String? = null,
+  @SerialName("with")
+  public val withValues: Map<String, String> = emptyMap(),
+  public val steps: List<ReusableStep> = emptyList(),
+  // Input declarations. Only allowed on reusableScenarios entries.
+  public val inputs: Map<String, ReusableInput> = emptyMap(),
   public val initializationMethods: List<InitializationMethod> = listOf(),
   @Deprecated("use initializationMethods")
   public val initializeMethods: InitializationMethod = InitializationMethod.Noop,
@@ -453,6 +532,27 @@ public class ArbigentScenarioContent @OptIn(ExperimentalUuidApi::class) construc
   public val additionalActions: List<String>? = null,
   public val mcpOptions: ArbigentMcpOptions? = null
 ) {
+  /** True when this scenario is a call to reusable scenarios instead of a goal-based leaf. */
+  public fun isCallForm(): Boolean = uses != null || steps.isNotEmpty()
+
+  /** Normalized call steps: `uses` is sugar for a single-entry `steps` list. */
+  public fun callSteps(): List<ReusableStep> =
+    if (uses != null) listOf(ReusableStep(uses = uses, withValues = withValues)) + steps
+    else steps
+
+  @Serializable
+  public data class ReusableStep(
+    public val uses: String,
+    @SerialName("with")
+    public val withValues: Map<String, String> = emptyMap(),
+  )
+
+  @Serializable
+  public data class ReusableInput(
+    public val required: Boolean = false,
+    public val default: String? = null,
+  )
+
   @Serializable
   public sealed interface CleanupData {
     @Serializable
@@ -560,12 +660,14 @@ public class ArbigentProjectSerializer(
 
   internal fun load(yamlString: String): ArbigentProjectFileContent {
     return yaml.decodeFromString(ArbigentProjectFileContent.serializer(), yamlString)
+      .also { it.validateReusableScenarios() }
   }
 
   private fun load(inputStream: InputStream): ArbigentProjectFileContent {
     val jsonString = fileSystem.readText(inputStream)
     val projectFileContent =
       yaml.decodeFromString(ArbigentProjectFileContent.serializer(), jsonString)
+    projectFileContent.validateReusableScenarios()
     return projectFileContent
   }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -307,6 +307,27 @@ public sealed interface AiDecisionCacheStrategy {
 
 }
 
+/**
+ * Resolves {{inputs.*}} inside Maestro YAML referenced from a reusable leaf's initialization
+ * methods, so the initializer can run the substituted flow (it prefers yamlContent when present).
+ */
+private fun resolveMaestroYamlInputs(
+  methods: List<ArbigentScenarioContent.InitializationMethod>,
+  inputBindings: Map<String, String>?,
+  fixedScenarios: List<FixedScenario>
+): List<ArbigentScenarioContent.InitializationMethod> {
+  if (inputBindings == null) return methods
+  return methods.map { method ->
+    if (method !is ArbigentScenarioContent.InitializationMethod.MaestroYaml) return@map method
+    val yamlText = fixedScenarios.firstOrNull { it.id == method.scenarioId }?.yamlText
+    if (yamlText != null && ReusableInputsResolver.containsInputPlaceholder(yamlText)) {
+      method.copy(yamlContent = ReusableInputsResolver.resolve(yamlText, inputBindings))
+    } else {
+      method
+    }
+  }
+}
+
 public fun List<ArbigentScenarioContent>.createArbigentScenario(
   projectSettings: ArbigentProjectSettings,
   scenario: ArbigentScenarioContent,
@@ -351,21 +372,11 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
     } else {
       nodeScenario.goal
     }
-    val initializationMethods = nodeScenario.initializationMethods.ifEmpty { listOf(nodeScenario.initializeMethods) }
-      .map { method ->
-        // Resolve {{inputs.*}} inside referenced Maestro YAML for reusable leaves so the
-        // initializer can run the substituted flow (it prefers yamlContent when present).
-        if (inputBindings != null && method is ArbigentScenarioContent.InitializationMethod.MaestroYaml) {
-          val yamlText = fixedScenarios.firstOrNull { it.id == method.scenarioId }?.yamlText
-          if (yamlText != null && ReusableInputsResolver.containsInputPlaceholder(yamlText)) {
-            method.copy(yamlContent = ReusableInputsResolver.resolve(yamlText, inputBindings))
-          } else {
-            method
-          }
-        } else {
-          method
-        }
-      }
+    val initializationMethods = resolveMaestroYamlInputs(
+      methods = nodeScenario.initializationMethods.ifEmpty { listOf(nodeScenario.initializeMethods) },
+      inputBindings = inputBindings,
+      fixedScenarios = fixedScenarios
+    )
 
     result.add(
       ArbigentAgentTask(

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioAssignment.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioAssignment.kt
@@ -19,7 +19,7 @@ public data class ArbigentScenarioAssignment(
         ArbigentAgentResults(
           status = "History ${index + 1} / " + taskAssignmentsHistory.size,
           agentResults = taskAssignments.map { (task, agent) ->
-            agent.getResult()
+            agent.getResult().copy(callBreadcrumb = task.callBreadcrumb)
           }
         )
       }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReusableScenarios.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReusableScenarios.kt
@@ -65,9 +65,26 @@ public fun ArbigentProjectFileContent.validateReusableScenarios() {
       if (content.aiOptions != null || content.mcpOptions != null || content.cacheOptions != null || content.additionalActions != null) {
         errors += "$where: execution options (aiOptions/mcpOptions/cacheOptions/additionalActions) are not allowed on a call-form scenario; set them on the reusable leaf"
       }
+      // Fields with non-null defaults can only be checked against their default values;
+      // an explicitly-written default is indistinguishable after decoding and is accepted.
+      if (content.maxStep != 10) {
+        errors += "$where: maxStep is not allowed on a call-form scenario; set it on the reusable leaf"
+      }
+      if (content.imageAssertionHistoryCount != 1) {
+        errors += "$where: imageAssertionHistoryCount is not allowed on a call-form scenario; set it on the reusable leaf"
+      }
+      if (content.userPromptTemplate != UserPromptTemplate.DEFAULT_TEMPLATE) {
+        errors += "$where: userPromptTemplate is not allowed on a call-form scenario; set it on the reusable leaf"
+      }
+      @Suppress("DEPRECATION")
+      if (content.initializeMethods != ArbigentScenarioContent.InitializationMethod.Noop) {
+        errors += "$where: initializeMethods are not allowed on a call-form scenario; move them into the reusable leaf"
+      }
     } else {
-      if (content.goal.isEmpty()) {
-        errors += "$where: a scenario must have a goal, uses, or steps"
+      // Empty-goal leaves are only rejected in reusableScenarios (a new namespace with no
+      // legacy files); ordinary scenarios could always be saved with an empty goal (WIP).
+      if (content.goal.isEmpty() && isReusable) {
+        errors += "$where: a reusable scenario must have a goal, uses, or steps"
       }
       if (content.withValues.isNotEmpty()) {
         errors += "$where: 'with' requires 'uses'"

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReusableScenarios.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReusableScenarios.kt
@@ -1,0 +1,167 @@
+package io.github.takahirom.arbigent
+
+/**
+ * Thrown when a project file violates the reusable-scenario rules.
+ * All violations are detected at load time so that a part is never silently skipped at runtime.
+ */
+public class ArbigentProjectValidationException(message: String) : RuntimeException(message)
+
+/**
+ * Resolves `{{inputs.name}}` placeholders with values bound at the call site (`with:` + declared defaults).
+ * Bare `{{name}}` placeholders are project variables and stay untouched here — they are resolved
+ * at runtime by [GoalVariableResolver].
+ */
+public object ReusableInputsResolver {
+  // (?<!\\) keeps escaped placeholders (\{{inputs.x}}) for GoalVariableResolver's escape handling.
+  private val INPUT_PATTERN = """(?<!\\)\{\{\s*inputs\.([^}]+)\}\}""".toRegex()
+
+  public fun resolve(text: String, bindings: Map<String, String>): String {
+    return INPUT_PATTERN.replace(text) { matchResult ->
+      val name = matchResult.groupValues[1].trim()
+      bindings[name] ?: matchResult.value
+    }
+  }
+
+  public fun containsInputPlaceholder(text: String): Boolean = INPUT_PATTERN.containsMatchIn(text)
+
+  /** Input names referenced as {{inputs.name}} in the given text. */
+  public fun referencedInputNames(text: String): Set<String> =
+    INPUT_PATTERN.findAll(text).map { it.groupValues[1].trim() }.toSet()
+
+  /** Breadcrumb label like `login (user=paid)` used in reports and the UI tree. */
+  public fun breadcrumbLabel(reusableId: String, withValues: Map<String, String>): String =
+    if (withValues.isEmpty()) reusableId
+    else "$reusableId (${withValues.entries.joinToString(", ") { "${it.key}=${it.value}" }})"
+}
+
+/**
+ * Load-time validation of reusable scenarios. Throws [ArbigentProjectValidationException]
+ * with all violations joined, so the user can fix everything in one pass.
+ */
+public fun ArbigentProjectFileContent.validateReusableScenarios() {
+  val errors = mutableListOf<String>()
+  val reusableById = reusableScenarios.associateBy { it.id }
+
+  fun validateNode(content: ArbigentScenarioContent, isReusable: Boolean) {
+    val where = (if (isReusable) "reusableScenarios" else "scenarios") + " '" + content.id + "'"
+    val isCall = content.isCallForm()
+
+    if (isCall) {
+      if (content.goal.isNotEmpty()) {
+        errors += "$where: a call-form scenario (uses/steps) must not have a goal"
+      }
+      if (content.uses != null && content.steps.isNotEmpty()) {
+        errors += "$where: use either 'uses' or 'steps', not both"
+      }
+      if (content.initializationMethods.isNotEmpty()) {
+        errors += "$where: initializationMethods are not allowed on a call-form scenario; move them into the reusable leaf"
+      }
+      if (content.imageAssertions.isNotEmpty()) {
+        errors += "$where: imageAssertions are not allowed on a call-form scenario; move them into the reusable leaf"
+      }
+      if (content.type.isExecution()) {
+        errors += "$where: type Execution is not allowed on a call-form scenario; set it on the reusable leaf"
+      }
+      if (content.aiOptions != null || content.mcpOptions != null || content.cacheOptions != null || content.additionalActions != null) {
+        errors += "$where: execution options (aiOptions/mcpOptions/cacheOptions/additionalActions) are not allowed on a call-form scenario; set them on the reusable leaf"
+      }
+    } else {
+      if (content.goal.isEmpty()) {
+        errors += "$where: a scenario must have a goal, uses, or steps"
+      }
+      if (content.withValues.isNotEmpty()) {
+        errors += "$where: 'with' requires 'uses'"
+      }
+    }
+
+    if (isReusable) {
+      if (content.dependencyId != null) {
+        errors += "$where: 'dependency' is not allowed on a reusable scenario; express prerequisites at the call site"
+      }
+      if (content.tags.isNotEmpty()) {
+        errors += "$where: 'tags' are not allowed on a reusable scenario"
+      }
+      if (RESERVED_ID_CHARS.any { content.id.contains(it) }) {
+        errors += "$where: reusable scenario ids must not contain '/', '#', or '@' (reserved for future cross-file references)"
+      }
+    } else {
+      if (content.inputs.isNotEmpty()) {
+        errors += "$where: 'inputs' can only be declared on reusableScenarios entries"
+      }
+    }
+
+    // {{inputs.*}} may only appear in reusable definitions and only for declared inputs.
+    val referencedInputs = ReusableInputsResolver.referencedInputNames(content.goal) +
+      content.initializationMethods.filterIsInstance<ArbigentScenarioContent.InitializationMethod.MaestroYaml>()
+        .mapNotNull { method -> fixedScenarios.firstOrNull { it.id == method.scenarioId }?.yamlText }
+        .flatMap { ReusableInputsResolver.referencedInputNames(it) }
+    if (isReusable) {
+      (referencedInputs - content.inputs.keys).forEach {
+        errors += "$where: '{{inputs.$it}}' is not declared in inputs"
+      }
+    } else if (referencedInputs.isNotEmpty()) {
+      errors += "$where: '{{inputs.*}}' can only be used inside reusable scenario definitions"
+    }
+
+    // Call sites: references must resolve, with-keys must be declared, required inputs must be bound.
+    content.callSteps().forEach { step ->
+      if (RESERVED_ID_CHARS.any { step.uses.contains(it) }) {
+        errors += "$where: uses '${step.uses}' must not contain '/', '#', or '@' (reserved for future cross-file references)"
+        return@forEach
+      }
+      val target = reusableById[step.uses]
+      if (target == null) {
+        errors += "$where: uses '${step.uses}' is not defined in reusableScenarios"
+        return@forEach
+      }
+      (step.withValues.keys - target.inputs.keys).forEach {
+        errors += "$where: with key '$it' is not declared in inputs of '${step.uses}'"
+      }
+      target.inputs.forEach { (name, input) ->
+        if (input.required && input.default == null && !step.withValues.containsKey(name)) {
+          errors += "$where: required input '$name' of '${step.uses}' is not provided via 'with'"
+        }
+      }
+      // {{inputs.*}} inside with-values is explicit propagation; only valid when the caller declares them.
+      step.withValues.values.flatMap { ReusableInputsResolver.referencedInputNames(it) }.toSet()
+        .minus(content.inputs.keys)
+        .forEach {
+          errors += "$where: with value references '{{inputs.$it}}' which is not declared in this scenario's inputs"
+        }
+    }
+  }
+
+  val duplicateReusableIds = reusableScenarios.groupBy { it.id }.filterValues { it.size > 1 }.keys
+  duplicateReusableIds.forEach { errors += "reusableScenarios: duplicate id '$it'" }
+
+  scenarioContents.forEach { validateNode(it, isReusable = false) }
+  reusableScenarios.forEach { validateNode(it, isReusable = true) }
+
+  // Cycle detection over composite references.
+  val visitState = mutableMapOf<String, Int>() // 0 = visiting, 1 = done
+  fun visit(id: String, path: List<String>) {
+    when (visitState[id]) {
+      0 -> {
+        errors += "reusableScenarios: cyclic reference detected: ${(path + id).joinToString(" -> ")}"
+        return
+      }
+      1 -> return
+    }
+    visitState[id] = 0
+    reusableById[id]?.callSteps()?.forEach { step ->
+      if (reusableById.containsKey(step.uses)) {
+        visit(step.uses, path + id)
+      }
+    }
+    visitState[id] = 1
+  }
+  reusableScenarios.forEach { visit(it.id, emptyList()) }
+
+  if (errors.isNotEmpty()) {
+    throw ArbigentProjectValidationException(
+      "Invalid reusable scenario configuration:\n" + errors.joinToString("\n") { "- $it" }
+    )
+  }
+}
+
+private val RESERVED_ID_CHARS = listOf("/", "#", "@")

--- a/arbigent-core/src/test/java/ReusableScenariosTest.kt
+++ b/arbigent-core/src/test/java/ReusableScenariosTest.kt
@@ -285,6 +285,81 @@ class ReusableScenariosTest {
     assertEquals(0, project.reusableScenarios.size)
   }
 
+  @Test
+  fun emptyGoalScenariosFromLegacyFilesStillLoad() {
+    // Work-in-progress scenarios could always be saved with an empty goal.
+    val project = load(
+      """
+      scenarios:
+      - id: "wip"
+        goal: ""
+      """
+    )
+    assertEquals(1, project.scenarioContents.size)
+  }
+
+  @Test
+  fun defaultedInputsAppearInBreadcrumb() {
+    val project = load(
+      """
+      scenarios:
+      - id: "call-login"
+        uses: "login"
+      reusableScenarios:
+      - id: "login"
+        inputs:
+          method:
+            default: "email"
+        goal: "Log in via {{inputs.method}}"
+      """
+    )
+    assertEquals(
+      "call-login › login (method=email)",
+      project.tasksOf("call-login")[0].callBreadcrumb
+    )
+  }
+
+  @Test
+  fun callFormMustNotHaveMaxStepOrPromptTemplate() {
+    assertValidationError(
+      "maxStep is not allowed",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "part"
+        maxStep: 25
+      reusableScenarios:
+      - id: "part"
+        goal: "part goal"
+      """
+    )
+    assertValidationError(
+      "userPromptTemplate is not allowed",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "part"
+        userPromptTemplate: "custom {{USER_INPUT_GOAL}}"
+      reusableScenarios:
+      - id: "part"
+        goal: "part goal"
+      """
+    )
+    assertValidationError(
+      "initializeMethods are not allowed",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "part"
+        initializeMethods:
+          type: "Back"
+      reusableScenarios:
+      - id: "part"
+        goal: "part goal"
+      """
+    )
+  }
+
   // ----- Load-time validation -----
 
   private fun assertValidationError(expectedMessagePart: String, yaml: String) {

--- a/arbigent-core/src/test/java/ReusableScenariosTest.kt
+++ b/arbigent-core/src/test/java/ReusableScenariosTest.kt
@@ -1,0 +1,537 @@
+package io.github.takahirom.arbigent.sample.test
+
+import io.github.takahirom.arbigent.*
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.test.runTest
+import maestro.orchestra.MaestroCommand
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class ReusableScenariosTest {
+  private fun load(yaml: String): ArbigentProjectFileContent = ArbigentProjectSerializer().load(yaml)
+
+  private fun ArbigentProjectFileContent.tasksOf(scenarioId: String) =
+    scenarioContents.createArbigentScenario(
+      projectSettings = settings,
+      scenario = scenarioContents.first { it.id == scenarioId },
+      aiFactory = { FakeAi() },
+      deviceFactory = { FakeDevice() },
+      aiDecisionCache = ArbigentAiDecisionCache.Disabled,
+      fixedScenarios = fixedScenarios,
+      reusableScenarios = reusableScenarios
+    ).agentTasks
+
+  // ----- Expansion -----
+
+  @Test
+  fun singleUsesExpandsToOneTaskWithSubstitutedGoal() {
+    val project = load(
+      """
+      scenarios:
+      - id: "call-login"
+        uses: "login"
+        with:
+          user: "paid"
+      reusableScenarios:
+      - id: "login"
+        inputs:
+          user:
+            required: true
+        goal: "Log in as {{inputs.user}}"
+      """
+    )
+    val tasks = project.tasksOf("call-login")
+    assertEquals(1, tasks.size)
+    assertEquals("Log in as paid", tasks[0].goal)
+    assertEquals("call-login", tasks[0].scenarioId)
+    assertEquals("call-login › login (user=paid)", tasks[0].callBreadcrumb)
+  }
+
+  @Test
+  fun stepsExpandInOrderAndCompositeNests() {
+    val project = load(
+      """
+      scenarios:
+      - id: "combo"
+        steps:
+        - uses: "change-language"
+          with:
+            lang: "English"
+        - uses: "verify-home"
+      reusableScenarios:
+      - id: "change-language"
+        inputs:
+          lang:
+            required: true
+        steps:
+        - uses: "open-settings"
+        - uses: "set-language"
+          with:
+            lang: "{{inputs.lang}}"
+      - id: "open-settings"
+        goal: "Open the settings screen"
+      - id: "set-language"
+        inputs:
+          lang:
+            required: true
+        goal: "Set language to {{inputs.lang}}"
+      - id: "verify-home"
+        goal: "Verify the home screen is shown"
+      """
+    )
+    val tasks = project.tasksOf("combo")
+    assertEquals(3, tasks.size)
+    assertEquals("Open the settings screen", tasks[0].goal)
+    assertEquals("Set language to English", tasks[1].goal)
+    assertEquals("Verify the home screen is shown", tasks[2].goal)
+    assertEquals("combo › change-language (lang=English) › open-settings", tasks[0].callBreadcrumb)
+    assertEquals("combo › change-language (lang=English) › set-language (lang=English)", tasks[1].callBreadcrumb)
+    assertEquals("combo › verify-home", tasks[2].callBreadcrumb)
+  }
+
+  @Test
+  fun ordinaryAndReusableNodesMixAlongDependencyChain() {
+    val project = load(
+      """
+      scenarios:
+      - id: "launch-app"
+        goal: "Launch the app"
+      - id: "become-paid"
+        dependency: "launch-app"
+        uses: "upgrade"
+        with:
+          plan: "premium"
+      - id: "content-a"
+        dependency: "become-paid"
+        goal: "Open content A"
+      reusableScenarios:
+      - id: "upgrade"
+        inputs:
+          plan:
+            required: true
+        goal: "Purchase the {{inputs.plan}} plan"
+      """
+    )
+    val tasks = project.tasksOf("content-a")
+    assertEquals(listOf("Launch the app", "Purchase the premium plan", "Open content A"), tasks.map { it.goal })
+    assertNull(tasks[0].callBreadcrumb)
+    assertEquals("become-paid › upgrade (plan=premium)", tasks[1].callBreadcrumb)
+    assertNull(tasks[2].callBreadcrumb)
+  }
+
+  @Test
+  fun defaultInputIsUsedWhenNotProvided() {
+    val project = load(
+      """
+      scenarios:
+      - id: "call-login"
+        uses: "login"
+      reusableScenarios:
+      - id: "login"
+        inputs:
+          method:
+            default: "email"
+        goal: "Log in via {{inputs.method}}"
+      """
+    )
+    assertEquals("Log in via email", project.tasksOf("call-login")[0].goal)
+  }
+
+  @Test
+  fun bareVariablesAreLeftForRuntimeResolution() {
+    val project = load(
+      """
+      scenarios:
+      - id: "call-login"
+        uses: "login"
+        with:
+          user: "paid"
+      reusableScenarios:
+      - id: "login"
+        inputs:
+          user:
+            required: true
+        goal: "Log in as {{inputs.user}} on {{app_name}}"
+      """
+    )
+    assertEquals("Log in as paid on {{app_name}}", project.tasksOf("call-login")[0].goal)
+  }
+
+  @Test
+  fun reusableLeafKeepsItsOwnExecutionOptions() {
+    val project = load(
+      """
+      scenarios:
+      - id: "caller"
+        uses: "part"
+      reusableScenarios:
+      - id: "part"
+        goal: "Do something"
+        maxStep: 25
+      """
+    )
+    assertEquals(25, project.tasksOf("caller")[0].maxStep)
+  }
+
+  // ----- Maestro yamlText substitution -----
+
+  @Test
+  fun maestroYamlInputsAreSubstitutedAndExecuted() = runTest {
+    ArbigentCoroutinesDispatcher.dispatcher = coroutineContext[CoroutineDispatcher]!!
+    val executedCommands = mutableListOf<MaestroCommand>()
+    val fakeDevice = FakeDevice()
+    val recordingDevice = object : ArbigentDevice by fakeDevice {
+      override fun executeActions(actions: List<MaestroCommand>) {
+        executedCommands.addAll(actions)
+        fakeDevice.executeActions(actions)
+      }
+    }
+    val project = load(
+      """
+      scenarios:
+      - id: "caller"
+        uses: "deeplink-login"
+        with:
+          user: "premium-user"
+      reusableScenarios:
+      - id: "deeplink-login"
+        type:
+          type: "Execution"
+        inputs:
+          user:
+            required: true
+        initializationMethods:
+        - type: "MaestroYaml"
+          scenarioId: "login-flow"
+        goal: "Log in via deeplink"
+      fixedScenarios:
+      - id: "login-flow"
+        title: "login"
+        description: "login flow"
+        yamlText: |-
+          appId: "com.example.app"
+          ---
+          - openLink: "example://login?user={{inputs.user}}"
+      """
+    )
+    val scenario = project.scenarioContents.createArbigentScenario(
+      projectSettings = project.settings,
+      scenario = project.scenarioContents.first { it.id == "caller" },
+      aiFactory = { FakeAi() },
+      deviceFactory = { recordingDevice },
+      aiDecisionCache = ArbigentAiDecisionCache.Disabled,
+      fixedScenarios = project.fixedScenarios,
+      reusableScenarios = project.reusableScenarios
+    )
+    val executor = ArbigentScenarioExecutor()
+    executor.execute(scenario, MCPClient())
+    assertTrue(executor.isGoalAchieved())
+    val openLink = executedCommands.mapNotNull { it.openLinkCommand }.firstOrNull()
+    assertEquals("example://login?user=premium-user", openLink?.link)
+  }
+
+  // ----- Round-trip -----
+
+  @Test
+  fun roundTripKeepsReusableScenarios() {
+    val yaml =
+      """
+      scenarios:
+      - id: "caller"
+        steps:
+        - uses: "part"
+          with:
+            key: "value"
+      reusableScenarios:
+      - id: "part"
+        inputs:
+          key:
+            required: true
+        goal: "Use {{inputs.key}}"
+      """
+    val serializer = ArbigentProjectSerializer()
+    val loaded = serializer.load(yaml)
+    val saved = serializer.encodeToString(loaded)
+    val reloaded = serializer.load(saved)
+    assertEquals(1, reloaded.reusableScenarios.size)
+    assertEquals("part", reloaded.reusableScenarios[0].id)
+    assertEquals(true, reloaded.reusableScenarios[0].inputs["key"]?.required)
+    assertEquals("part", reloaded.scenarioContents[0].callSteps().single().uses)
+    assertEquals(mapOf("key" to "value"), reloaded.scenarioContents[0].callSteps().single().withValues)
+  }
+
+  @Test
+  fun oldProjectFilesStillLoad() {
+    val project = load(
+      """
+      scenarios:
+      - id: "A-ID"
+        goal: "A-GOAL"
+      """
+    )
+    assertEquals(1, project.scenarioContents.size)
+    assertEquals(0, project.reusableScenarios.size)
+  }
+
+  // ----- Load-time validation -----
+
+  private fun assertValidationError(expectedMessagePart: String, yaml: String) {
+    val exception = assertFailsWith<ArbigentProjectValidationException> { load(yaml) }
+    assertTrue(
+      exception.message!!.contains(expectedMessagePart),
+      "Expected message to contain '$expectedMessagePart' but was: ${exception.message}"
+    )
+  }
+
+  @Test
+  fun unknownUsesReferenceFailsAtLoad() {
+    assertValidationError(
+      "'missing' is not defined",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "missing"
+      """
+    )
+  }
+
+  @Test
+  fun goalAndUsesAreExclusive() {
+    assertValidationError(
+      "must not have a goal",
+      """
+      scenarios:
+      - id: "caller"
+        goal: "some goal"
+        uses: "part"
+      reusableScenarios:
+      - id: "part"
+        goal: "part goal"
+      """
+    )
+  }
+
+  @Test
+  fun usesAndStepsAreExclusive() {
+    assertValidationError(
+      "not both",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "part"
+        steps:
+        - uses: "part"
+      reusableScenarios:
+      - id: "part"
+        goal: "part goal"
+      """
+    )
+  }
+
+  @Test
+  fun callFormMustNotHaveInitializationMethods() {
+    assertValidationError(
+      "initializationMethods are not allowed",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "part"
+        initializationMethods:
+        - type: "Back"
+      reusableScenarios:
+      - id: "part"
+        goal: "part goal"
+      """
+    )
+  }
+
+  @Test
+  fun cyclicCompositeReferencesFailAtLoad() {
+    assertValidationError(
+      "cyclic",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "a"
+      reusableScenarios:
+      - id: "a"
+        steps:
+        - uses: "b"
+      - id: "b"
+        steps:
+        - uses: "a"
+      """
+    )
+  }
+
+  @Test
+  fun undeclaredWithKeyFailsAtLoad() {
+    assertValidationError(
+      "with key 'usr' is not declared",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "login"
+        with:
+          usr: "paid"
+      reusableScenarios:
+      - id: "login"
+        inputs:
+          user:
+            required: true
+        goal: "Log in as {{inputs.user}}"
+      """
+    )
+  }
+
+  @Test
+  fun missingRequiredInputFailsAtLoad() {
+    assertValidationError(
+      "required input 'user'",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "login"
+      reusableScenarios:
+      - id: "login"
+        inputs:
+          user:
+            required: true
+        goal: "Log in as {{inputs.user}}"
+      """
+    )
+  }
+
+  @Test
+  fun undeclaredInputsPlaceholderInReusableGoalFailsAtLoad() {
+    assertValidationError(
+      "'{{inputs.user}}' is not declared",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "login"
+      reusableScenarios:
+      - id: "login"
+        goal: "Log in as {{inputs.user}}"
+      """
+    )
+  }
+
+  @Test
+  fun inputsPlaceholderOutsideReusableFailsAtLoad() {
+    assertValidationError(
+      "can only be used inside reusable",
+      """
+      scenarios:
+      - id: "caller"
+        goal: "Log in as {{inputs.user}}"
+      """
+    )
+  }
+
+  @Test
+  fun dependencyOnReusableDefinitionFailsAtLoad() {
+    assertValidationError(
+      "'dependency' is not allowed on a reusable scenario",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "part"
+      reusableScenarios:
+      - id: "part"
+        dependency: "caller"
+        goal: "part goal"
+      """
+    )
+  }
+
+  @Test
+  fun tagsOnReusableDefinitionFailsAtLoad() {
+    assertValidationError(
+      "'tags' are not allowed on a reusable scenario",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "part"
+      reusableScenarios:
+      - id: "part"
+        goal: "part goal"
+        tags:
+        - name: "tag"
+      """
+    )
+  }
+
+  @Test
+  fun inputsOnOrdinaryScenarioFailsAtLoad() {
+    assertValidationError(
+      "'inputs' can only be declared on reusableScenarios",
+      """
+      scenarios:
+      - id: "caller"
+        goal: "some goal"
+        inputs:
+          user:
+            required: true
+      """
+    )
+  }
+
+  @Test
+  fun reservedCharactersInUsesFailAtLoad() {
+    assertValidationError(
+      "reserved for future cross-file references",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "./common.yaml#login"
+      """
+    )
+  }
+
+  @Test
+  fun duplicateReusableIdsFailAtLoad() {
+    assertValidationError(
+      "duplicate id 'part'",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "part"
+      reusableScenarios:
+      - id: "part"
+        goal: "part goal"
+      - id: "part"
+        goal: "another goal"
+      """
+    )
+  }
+
+  @Test
+  fun maestroYamlInputsMustBeDeclared() {
+    assertValidationError(
+      "'{{inputs.user}}' is not declared",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "deeplink-login"
+      reusableScenarios:
+      - id: "deeplink-login"
+        initializationMethods:
+        - type: "MaestroYaml"
+          scenarioId: "login-flow"
+        goal: "Log in via deeplink"
+      fixedScenarios:
+      - id: "login-flow"
+        title: "login"
+        description: "login flow"
+        yamlText: |-
+          appId: "com.example.app"
+          ---
+          - openLink: "example://login?user={{inputs.user}}"
+      """
+    )
+  }
+}

--- a/arbigent-core/src/test/java/ReusableScenariosTest.kt
+++ b/arbigent-core/src/test/java/ReusableScenariosTest.kt
@@ -180,7 +180,16 @@ class ReusableScenariosTest {
 
   @Test
   fun maestroYamlInputsAreSubstitutedAndExecuted() = runTest {
+    val previousDispatcher = ArbigentCoroutinesDispatcher.dispatcher
     ArbigentCoroutinesDispatcher.dispatcher = coroutineContext[CoroutineDispatcher]!!
+    try {
+      maestroYamlInputsAreSubstitutedAndExecutedBody()
+    } finally {
+      ArbigentCoroutinesDispatcher.dispatcher = previousDispatcher
+    }
+  }
+
+  private suspend fun maestroYamlInputsAreSubstitutedAndExecutedBody() {
     val executedCommands = mutableListOf<MaestroCommand>()
     val fakeDevice = FakeDevice()
     val recordingDevice = object : ArbigentDevice by fakeDevice {

--- a/arbigent-reusable-scenarios-specification.md
+++ b/arbigent-reusable-scenarios-specification.md
@@ -168,7 +168,7 @@ Expanded tasks appear individually in the scenario's result (composite
 one scenario). Each task is labeled with its **call breadcrumb and bound
 inputs**, e.g.:
 
-```
+```text
 premium-content-with-paid-user › login (user=paid)
 change-language-to-english › navigate-to-language-settings
 ```
@@ -190,9 +190,9 @@ hand-written `reusableScenarios` / `steps` / `inputs` / `uses` / `with`.
 ### Call-site editing: the three-way type selector
 
 The existing "Scenario / Execution" `RadioButtonRow` group in the scenario
-editor (`Scenario.kt:331-353`) is extended to three options:
+editor (the scenario-type `RadioButtonRow` group in `Scenario.kt`) is extended to three options:
 
-```
+```text
 ( ) Scenario        — The agent will try to achieve the goal.
 ( ) Execution       — Just execute the initializations and image assertions.
 ( ) Reusable steps  — Call reusable scenarios in order.
@@ -214,7 +214,7 @@ editor (`Scenario.kt:331-353`) is extended to three options:
 
 Steps list editor:
 
-```
+```text
 ┌─ Steps ─────────────────────────────────┐
 │ 1. [login ▾][Browse]                     │
 │    with:                                 │
@@ -225,7 +225,8 @@ Steps list editor:
 ```
 
 - Each step row selects its target with the "title + Browse" pattern already
-  used by the Maestro initialization row (`Scenario.kt:766-793`), opening the
+  used by the Maestro initialization row (the `MaestroYaml` branch of
+  `InitializationOptions` in `Scenario.kt`), opening the
   Reusable Scenarios dialog in selection mode (same mechanism as
   `FixedScenariosDialog`'s `onScenarioSelected`).
 - The `with` editor is **generated from the target's `inputs` declaration**:
@@ -338,6 +339,10 @@ reusableScenarios:
 - id: "login"
   inputs:
     user: { required: true }
+  initializationMethods:
+  - type: "MaestroYaml"
+    scenarioId: "login-deeplink-flow"   # -> fixedScenarios below; its yamlText
+                                        #    also receives {{inputs.user}}
   goal: "Log in with the {{inputs.user}} account on {{app_name}}"
                               # {{app_name}} is a project variable (bare form)
 - id: "play-premium-content"

--- a/arbigent-reusable-scenarios-specification.md
+++ b/arbigent-reusable-scenarios-specification.md
@@ -48,6 +48,10 @@ options, exactly as scenarios do today:
   `maxStep`, `maxRetry`, `imageAssertions`, `imageAssertionHistoryCount`,
   `deviceFormFactor`, `userPromptTemplate`, `aiOptions`, `cacheOptions`,
   `additionalActions`, `mcpOptions`.
+- Note: retry is a **scenario-level** mechanism (it re-runs the calling
+  scenario's whole flattened task list), so `maxRetry` declared on a reusable
+  definition is not applied per expanded task — the calling scenario's
+  `maxRetry` governs.
 
 **Call form** (has `uses` or `steps`): a pure reference. Allowed fields:
 
@@ -55,10 +59,16 @@ options, exactly as scenarios do today:
   single-entry `steps`.
 - `steps` — an ordered list of `{ uses, with }` entries. **References only**;
   no inline goals inside `steps`.
-- Execution options (`initializationMethods`, `maxStep`, `mcpOptions`, …) are
+- Execution options (`initializationMethods`, `maxStep`, `mcpOptions`,
+  `imageAssertions`, `userPromptTemplate`, `type: Execution`, …) are
   **not allowed** on the call form. What runs is determined entirely by the
   definition; the call site only binds parameters and tree position.
-  Writing them is a load-time error.
+  Writing them is a load-time error. (Caveat: fields whose schema default is a
+  real value — e.g. `maxStep: 10` — cannot be distinguished from "unset" after
+  decoding; explicitly writing the default is accepted.)
+- Exception: `maxRetry` and `deviceFormFactor` stay **scenario-level** settings
+  and are therefore allowed on the call form — retry wraps the scenario's whole
+  flattened task list, and the scenario-level form factor is tree context.
 
 ### Placement differences
 

--- a/arbigent-reusable-scenarios-specification.md
+++ b/arbigent-reusable-scenarios-specification.md
@@ -1,6 +1,6 @@
 # Reusable Scenarios Specification
 
-Status: Design finalized, not yet implemented.
+Status: Implemented.
 
 ## Motivation
 

--- a/arbigent-reusable-scenarios-specification.md
+++ b/arbigent-reusable-scenarios-specification.md
@@ -1,0 +1,375 @@
+# Reusable Scenarios Specification
+
+Status: Design finalized, not yet implemented.
+
+## Motivation
+
+Today Arbigent has two reuse mechanisms, and both have structural limits:
+
+- `dependency` (`dependencyId`): scenarios share steps only as a **common
+  prefix from the root** of a dependency chain. Two scenario trees with
+  different roots cannot share a step in the middle; the goal text must be
+  copy-pasted.
+- `fixedScenarios` (Maestro YAML snippets): reusable, but only usable as an
+  `initializationMethods` entry, never in the middle or at the end of a flow.
+
+Reusable Scenarios add a project-level library of AI-scenario parts that can
+be referenced from any position in any scenario tree, with parameters —
+modeled after GitHub Actions reusable workflows (`uses` / `with` / `inputs`).
+
+Goals addressed (from the design discussion):
+
+- **(a)** Insert shared steps at an arbitrary position in a flow, not just as
+  a prefix or during initialization.
+- **(c)** Keep parts out of the executable scenario tree — a library, not a
+  set of runnable scenarios.
+- Parameterization (`with`), so one part serves multiple callers
+  (e.g. `login` with `user: paid` vs `user: free`).
+
+Out of scope for this iteration:
+
+- **Cross-file / cross-project reuse.** Only same-file references are
+  supported. The syntax reserves room for a future file-reference form (see
+  [Reserved syntax](#reserved-syntax)).
+- Inlining (the inverse of "Make this reusable").
+- Automatic parameter extraction in "Make this reusable".
+
+## Data model
+
+### Two node forms
+
+Every scenario — whether under `scenarios:` or `reusableScenarios:` — takes
+exactly one of two forms. Mixing fields across forms is a **load-time error**.
+
+**Leaf form** (has `goal`): carries the executable content and all execution
+options, exactly as scenarios do today:
+
+- `goal`, `type` (`Scenario` | `Execution`), `initializationMethods`,
+  `maxStep`, `maxRetry`, `imageAssertions`, `imageAssertionHistoryCount`,
+  `deviceFormFactor`, `userPromptTemplate`, `aiOptions`, `cacheOptions`,
+  `additionalActions`, `mcpOptions`.
+
+**Call form** (has `uses` or `steps`): a pure reference. Allowed fields:
+
+- `uses` + `with` — call a single reusable scenario. Sugar for a
+  single-entry `steps`.
+- `steps` — an ordered list of `{ uses, with }` entries. **References only**;
+  no inline goals inside `steps`.
+- Execution options (`initializationMethods`, `maxStep`, `mcpOptions`, …) are
+  **not allowed** on the call form. What runs is determined entirely by the
+  definition; the call site only binds parameters and tree position.
+  Writing them is a load-time error.
+
+### Placement differences
+
+| | `scenarios:` | `reusableScenarios:` |
+|---|---|---|
+| Executable / appears in the tree | yes | no (reference-only library) |
+| `dependency`, `tags` | allowed | **not allowed** (tree context stays at the call site) |
+| Leaf form | allowed (this is today's scenario) | allowed |
+| Call form (`uses` / `steps`) | allowed | allowed (composites may nest) |
+
+Nesting composites (a reusable calling another reusable) is allowed.
+**Cycles are detected at load time** and rejected.
+
+### Relationship to `fixedScenarios`
+
+`fixedScenarios` stays as-is: the store for deterministic Maestro YAML
+snippets, referenced via the existing `initializationMethods` entry
+`MaestroYaml(scenarioId)`. No migration, no deprecation.
+
+A reusable **leaf** may carry `initializationMethods`, so a deterministic
+reusable step is expressed with existing machinery — no new execution path:
+
+```yaml
+reusableScenarios:
+- id: "login-via-deeplink"
+  type: "Execution"            # decision interceptor answers GoalAchieved
+                               # immediately — zero AI calls
+  initializationMethods:
+  - type: "MaestroYaml"
+    scenarioId: "login-deeplink-flow"   # -> fixedScenarios, as today
+  goal: "Log in via deeplink"  # not executed; report label only
+```
+
+Division of roles: `fixedScenarios` = deterministic setup snippets, attachable
+to any leaf (including reusable leaves) as initialization.
+`reusableScenarios` = AI scenario parts, callable anywhere.
+
+## Parameters
+
+### Declaration (`inputs`)
+
+Reusable scenarios declare their parameters. Strings only; `required` and
+`default` are the only attributes:
+
+```yaml
+reusableScenarios:
+- id: "login"
+  inputs:
+    user:
+      required: true
+    method:
+      default: "email"
+  goal: "Log in with the {{inputs.user}} account using {{inputs.method}}"
+```
+
+### Variable namespaces
+
+- `{{name}}` (bare) — **project variable** (`appSettings.variables`),
+  resolved at runtime, everywhere, exactly as today. Full backward
+  compatibility; bare form never changes meaning inside a reusable.
+- `{{inputs.name}}` — **declared input**, valid only inside a reusable
+  definition. Load-time checked against the `inputs:` declaration.
+
+Collisions are syntactically impossible. Both namespaces are usable in the
+same goal. Input substitution also applies to the `yamlText` of Maestro
+flows referenced from a reusable leaf's `initializationMethods`.
+
+### Propagation
+
+Explicit only (as in GitHub Actions). A composite passes values down by
+writing them: `with: { user: "{{inputs.user}}" }`. No implicit inheritance.
+
+## Load-time validation
+
+All of the following are **errors at project load**, not runtime warnings.
+(Rationale: the serializer runs with `strictMode=false`, so typos are
+otherwise silently ignored; and the existing fixed-scenario lookup failure
+merely logs and skips at runtime — a part silently skipped is the worst
+failure mode for a test tool.)
+
+1. `uses` referencing an id that does not exist in `reusableScenarios`.
+2. Cyclic composite references.
+3. Mixing leaf and call fields on one node (`goal` + `uses`, execution
+   options on a call form, `dependency`/`tags` on a reusable, …).
+4. `with` keys not declared in the target's `inputs`.
+5. A `required` input missing from `with` (after applying `default`s).
+6. `{{inputs.name}}` referencing an undeclared input; `{{inputs.*}}` used
+   outside a reusable definition.
+7. `uses` values containing `/`, `#`, or `@` (reserved, see below).
+
+## Execution semantics
+
+A call-form scenario expands, at `createArbigentScenario` time, into the flat
+`List<ArbigentAgentTask>` the engine already runs — the same output shape as
+dependency-chain expansion. Each reusable leaf becomes one task carrying its
+own options (`mcpOptions`, `maxStep`, …), so per-task configuration works
+unchanged. Retry, initialization interception, and reporting all inherit the
+existing per-task behavior; no engine changes.
+
+A call-form scenario under `scenarios:` participates in the tree normally:
+it may have `dependency`, may be depended upon, and may be non-leaf.
+
+## Reporting
+
+Expanded tasks appear individually in the scenario's result (composite
+`change-language` calling `A`, `B` yields tasks for both A and B under the
+one scenario). Each task is labeled with its **call breadcrumb and bound
+inputs**, e.g.:
+
+```
+premium-content-with-paid-user › login (user=paid)
+change-language-to-english › navigate-to-language-settings
+```
+
+Rationale: the same part can run several times per execution; goal text alone
+cannot distinguish which call failed. Implementation: `ArbigentAgentTask`
+carries the originating reusable id and a snapshot of resolved `with` values
+into the result model; aggregation is unchanged.
+
+## UI (full support — level "c")
+
+Arbigent does not ship features that cannot be driven from the GUI.
+
+### Round-trip safety (hard requirement)
+
+The UI model must know all new fields so that open-then-save never drops
+hand-written `reusableScenarios` / `steps` / `inputs` / `uses` / `with`.
+
+### Call-site editing: the three-way type selector
+
+The existing "Scenario / Execution" `RadioButtonRow` group in the scenario
+editor (`Scenario.kt:331-353`) is extended to three options:
+
+```
+( ) Scenario        — The agent will try to achieve the goal.
+( ) Execution       — Just execute the initializations and image assertions.
+( ) Reusable steps  — Call reusable scenarios in order.
+```
+
+- "Scenario" / "Execution" map to the leaf form's `type` field, as today.
+  "Reusable steps" switches the node to the call form. The mapping of one
+  radio group onto two schema axes is absorbed at the serialization layer.
+- When "Reusable steps" is selected, the Goal text area is replaced by the
+  steps list, and fields that are invalid on the call form
+  (`initializationMethods`, `maxStep`, image assertions, …) are hidden —
+  UI visibility mirrors the load-time validation rules exactly.
+- The UI never presents a separate single-`uses` shape: the call form is
+  always a steps list (one entry = single call). The `uses:` sugar is only
+  produced by the YAML writer when the list has exactly one entry.
+- Switching away from a form that has content (e.g. Goal with a non-empty
+  goal → Reusable steps) prompts the user, offering "Make this reusable"
+  as the non-destructive path.
+
+Steps list editor:
+
+```
+┌─ Steps ─────────────────────────────────┐
+│ 1. [login ▾][Browse]                     │
+│    with:                                 │
+│      user*: [paid        ]               │  * = required
+│ 2. [play-premium-content ▾][Browse]      │
+│ [+ Add step]                             │
+└─────────────────────────────────────────┘
+```
+
+- Each step row selects its target with the "title + Browse" pattern already
+  used by the Maestro initialization row (`Scenario.kt:766-793`), opening the
+  Reusable Scenarios dialog in selection mode (same mechanism as
+  `FixedScenariosDialog`'s `onScenarioSelected`).
+- The `with` editor is **generated from the target's `inputs` declaration**:
+  one field per declared input, required inputs marked, `default` shown as
+  placeholder. Free-form key/value entry is not offered — undeclared keys
+  are load-time errors, so the UI does not allow creating them.
+
+### Definition editing: Reusable Scenarios dialog
+
+A structural sibling of `FixedScenariosDialog` (list + add/edit/delete +
+selection mode), opened from the same top-level location as the existing
+"Maestro YAML Scenarios" dialog. The editor pane reuses the same scenario
+content editor as `scenarios:` (three-way radio, goal editor, option
+sections, steps builder) with these differences:
+
+- `dependency` and `tags` controls are absent (not allowed on reusables).
+- An **inputs declaration editor**: rows of (name, required checkbox,
+  default value).
+- Live validation mirroring the load-time rules (unresolved references,
+  cycles, undeclared `{{inputs.*}}`), following the precedent of the
+  live Maestro syntax check in `FixedScenariosDialog`.
+
+### "Make this reusable"
+
+A mechanical refactoring on an existing scenario X, available from the
+scenario editor and offered on destructive form switches (see above).
+Pressing it opens a **confirmation dialog** previewing the outcome (new
+reusable id/title, the fields that will move) before anything is applied:
+
+- Create a new reusable: move `goal` + `type` + `initializationMethods` +
+  all execution-tuning fields. New id derived from the title, editable in
+  the dialog.
+- X becomes a call node: keeps `id` / `dependency` / `tags`, body becomes
+  `uses: <new-id>`. Because X's id is unchanged, scenarios depending on X
+  are unaffected.
+- No automatic parameterization — the user introduces `{{inputs.*}}` by
+  hand afterwards (guessing wrong silently corrupts behavior).
+- Operates on the in-memory model; undo before save works naturally, but
+  the confirmation dialog is the primary guard since the transformation is
+  not trivially reversible by hand (no "inline" inverse in this iteration).
+
+### Scenario tree
+
+Call nodes appear in the tree like any scenario, labeled with the called
+reusable's title and bound inputs (e.g. `login (user=paid)`), with a badge
+distinguishing them from leaf scenarios.
+
+## CLI
+
+No new commands. Reusable scenarios are consumed transparently when the
+project YAML is loaded. `--scenario-ids` targets `scenarios:` entries only;
+reusable ids are not runnable.
+
+## Reserved syntax
+
+`uses` values are plain ids in this iteration. Ids containing `/`, `#`, or
+`@` are rejected at load time so that a future file/remote reference form
+(e.g. `./common.yaml#login`) can be introduced without ambiguity.
+
+## YAML vocabulary (final)
+
+| Concept | Key | Origin |
+|---|---|---|
+| Parts store | `reusableScenarios` | sibling of `fixedScenarios` |
+| Reference | `uses` | GitHub Actions |
+| Arguments | `with` | GitHub Actions |
+| Input declaration | `inputs` (`required`, `default`) | GitHub Actions |
+| Composition list | `steps` | GitHub Actions |
+| Input reference | `{{inputs.name}}` | GHA `inputs.` prefix on the existing `{{...}}` resolver |
+
+## Full example
+
+```yaml
+scenarios:
+# Combination tests: compose directly at the call site; no named composite
+# needed, so the parts store is not polluted by one-off combinations.
+- id: "premium-content-with-paid-user"
+  tags:
+  - name: "billing"
+  steps:
+  - uses: "login"
+    with: { user: "paid" }
+  - uses: "play-premium-content"
+
+- id: "premium-content-with-free-user"
+  steps:
+  - uses: "login"
+    with: { user: "free" }
+  - uses: "play-premium-content"
+
+# A call node can also sit anywhere in a dependency chain.
+- id: "change-language"
+  dependency: "premium-content-with-paid-user"
+  uses: "change-language-to-english"
+
+# Ordinary and reusable nodes mix freely along a chain:
+# ordinary leaf -> reusable call -> ordinary leaf.
+- id: "launch-app"
+  goal: "Launch the app and reach the home screen"
+- id: "become-paid-user"
+  dependency: "launch-app"
+  uses: "upgrade-to-paid"
+  with: { plan: "premium" }
+- id: "go-to-content-a"
+  dependency: "become-paid-user"
+  goal: "Navigate to content A and open its detail page"
+
+reusableScenarios:
+# Leaf: full option set available per part.
+- id: "login"
+  inputs:
+    user: { required: true }
+  goal: "Log in with the {{inputs.user}} account on {{app_name}}"
+                              # {{app_name}} is a project variable (bare form)
+- id: "play-premium-content"
+  goal: "Open and play any premium content; verify playback or the paywall"
+  maxStep: 15
+
+# Composite: references only, nesting allowed, cycles rejected at load.
+- id: "change-language-to-english"
+  steps:
+  - uses: "navigate-to-language-settings"
+  - uses: "set-language"
+    with: { lang: "English" }
+
+- id: "navigate-to-language-settings"
+  goal: "Open Settings and navigate to System > Languages"
+  mcpOptions: "..."
+
+- id: "set-language"
+  inputs:
+    lang: { required: true }
+  goal: "Add {{inputs.lang}} to the language list and move it to the top"
+
+- id: "upgrade-to-paid"
+  inputs:
+    plan: { required: true }
+  goal: "Purchase the {{inputs.plan}} plan and verify the account is upgraded"
+
+fixedScenarios:            # unchanged; still referenced from
+- id: "login-deeplink-flow"  # initializationMethods of any leaf
+  title: "login via deeplink"
+  yamlText: |-
+    appId: "com.example.app"
+    ---
+    - openLink: "example://login?user={{inputs.user}}"
+```

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/App.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/App.kt
@@ -112,6 +112,17 @@ private fun MainScreen(
         appStateHolder.projectDialogState.value = ProjectDialogState.NotSelected
       }
     )
+  } else if (projectDialogState is ProjectDialogState.ShowReusableScenariosDialog) {
+    ReusableScenariosDialog(
+      appStateHolder = appStateHolder,
+      onCloseRequest = {
+        appStateHolder.projectDialogState.value = ProjectDialogState.NotSelected
+      },
+      onScenarioSelected = { reusableScenarioId ->
+        appStateHolder.updateReusableStepSelection(reusableScenarioId)
+        appStateHolder.projectDialogState.value = ProjectDialogState.NotSelected
+      }
+    )
   }
   val scenarioIndex by appStateHolder.selectedScenarioIndex.collectAsState()
   var scenariosWidth by remember { mutableStateOf(200.dp) }
@@ -164,7 +175,7 @@ private fun MainScreen(
                   content = {
                     Text(
                       modifier = Modifier.testTag("dependency_scenario"),
-                      text = scenarioStateHolder.goal
+                      text = scenarioStateHolder.goal.ifBlank { scenarioStateHolder.id }
                     )
                   }
                 )
@@ -195,7 +206,16 @@ private fun MainScreen(
           getFixedScenarioById = { scenarioId ->
             appStateHolder.getFixedScenarioById(scenarioId)
           },
-          mcpServerNames = appStateHolder.mcpServerNamesFlow.collectAsState().value
+          mcpServerNames = appStateHolder.mcpServerNamesFlow.collectAsState().value,
+          onShowReusableScenariosDialog = { scenarioStateHolder, index ->
+            appStateHolder.onShowReusableScenariosDialogWithContext(scenarioStateHolder, index)
+          },
+          getReusableScenarioById = { reusableScenarioId ->
+            appStateHolder.getReusableScenarioById(reusableScenarioId)
+          },
+          onMakeReusable = { scenarioStateHolder, newReusableId ->
+            appStateHolder.makeScenarioReusable(scenarioStateHolder, newReusableId)
+          }
         )
       }
     }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -81,6 +81,32 @@ class ArbigentAppStateHolder(
     _reusableScenariosFlow.value = _reusableScenariosFlow.value.map {
       if (it.id == originalId) scenario else it
     }
+    if (originalId != scenario.id) {
+      renameReusableScenarioReferences(originalId, scenario.id)
+    }
+  }
+
+  /** Rewrite every uses/steps reference so a reusable-scenario rename never leaves callers dangling. */
+  private fun renameReusableScenarioReferences(oldId: String, newId: String) {
+    allScenarioStateHoldersStateFlow.value.forEach { holder ->
+      val steps = holder.reusableStepsStateFlow.value
+      if (steps.any { it.uses == oldId }) {
+        holder.reusableStepsStateFlow.value = steps.map {
+          if (it.uses == oldId) it.copy(uses = newId) else it
+        }
+      }
+    }
+    _reusableScenariosFlow.value = _reusableScenariosFlow.value.map { reusable ->
+      if (reusable.callSteps().none { it.uses == oldId }) return@map reusable
+      ArbigentScenarioContent(
+        id = reusable.id,
+        steps = reusable.callSteps().map {
+          if (it.uses == oldId) it.copy(uses = newId) else it
+        },
+        inputs = reusable.inputs,
+        noteForHumans = reusable.noteForHumans,
+      )
+    }
   }
 
   fun removeReusableScenario(reusableScenarioId: String) {
@@ -115,7 +141,9 @@ class ArbigentAppStateHolder(
         goal = content.goal,
         type = content.type,
         initializationMethods = content.initializationMethods,
+        maxRetry = content.maxRetry,
         maxStep = content.maxStep,
+        deviceFormFactor = content.deviceFormFactor,
         imageAssertionHistoryCount = content.imageAssertionHistoryCount,
         imageAssertions = content.imageAssertions,
         userPromptTemplate = content.userPromptTemplate,
@@ -302,6 +330,10 @@ class ArbigentAppStateHolder(
     allScenarioStateHoldersStateFlow.value += scenarioStateHolder
     selectedScenarioIndex.value =
       sortedScenariosAndDepths().indexOfFirst { it.first.id == scenarioStateHolder.id }
+  }
+
+  internal fun addScenarioStateHolder(scenarioStateHolder: ArbigentScenarioStateHolder) {
+    allScenarioStateHoldersStateFlow.value += scenarioStateHolder
   }
 
   private var job: Job? = null

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -156,6 +156,26 @@ class ArbigentAppStateHolder(
     scenarioStateHolder.convertToCallNode(reusableId)
   }
 
+  /**
+   * Validates the project as it would look with [candidate] added (or replacing [originalId]).
+   * Returns the validation error message, or null when valid. Used to reject editor saves
+   * that would produce a project file that fails to load.
+   */
+  fun validateReusableScenarioCandidate(candidate: ArbigentScenarioContent, originalId: String?): String? {
+    val prospectiveReusables = if (originalId == null) {
+      _reusableScenariosFlow.value + candidate
+    } else {
+      _reusableScenariosFlow.value.map { if (it.id == originalId) candidate else it }
+    }
+    return runCatching {
+      ArbigentProjectFileContent(
+        scenarioContents = allScenarioStateHoldersStateFlow.value.map { it.createArbigentScenarioContent() },
+        reusableScenarios = prospectiveReusables,
+        fixedScenarios = _fixedScenariosFlow.value,
+      ).validateReusableScenarios()
+    }.exceptionOrNull()?.message
+  }
+
   // Target of the reusable-scenario selection dialog: scenario holder and step index.
   private val _currentReusableStepTarget = MutableStateFlow<Pair<ArbigentScenarioStateHolder, Int>?>(null)
 
@@ -541,6 +561,11 @@ class ArbigentAppStateHolder(
       return
     }
     val content = getCurrentProjectFileContent()
+    // Never write a project file that would fail to load; surface the problem instead.
+    runCatching { content.validateReusableScenarios() }.exceptionOrNull()?.let { e ->
+      showErrorDialog(e)
+      return
+    }
     arbigentProjectSerializer.save(
       projectFileContent = content,
       file = file

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -77,9 +77,9 @@ class ArbigentAppStateHolder(
     _reusableScenariosFlow.value = _reusableScenariosFlow.value + scenario
   }
 
-  fun updateReusableScenario(scenario: ArbigentScenarioContent) {
+  fun updateReusableScenario(scenario: ArbigentScenarioContent, originalId: String = scenario.id) {
     _reusableScenariosFlow.value = _reusableScenariosFlow.value.map {
-      if (it.id == scenario.id) scenario else it
+      if (it.id == originalId) scenario else it
     }
   }
 

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -70,6 +70,88 @@ class ArbigentAppStateHolder(
     return _fixedScenariosFlow.value.find { it.id == scenarioId }
   }
 
+  private val _reusableScenariosFlow = MutableStateFlow<List<ArbigentScenarioContent>>(emptyList())
+  val reusableScenariosFlow: StateFlow<List<ArbigentScenarioContent>> = _reusableScenariosFlow.asStateFlow()
+
+  fun addReusableScenario(scenario: ArbigentScenarioContent) {
+    _reusableScenariosFlow.value = _reusableScenariosFlow.value + scenario
+  }
+
+  fun updateReusableScenario(scenario: ArbigentScenarioContent) {
+    _reusableScenariosFlow.value = _reusableScenariosFlow.value.map {
+      if (it.id == scenario.id) scenario else it
+    }
+  }
+
+  fun removeReusableScenario(reusableScenarioId: String) {
+    _reusableScenariosFlow.value = _reusableScenariosFlow.value.filter { it.id != reusableScenarioId }
+  }
+
+  fun getReusableScenarioById(reusableScenarioId: String): ArbigentScenarioContent? {
+    return _reusableScenariosFlow.value.find { it.id == reusableScenarioId }
+  }
+
+  /** Ids of scenarios and reusable scenarios that reference [reusableScenarioId] via uses/steps. */
+  fun reusableScenarioReferences(reusableScenarioId: String): List<String> {
+    val fromScenarios = allScenarioStateHoldersStateFlow.value
+      .filter { holder -> holder.reusableStepsStateFlow.value.any { it.uses == reusableScenarioId } }
+      .map { it.id }
+    val fromReusables = _reusableScenariosFlow.value
+      .filter { reusable -> reusable.callSteps().any { it.uses == reusableScenarioId } }
+      .map { it.id }
+    return fromScenarios + fromReusables
+  }
+
+  /**
+   * Make this reusable: move the scenario's executable content into a new reusable scenario
+   * and turn the scenario itself into a call node. The scenario keeps its id, dependency and
+   * tags, so scenarios depending on it are unaffected.
+   */
+  fun makeScenarioReusable(scenarioStateHolder: ArbigentScenarioStateHolder, reusableId: String) {
+    val content = scenarioStateHolder.createArbigentScenarioContent()
+    addReusableScenario(
+      ArbigentScenarioContent(
+        id = reusableId,
+        goal = content.goal,
+        type = content.type,
+        initializationMethods = content.initializationMethods,
+        maxStep = content.maxStep,
+        imageAssertionHistoryCount = content.imageAssertionHistoryCount,
+        imageAssertions = content.imageAssertions,
+        userPromptTemplate = content.userPromptTemplate,
+        aiOptions = content.aiOptions,
+        cacheOptions = content.cacheOptions,
+        additionalActions = content.additionalActions,
+        mcpOptions = content.mcpOptions,
+      )
+    )
+    scenarioStateHolder.convertToCallNode(reusableId)
+  }
+
+  // Target of the reusable-scenario selection dialog: scenario holder and step index.
+  private val _currentReusableStepTarget = MutableStateFlow<Pair<ArbigentScenarioStateHolder, Int>?>(null)
+
+  fun showReusableScenariosDialog() {
+    _currentReusableStepTarget.value = null
+    projectDialogState.value = ProjectDialogState.ShowReusableScenariosDialog
+  }
+
+  fun onShowReusableScenariosDialogWithContext(scenarioStateHolder: ArbigentScenarioStateHolder, stepIndex: Int) {
+    _currentReusableStepTarget.value = scenarioStateHolder to stepIndex
+    projectDialogState.value = ProjectDialogState.ShowReusableScenariosDialog
+  }
+
+  fun updateReusableStepSelection(reusableScenarioId: String) {
+    val (scenarioStateHolder, index) = _currentReusableStepTarget.value ?: return
+    val steps = scenarioStateHolder.reusableStepsStateFlow.value
+    if (index in steps.indices) {
+      scenarioStateHolder.onReusableStepChanged(
+        index,
+        steps[index].copy(uses = reusableScenarioId)
+      )
+    }
+  }
+
   fun getScenarioReferences(scenarioId: String): List<Pair<ArbigentScenarioStateHolder, Int>> {
     val references = mutableListOf<Pair<ArbigentScenarioStateHolder, Int>>()
     
@@ -128,6 +210,7 @@ class ArbigentAppStateHolder(
     data object ShowProjectSettings : ProjectDialogState
     data object ShowGenerateScenarioDialog : ProjectDialogState
     data object ShowFixedScenariosDialog : ProjectDialogState
+    data object ShowReusableScenariosDialog : ProjectDialogState
   }
 
   val deviceConnectionState: MutableStateFlow<DeviceConnectionState> =
@@ -319,7 +402,8 @@ class ArbigentAppStateHolder(
         },
         aiDecisionCache = decisionCache.value,
         appSettings = appSettings,
-        fixedScenarios = this@ArbigentAppStateHolder._fixedScenariosFlow.value
+        fixedScenarios = this@ArbigentAppStateHolder._fixedScenariosFlow.value,
+        reusableScenarios = this@ArbigentAppStateHolder._reusableScenariosFlow.value
       )
 
   private fun sortedScenarioAndDepth(allScenarios: List<ArbigentScenarioStateHolder>): List<Pair<ArbigentScenarioStateHolder, Int>> {
@@ -406,6 +490,7 @@ class ArbigentAppStateHolder(
         additionalActions = additionalActionsFlow.value
       ),
       scenarioContents = sortedScenarios.map { it.createArbigentScenarioContent() },
+      reusableScenarios = _reusableScenariosFlow.value,
       fixedScenarios = _fixedScenariosFlow.value
     )
   }
@@ -458,6 +543,7 @@ class ArbigentAppStateHolder(
     defaultDeviceFormFactorFlow.value = projectFile.settings.deviceFormFactor
     additionalActionsFlow.value = projectFile.settings.additionalActions
     _fixedScenariosFlow.value = projectFile.fixedScenarios
+    _reusableScenariosFlow.value = projectFile.reusableScenarios
     projectStateFlow.value = ArbigentProject(
       settings = projectFile.settings,
       initialScenarios = arbigentScenarioStateHolders.map {

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentScenarioStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentScenarioStateHolder.kt
@@ -62,6 +62,15 @@ constructor(
     MutableStateFlow(ArbigentScenarioType.Scenario)
   fun scenarioType() = scenarioTypeStateFlow.value
 
+  // Call form ("Reusable steps"): the scenario calls reusable scenarios instead of having a goal.
+  val reusableStepsModeStateFlow: MutableStateFlow<Boolean> = MutableStateFlow(false)
+  val reusableStepsStateFlow: MutableStateFlow<List<ArbigentScenarioContent.ReusableStep>> =
+    MutableStateFlow(emptyList())
+
+  // Input declarations. Only used when this holder edits a reusableScenarios entry.
+  val reusableInputsStateFlow: MutableStateFlow<List<Pair<String, ArbigentScenarioContent.ReusableInput>>> =
+    MutableStateFlow(emptyList())
+
   val dependencyScenarioStateHolderStateFlow = MutableStateFlow<ArbigentScenarioStateHolder?>(null)
   val arbigentScenarioExecutorStateFlow = MutableStateFlow<ArbigentScenarioExecutor?>(null)
   val isNewlyGenerated = MutableStateFlow(false)
@@ -171,7 +180,77 @@ constructor(
     _mcpOptions.value = options
   }
 
+  fun onReusableStepsModeChanged(enabled: Boolean) {
+    reusableStepsModeStateFlow.value = enabled
+    if (enabled && reusableStepsStateFlow.value.isEmpty()) {
+      // Show one unselected step row so the Browse button is visible right away.
+      reusableStepsStateFlow.value = listOf(ArbigentScenarioContent.ReusableStep(uses = ""))
+    }
+  }
+
+  fun onAddReusableStep() {
+    reusableStepsStateFlow.value += ArbigentScenarioContent.ReusableStep(uses = "")
+  }
+
+  fun onReusableStepChanged(index: Int, step: ArbigentScenarioContent.ReusableStep) {
+    reusableStepsStateFlow.value = reusableStepsStateFlow.value.toMutableList().apply {
+      set(index, step)
+    }
+  }
+
+  fun onRemoveReusableStep(index: Int) {
+    reusableStepsStateFlow.value = reusableStepsStateFlow.value.toMutableList().apply {
+      removeAt(index)
+    }
+  }
+
+  fun onAddReusableInput() {
+    reusableInputsStateFlow.value += ("" to ArbigentScenarioContent.ReusableInput())
+  }
+
+  fun onReusableInputChanged(index: Int, name: String, input: ArbigentScenarioContent.ReusableInput) {
+    reusableInputsStateFlow.value = reusableInputsStateFlow.value.toMutableList().apply {
+      set(index, name to input)
+    }
+  }
+
+  fun onRemoveReusableInput(index: Int) {
+    reusableInputsStateFlow.value = reusableInputsStateFlow.value.toMutableList().apply {
+      removeAt(index)
+    }
+  }
+
+  /** Turn this scenario into a call node that uses [reusableId] (Make this reusable). */
+  fun convertToCallNode(reusableId: String) {
+    reusableStepsModeStateFlow.value = true
+    reusableStepsStateFlow.value = listOf(ArbigentScenarioContent.ReusableStep(uses = reusableId))
+    onGoalChanged("")
+    _initializationMethodStateFlow.value = emptyList()
+    imageAssertionsStateFlow.value = emptyList()
+    scenarioTypeStateFlow.value = ArbigentScenarioType.Scenario
+    _aiOptions.value = null
+    _cacheOptions.value = null
+    _additionalActions.value = null
+    _mcpOptions.value = null
+  }
+
   fun createArbigentScenarioContent(): ArbigentScenarioContent {
+    if (reusableStepsModeStateFlow.value) {
+      val steps = reusableStepsStateFlow.value.filter { it.uses.isNotBlank() }
+      return ArbigentScenarioContent(
+        id = id,
+        goal = "",
+        dependencyId = dependencyScenarioStateHolderStateFlow.value?.id,
+        uses = steps.singleOrNull()?.uses,
+        withValues = steps.singleOrNull()?.withValues ?: emptyMap(),
+        steps = if (steps.size == 1) emptyList() else steps,
+        noteForHumans = noteForHumans.text.toString(),
+        maxRetry = maxRetryState.text.toString().toIntOrNull() ?: 3,
+        tags = tagManager.tagsForScenario(this),
+        deviceFormFactor = deviceFormFactorStateFlow.value,
+        inputs = reusableInputsStateFlow.value.filter { it.first.isNotBlank() }.toMap(),
+      )
+    }
     return ArbigentScenarioContent(
       id = id,
       goal = goal,
@@ -193,12 +272,16 @@ constructor(
       aiOptions = aiOptionsFlow.value,
       cacheOptions = cacheOptionsFlow.value,
       additionalActions = additionalActionsFlow.value,
-      mcpOptions = mcpOptionsFlow.value
+      mcpOptions = mcpOptionsFlow.value,
+      inputs = reusableInputsStateFlow.value.filter { it.first.isNotBlank() }.toMap(),
     )
   }
 
   fun load(scenarioContent: ArbigentScenarioContent) {
     _id.value = scenarioContent.id
+    reusableStepsModeStateFlow.value = scenarioContent.isCallForm()
+    reusableStepsStateFlow.value = scenarioContent.callSteps()
+    reusableInputsStateFlow.value = scenarioContent.inputs.toList()
     onGoalChanged(scenarioContent.goal)
     maxRetryState.edit {
       replace(0, length, scenarioContent.maxRetry.toString())

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/LeftScenariosPanel.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/LeftScenariosPanel.kt
@@ -196,9 +196,17 @@ internal fun LeftScenariosPanel(
               
               val runningInfo by scenarioStateHolder.arbigentScenarioRunningInfo.collectAsState()
               val scenarioType by scenarioStateHolder.scenarioTypeStateFlow.collectAsState()
+              val reusableStepsMode by scenarioStateHolder.reusableStepsModeStateFlow.collectAsState()
+              val reusableSteps by scenarioStateHolder.reusableStepsStateFlow.collectAsState()
               Text(
                 modifier = Modifier.weight(1f),
-                text = if (scenarioType.isScenario()) {
+                text = if (reusableStepsMode) {
+                  "↻ " + reusableSteps.joinToString(" -> ") { step ->
+                    step.uses.ifBlank { "?" } +
+                      if (step.withValues.isEmpty()) ""
+                      else " (" + step.withValues.entries.joinToString(", ") { "${it.key}=${it.value}" } + ")"
+                  }
+                } else if (scenarioType.isScenario()) {
                   "Goal: $goal"
                 } else {
                   val scenarioId by scenarioStateHolder.idStateFlow.collectAsState()

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ReusableScenarioComponents.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ReusableScenarioComponents.kt
@@ -1,0 +1,225 @@
+package io.github.takahirom.arbigent.ui
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import io.github.takahirom.arbigent.ArbigentScenarioContent
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.Checkbox
+import org.jetbrains.jewel.ui.component.DefaultButton
+import org.jetbrains.jewel.ui.component.GroupHeader
+import org.jetbrains.jewel.ui.component.IconActionButton
+import org.jetbrains.jewel.ui.component.OutlinedButton
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.TextField
+import org.jetbrains.jewel.ui.icons.AllIconsKeys
+import org.jetbrains.jewel.ui.painter.hints.Size
+
+/**
+ * Editor for the call form: an ordered list of reusable-scenario calls.
+ * Each row selects its target via the Reusable Scenarios dialog (Browse) and binds
+ * the target's declared inputs via generated `with` fields.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun ReusableStepsEditor(
+  scenarioStateHolder: ArbigentScenarioStateHolder,
+  getReusableScenarioById: (String) -> ArbigentScenarioContent?,
+  onBrowseReusableScenarios: (ArbigentScenarioStateHolder, Int) -> Unit,
+) {
+  val steps by scenarioStateHolder.reusableStepsStateFlow.collectAsState()
+  Column(
+    modifier = Modifier.fillMaxWidth().padding(4.dp).testTag("reusable_steps_editor")
+  ) {
+    GroupHeader("Steps")
+    steps.forEachIndexed { index, step ->
+      val target = getReusableScenarioById(step.uses)
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(vertical = 2.dp)
+      ) {
+        Text("${index + 1}.", modifier = Modifier.padding(end = 4.dp))
+        Text(
+          text = step.uses.ifBlank { "Select scenario" },
+          modifier = Modifier
+            .width(200.dp)
+            .background(JewelTheme.globalColors.panelBackground)
+            .padding(8.dp)
+            .clickable { onBrowseReusableScenarios(scenarioStateHolder, index) }
+            .testTag("reusable_step_uses_$index")
+        )
+        IconActionButton(
+          key = AllIconsKeys.General.OpenDisk,
+          onClick = { onBrowseReusableScenarios(scenarioStateHolder, index) },
+          contentDescription = "Browse reusable scenarios",
+          hint = Size(16),
+          modifier = Modifier.testTag("browse_reusable_scenarios_$index")
+        ) {
+          Text("Browse reusable scenarios")
+        }
+        IconActionButton(
+          key = AllIconsKeys.General.Delete,
+          onClick = { scenarioStateHolder.onRemoveReusableStep(index) },
+          contentDescription = "Remove step",
+          hint = Size(16),
+        ) {
+          Text("Remove step")
+        }
+      }
+      if (step.uses.isNotBlank() && target == null) {
+        Text(
+          text = "'${step.uses}' is not defined in reusable scenarios",
+          color = androidx.compose.ui.graphics.Color.Red,
+          modifier = Modifier.padding(start = 16.dp)
+        )
+      }
+      // `with` fields generated from the target's declared inputs.
+      target?.inputs?.forEach { (name, input) ->
+        Row(
+          verticalAlignment = Alignment.CenterVertically,
+          modifier = Modifier.padding(start = 16.dp, top = 2.dp)
+        ) {
+          Text(
+            text = name + if (input.required && input.default == null) " *" else "",
+            modifier = Modifier.width(120.dp)
+          )
+          TextField(
+            value = step.withValues[name] ?: "",
+            onValueChange = { newValue ->
+              val newWith = step.withValues.toMutableMap()
+              if (newValue.isEmpty()) newWith.remove(name) else newWith[name] = newValue
+              scenarioStateHolder.onReusableStepChanged(index, step.copy(withValues = newWith))
+            },
+            placeholder = { Text(input.default ?: "") },
+            modifier = Modifier.width(200.dp).testTag("reusable_step_with_${index}_$name")
+          )
+        }
+      }
+    }
+    Row {
+      OutlinedButton(
+        onClick = { scenarioStateHolder.onAddReusableStep() },
+        modifier = Modifier.padding(4.dp).testTag("add_reusable_step_button")
+      ) {
+        Text("+ Add step")
+      }
+    }
+  }
+}
+
+/** Editor for a reusable scenario's input declarations (name / required / default). */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun ReusableInputsEditor(
+  scenarioStateHolder: ArbigentScenarioStateHolder,
+) {
+  val inputs by scenarioStateHolder.reusableInputsStateFlow.collectAsState()
+  Column(modifier = Modifier.padding(4.dp).testTag("reusable_inputs_editor")) {
+    inputs.forEachIndexed { index, (name, input) ->
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier.padding(vertical = 2.dp)
+      ) {
+        TextField(
+          value = name,
+          onValueChange = { scenarioStateHolder.onReusableInputChanged(index, it, input) },
+          placeholder = { Text("Input name") },
+          modifier = Modifier.width(160.dp).testTag("reusable_input_name_$index")
+        )
+        Checkbox(
+          checked = input.required,
+          onCheckedChange = {
+            scenarioStateHolder.onReusableInputChanged(index, name, input.copy(required = it))
+          },
+          modifier = Modifier.padding(start = 8.dp)
+        )
+        Text("required")
+        TextField(
+          value = input.default ?: "",
+          onValueChange = {
+            scenarioStateHolder.onReusableInputChanged(
+              index, name, input.copy(default = it.ifEmpty { null })
+            )
+          },
+          placeholder = { Text("Default value") },
+          modifier = Modifier.width(160.dp).padding(start = 8.dp)
+        )
+        IconActionButton(
+          key = AllIconsKeys.General.Delete,
+          onClick = { scenarioStateHolder.onRemoveReusableInput(index) },
+          contentDescription = "Remove input",
+          hint = Size(16),
+        ) {
+          Text("Remove input")
+        }
+      }
+    }
+    OutlinedButton(
+      onClick = { scenarioStateHolder.onAddReusableInput() },
+      modifier = Modifier.padding(4.dp).testTag("add_reusable_input_button")
+    ) {
+      Text("+ Add input")
+    }
+  }
+}
+
+/**
+ * Confirmation dialog for "Make this reusable". Previews what will move into the new
+ * reusable scenario before anything is applied; the new id is editable.
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+internal fun MakeReusableDialog(
+  scenarioStateHolder: ArbigentScenarioStateHolder,
+  onDismiss: () -> Unit,
+  onConfirm: (newReusableId: String) -> Unit,
+) {
+  val idState = remember { TextFieldState(scenarioStateHolder.id + "-reusable") }
+  Dialog(onDismissRequest = onDismiss) {
+    Column(
+      modifier = Modifier.background(JewelTheme.globalColors.panelBackground).padding(16.dp)
+    ) {
+      GroupHeader("Make this reusable")
+      Text(
+        text = "The goal, initialization methods and execution options of this scenario move into a new reusable scenario.\n" +
+          "This scenario keeps its id, dependency and tags, and becomes a call to the new reusable scenario,\n" +
+          "so scenarios depending on it are unaffected.\n" +
+          "Parameterize the goal with {{inputs.*}} by editing the reusable scenario afterwards.",
+        modifier = Modifier.padding(vertical = 8.dp)
+      )
+      Text("New reusable scenario id:")
+      TextField(
+        state = idState,
+        modifier = Modifier.width(320.dp).padding(vertical = 4.dp).testTag("make_reusable_id"),
+      )
+      Row(
+        horizontalArrangement = Arrangement.End,
+        modifier = Modifier.fillMaxWidth().padding(top = 8.dp)
+      ) {
+        OutlinedButton(onClick = onDismiss, modifier = Modifier.padding(end = 8.dp)) {
+          Text("Cancel")
+        }
+        DefaultButton(
+          onClick = { onConfirm(idState.text.toString()) },
+          enabled = idState.text.isNotBlank(),
+          modifier = Modifier.testTag("make_reusable_confirm")
+        ) {
+          Text("Make reusable")
+        }
+      }
+    }
+  }
+}

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ReusableScenariosDialog.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ReusableScenariosDialog.kt
@@ -149,10 +149,11 @@ fun ReusableScenariosDialog(
             editingScenario = null
           },
           onSave = { content ->
-            if (editingScenario == null) {
+            val original = editingScenario
+            if (original == null) {
               appStateHolder.addReusableScenario(content)
             } else {
-              appStateHolder.updateReusableScenario(content)
+              appStateHolder.updateReusableScenario(content, originalId = original.id)
             }
             showEditor = false
             editingScenario = null
@@ -244,9 +245,13 @@ private fun ReusableScenarioEditorDialog(
       }
 
       stepBrowseIndex?.let { index ->
+        val allReusables = appStateHolder.reusableScenariosFlow.collectAsState().value
         ReusableScenarioPicker(
-          candidates = appStateHolder.reusableScenariosFlow.collectAsState().value
-            .filter { it.id != stateHolder.id },
+          // Exclude candidates that would create a cycle: the candidate itself and any
+          // composite whose expansion reaches the reusable being edited.
+          candidates = allReusables.filter { candidate ->
+            candidate.id != stateHolder.id && !reachesReusable(candidate, stateHolder.id, allReusables)
+          },
           onDismiss = { stepBrowseIndex = null },
           onPicked = { pickedId ->
             val steps = stateHolder.reusableStepsStateFlow.value
@@ -275,6 +280,20 @@ private fun ReusableScenarioEditorDialog(
       }
     }
   )
+}
+
+/** True when [candidate]'s expansion (transitively) references [targetId]. */
+private fun reachesReusable(
+  candidate: ArbigentScenarioContent,
+  targetId: String,
+  allReusables: List<ArbigentScenarioContent>,
+  visited: MutableSet<String> = mutableSetOf(),
+): Boolean {
+  if (!visited.add(candidate.id)) return false
+  return candidate.callSteps().any { step ->
+    step.uses == targetId || allReusables.firstOrNull { it.id == step.uses }
+      ?.let { reachesReusable(it, targetId, allReusables, visited) } == true
+  }
 }
 
 /** Lightweight picker used inside the editor dialog to choose a reusable scenario. */

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ReusableScenariosDialog.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ReusableScenariosDialog.kt
@@ -1,0 +1,325 @@
+package io.github.takahirom.arbigent.ui
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import io.github.takahirom.arbigent.ArbigentScenarioContent
+import io.github.takahirom.arbigent.ArbigentTagManager
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.Orientation
+import org.jetbrains.jewel.ui.component.*
+import org.jetbrains.jewel.ui.icons.AllIconsKeys
+import org.jetbrains.jewel.ui.painter.hints.Size
+
+/**
+ * Library dialog for reusable scenarios: list + add/edit/delete + selection.
+ * Structural sibling of [FixedScenariosDialog].
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ReusableScenariosDialog(
+  appStateHolder: ArbigentAppStateHolder,
+  onCloseRequest: () -> Unit,
+  onScenarioSelected: (String) -> Unit,
+) {
+  val reusableScenarios by appStateHolder.reusableScenariosFlow.collectAsState()
+  var editingScenario by remember { mutableStateOf<ArbigentScenarioContent?>(null) }
+  var showEditor by remember { mutableStateOf(false) }
+  var selectedScenarioId by remember { mutableStateOf<String?>(null) }
+
+  TestCompatibleDialog(
+    onCloseRequest = onCloseRequest,
+    title = "Reusable Scenarios",
+    content = {
+      Column(
+        modifier = Modifier.padding(16.dp).fillMaxWidth().fillMaxHeight(0.8f)
+      ) {
+        LazyColumn(
+          modifier = Modifier.weight(1f).fillMaxWidth()
+        ) {
+          items(reusableScenarios) { scenario ->
+            Row(
+              modifier = Modifier.fillMaxWidth().padding(8.dp),
+              verticalAlignment = Alignment.CenterVertically
+            ) {
+              RadioButtonRow(
+                text = "",
+                selected = scenario.id == selectedScenarioId,
+                onClick = { selectedScenarioId = scenario.id },
+                modifier = Modifier.testTag("select_reusable_${scenario.id}")
+              )
+              Column(
+                modifier = Modifier.weight(1f).padding(start = 8.dp)
+              ) {
+                Text(
+                  text = scenario.id,
+                  modifier = Modifier.testTag("reusable_id_${scenario.id}")
+                )
+                Text(
+                  text = if (scenario.isCallForm()) {
+                    "Steps: " + scenario.callSteps().joinToString(" -> ") { it.uses }
+                  } else {
+                    scenario.goal
+                  },
+                )
+              }
+              IconActionButton(
+                key = AllIconsKeys.Actions.Edit,
+                onClick = {
+                  editingScenario = scenario
+                  showEditor = true
+                },
+                contentDescription = "Edit reusable scenario",
+                hint = Size(16),
+                modifier = Modifier.testTag("edit_reusable_${scenario.id}")
+              )
+              val references = appStateHolder.reusableScenarioReferences(scenario.id)
+              IconActionButton(
+                key = AllIconsKeys.General.Delete,
+                onClick = {
+                  if (references.isEmpty()) {
+                    appStateHolder.removeReusableScenario(scenario.id)
+                  }
+                },
+                enabled = references.isEmpty(),
+                contentDescription = "Delete reusable scenario",
+                hint = Size(16),
+                modifier = Modifier.testTag("delete_reusable_${scenario.id}")
+              ) {
+                if (references.isNotEmpty()) {
+                  Text("Referenced by: ${references.joinToString(", ")}")
+                }
+              }
+            }
+            Divider(orientation = Orientation.Horizontal)
+          }
+        }
+
+        Row(
+          modifier = Modifier.padding(8.dp).fillMaxWidth(),
+          horizontalArrangement = Arrangement.SpaceBetween
+        ) {
+          OutlinedButton(
+            onClick = {
+              editingScenario = null
+              showEditor = true
+            },
+            modifier = Modifier.testTag("add_reusable_button")
+          ) {
+            Text("Add Reusable Scenario")
+          }
+
+          Row {
+            DefaultButton(
+              onClick = {
+                selectedScenarioId?.let { onScenarioSelected(it) }
+                onCloseRequest()
+              },
+              enabled = selectedScenarioId != null,
+              modifier = Modifier.padding(end = 8.dp).testTag("select_reusable_button")
+            ) {
+              Text("Select")
+            }
+            OutlinedButton(
+              onClick = onCloseRequest,
+              modifier = Modifier.testTag("close_reusable_dialog_button")
+            ) {
+              Text("Close")
+            }
+          }
+        }
+      }
+
+      if (showEditor) {
+        ReusableScenarioEditorDialog(
+          appStateHolder = appStateHolder,
+          existingScenario = editingScenario,
+          onCloseRequest = {
+            showEditor = false
+            editingScenario = null
+          },
+          onSave = { content ->
+            if (editingScenario == null) {
+              appStateHolder.addReusableScenario(content)
+            } else {
+              appStateHolder.updateReusableScenario(content)
+            }
+            showEditor = false
+            editingScenario = null
+          }
+        )
+      }
+    }
+  )
+}
+
+/**
+ * Full editor for one reusable scenario definition, backed by [ArbigentScenarioStateHolder]
+ * so the same option editors as ordinary scenarios are available (goal, type,
+ * initialization methods, AI/MCP options, image assertions, steps, inputs).
+ */
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+private fun ReusableScenarioEditorDialog(
+  appStateHolder: ArbigentAppStateHolder,
+  existingScenario: ArbigentScenarioContent?,
+  onCloseRequest: () -> Unit,
+  onSave: (ArbigentScenarioContent) -> Unit,
+) {
+  val stateHolder = remember(existingScenario) {
+    ArbigentScenarioStateHolder(
+      id = existingScenario?.id ?: "new-reusable-scenario",
+      tagManager = ArbigentTagManager()
+    ).apply {
+      existingScenario?.let { load(it) }
+    }
+  }
+  // Browse target for steps rows inside this editor (local, to avoid nested library dialogs).
+  var stepBrowseIndex by remember { mutableStateOf<Int?>(null) }
+  // Fixed-scenario browse target for MaestroYaml initialization methods inside this editor.
+  var fixedScenarioBrowseIndex by remember { mutableStateOf<Int?>(null) }
+
+  TestCompatibleDialog(
+    onCloseRequest = onCloseRequest,
+    title = if (existingScenario == null) "Add Reusable Scenario" else "Edit Reusable Scenario",
+    content = {
+      Column(
+        modifier = Modifier.padding(16.dp).fillMaxWidth().fillMaxHeight(0.9f)
+      ) {
+        Column(
+          modifier = Modifier.weight(1f).verticalScroll(rememberScrollState())
+        ) {
+          val reusableStepsMode by stateHolder.reusableStepsModeStateFlow.collectAsState()
+          if (reusableStepsMode) {
+            ReusableStepsEditor(
+              scenarioStateHolder = stateHolder,
+              getReusableScenarioById = { appStateHolder.getReusableScenarioById(it) },
+              onBrowseReusableScenarios = { _, index -> stepBrowseIndex = index },
+            )
+          } else {
+            GroupHeader("Goal")
+            TextArea(
+              state = stateHolder.goalState,
+              modifier = Modifier.fillMaxWidth().height(80.dp).padding(4.dp)
+                .testTag("reusable_goal"),
+              placeholder = { Text("Goal (use {{inputs.name}} for declared inputs)") },
+            )
+          }
+          ScenarioOptions(
+            scenarioStateHolder = stateHolder,
+            scenarioCountById = { id ->
+              appStateHolder.reusableScenariosFlow.value.count { it.id == id && it.id != existingScenario?.id }
+            },
+            dependencyScenarioMenu = {},
+            onShowFixedScenariosDialog = { _, index -> fixedScenarioBrowseIndex = index },
+            getFixedScenarioById = { appStateHolder.getFixedScenarioById(it) },
+            mcpServerNames = appStateHolder.mcpServerNamesFlow.collectAsState().value,
+            isReusableDefinition = true,
+          )
+        }
+        Row(
+          modifier = Modifier.padding(8.dp).fillMaxWidth(),
+          horizontalArrangement = Arrangement.End
+        ) {
+          DefaultButton(
+            onClick = { onSave(stateHolder.createArbigentScenarioContent()) },
+            modifier = Modifier.padding(end = 8.dp).testTag("save_reusable_button")
+          ) {
+            Text(if (existingScenario == null) "Add" else "Update")
+          }
+          OutlinedButton(onClick = onCloseRequest) {
+            Text("Cancel")
+          }
+        }
+      }
+
+      stepBrowseIndex?.let { index ->
+        ReusableScenarioPicker(
+          candidates = appStateHolder.reusableScenariosFlow.collectAsState().value
+            .filter { it.id != stateHolder.id },
+          onDismiss = { stepBrowseIndex = null },
+          onPicked = { pickedId ->
+            val steps = stateHolder.reusableStepsStateFlow.value
+            if (index in steps.indices) {
+              stateHolder.onReusableStepChanged(index, steps[index].copy(uses = pickedId))
+            }
+            stepBrowseIndex = null
+          }
+        )
+      }
+
+      if (fixedScenarioBrowseIndex != null) {
+        FixedScenariosDialog(
+          appStateHolder = appStateHolder,
+          onCloseRequest = { fixedScenarioBrowseIndex = null },
+          onScenarioSelected = { fixedScenarioId ->
+            fixedScenarioBrowseIndex?.let { index ->
+              stateHolder.onInitializationMethodChanged(
+                index,
+                ArbigentScenarioContent.InitializationMethod.MaestroYaml(scenarioId = fixedScenarioId)
+              )
+            }
+            fixedScenarioBrowseIndex = null
+          }
+        )
+      }
+    }
+  )
+}
+
+/** Lightweight picker used inside the editor dialog to choose a reusable scenario. */
+@Composable
+private fun ReusableScenarioPicker(
+  candidates: List<ArbigentScenarioContent>,
+  onDismiss: () -> Unit,
+  onPicked: (String) -> Unit,
+) {
+  Dialog(onDismissRequest = onDismiss) {
+    Column(
+      modifier = Modifier.background(JewelTheme.globalColors.panelBackground).padding(16.dp)
+    ) {
+      GroupHeader("Select reusable scenario")
+      if (candidates.isEmpty()) {
+        Text("No reusable scenarios defined yet.")
+      }
+      LazyColumn(modifier = Modifier.heightIn(max = 300.dp)) {
+        items(candidates) { candidate ->
+          Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth().padding(4.dp)
+          ) {
+            OutlinedButton(
+              onClick = { onPicked(candidate.id) },
+              modifier = Modifier.testTag("pick_reusable_${candidate.id}")
+            ) {
+              Text(candidate.id)
+            }
+            Text(
+              text = if (candidate.isCallForm()) {
+                candidate.callSteps().joinToString(" -> ") { it.uses }
+              } else {
+                candidate.goal
+              },
+              modifier = Modifier.padding(start = 8.dp)
+            )
+          }
+        }
+      }
+      Row(horizontalArrangement = Arrangement.End, modifier = Modifier.fillMaxWidth()) {
+        OutlinedButton(onClick = onDismiss) {
+          Text("Cancel")
+        }
+      }
+    }
+  }
+}

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ReusableScenariosDialog.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ReusableScenariosDialog.kt
@@ -228,12 +228,29 @@ private fun ReusableScenarioEditorDialog(
             isReusableDefinition = true,
           )
         }
+        var validationError by remember { mutableStateOf<String?>(null) }
+        validationError?.let { error ->
+          Text(
+            text = error,
+            color = androidx.compose.ui.graphics.Color.Red,
+            modifier = Modifier.padding(8.dp).testTag("reusable_validation_error")
+          )
+        }
         Row(
           modifier = Modifier.padding(8.dp).fillMaxWidth(),
           horizontalArrangement = Arrangement.End
         ) {
           DefaultButton(
-            onClick = { onSave(stateHolder.createArbigentScenarioContent()) },
+            onClick = {
+              val content = stateHolder.createArbigentScenarioContent()
+              // Reject definitions that would make the saved project fail to load.
+              val error = appStateHolder.validateReusableScenarioCandidate(content, existingScenario?.id)
+              if (error == null) {
+                onSave(content)
+              } else {
+                validationError = error
+              }
+            },
             modifier = Modifier.padding(end = 8.dp).testTag("save_reusable_button")
           ) {
             Text(if (existingScenario == null) "Add" else "Update")

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/Scenario.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/Scenario.kt
@@ -79,9 +79,13 @@ fun Scenario(
   onShowFixedScenariosDialog: (ArbigentScenarioStateHolder, Int) -> Unit = { _, _ -> },
   getFixedScenarioById: (String) -> FixedScenario? = { null },
   mcpServerNames: List<String> = emptyList(),
+  onShowReusableScenariosDialog: (ArbigentScenarioStateHolder, Int) -> Unit = { _, _ -> },
+  getReusableScenarioById: (String) -> ArbigentScenarioContent? = { null },
+  onMakeReusable: (ArbigentScenarioStateHolder, String) -> Unit = { _, _ -> },
 ) {
   val arbigentScenarioExecutor: ArbigentScenarioExecutor? by scenarioStateHolder.arbigentScenarioExecutorStateFlow.collectAsState()
   val scenarioType by scenarioStateHolder.scenarioTypeStateFlow.collectAsState()
+  val reusableStepsMode by scenarioStateHolder.reusableStepsModeStateFlow.collectAsState()
   val goal = scenarioStateHolder.goalState
   var goalTextAreaHeight by remember { mutableStateOf(48.dp) }
   Column(
@@ -93,14 +97,22 @@ fun Scenario(
       Column(
         modifier = Modifier.weight(1f)
       ) {
-        TextArea(
-          modifier = Modifier.fillMaxWidth().padding(4.dp).testTag("goal").height(goalTextAreaHeight),
-          enabled = scenarioType.isScenario(),
-          state = goal,
-          placeholder = { Text("Goal") },
-          textStyle = JewelTheme.editorTextStyle,
-          decorationBoxModifier = Modifier.padding(horizontal = 8.dp)
-        )
+        if (reusableStepsMode) {
+          ReusableStepsEditor(
+            scenarioStateHolder = scenarioStateHolder,
+            getReusableScenarioById = getReusableScenarioById,
+            onBrowseReusableScenarios = onShowReusableScenariosDialog,
+          )
+        } else {
+          TextArea(
+            modifier = Modifier.fillMaxWidth().padding(4.dp).testTag("goal").height(goalTextAreaHeight),
+            enabled = scenarioType.isScenario(),
+            state = goal,
+            placeholder = { Text("Goal") },
+            textStyle = JewelTheme.editorTextStyle,
+            decorationBoxModifier = Modifier.padding(horizontal = 8.dp)
+          )
+        }
         Divider(
           orientation = Orientation.Horizontal,
           modifier = Modifier
@@ -161,6 +173,32 @@ fun Scenario(
       ) {
         Text(
           text = "Add sub scenario",
+        )
+      }
+      var makeReusableDialogShowing by remember { mutableStateOf(false) }
+      if (!reusableStepsMode) {
+        IconActionButton(
+          key = AllIconsKeys.Actions.MoveToButton,
+          onClick = {
+            makeReusableDialogShowing = true
+          },
+          contentDescription = "Make this reusable",
+          hint = Size(28),
+          modifier = Modifier.testTag("make_reusable_button")
+        ) {
+          Text(
+            text = "Make this reusable: move the goal and execution options into a reusable scenario and call it from here",
+          )
+        }
+      }
+      if (makeReusableDialogShowing) {
+        MakeReusableDialog(
+          scenarioStateHolder = scenarioStateHolder,
+          onDismiss = { makeReusableDialogShowing = false },
+          onConfirm = { newReusableId ->
+            makeReusableDialogShowing = false
+            onMakeReusable(scenarioStateHolder, newReusableId)
+          }
         )
       }
       var removeDialogShowing by remember { mutableStateOf(false) }
@@ -235,10 +273,11 @@ fun Scenario(
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
-private fun ScenarioFundamentalOptions(
+internal fun ScenarioFundamentalOptions(
   scenarioStateHolder: ArbigentScenarioStateHolder,
   scenarioCountById: (String) -> Int,
-  dependencyScenarioMenu: MenuScope.() -> Unit
+  dependencyScenarioMenu: MenuScope.() -> Unit,
+  isReusableDefinition: Boolean = false,
 ) {
   val updatedScenarioStateHolder by rememberUpdatedState(scenarioStateHolder)
   FlowRow {
@@ -294,20 +333,22 @@ private fun ScenarioFundamentalOptions(
         decorationBoxModifier = Modifier.padding(horizontal = 8.dp),
       )
     }
-    // Dependency
-    Column(
-      modifier = Modifier.padding(8.dp).width(160.dp)
-    ) {
-      GroupHeader("Scenario dependency")
-      val dependency by updatedScenarioStateHolder.dependencyScenarioStateHolderStateFlow.collectAsState()
-
-      Dropdown(
-        modifier = Modifier
-          .testTag("dependency_dropdown")
-          .padding(4.dp),
-        menuContent = dependencyScenarioMenu
+    // Dependency (not allowed on reusable scenario definitions)
+    if (!isReusableDefinition) {
+      Column(
+        modifier = Modifier.padding(8.dp).width(160.dp)
       ) {
-        Text(dependency?.goal ?: "Select dependency")
+        GroupHeader("Scenario dependency")
+        val dependency by updatedScenarioStateHolder.dependencyScenarioStateHolderStateFlow.collectAsState()
+
+        Dropdown(
+          modifier = Modifier
+            .testTag("dependency_dropdown")
+            .padding(4.dp),
+          menuContent = dependencyScenarioMenu
+        ) {
+          Text(dependency?.let { it.goal.ifBlank { it.id } } ?: "Select dependency")
+        }
       }
     }
     // Scenario type
@@ -324,18 +365,21 @@ private fun ScenarioFundamentalOptions(
         ) {
           Text(
             text = "Scenario: The agent will try to achieve the goal. \n" +
-              "Execution: Just execute the initializations and image assertions.",
+              "Execution: Just execute the initializations and image assertions. \n" +
+              "Reusable steps: Call reusable scenarios in order instead of having a goal.",
           )
         }
       }
       val inputActionType by updatedScenarioStateHolder.scenarioTypeStateFlow.collectAsState()
+      val reusableStepsMode by updatedScenarioStateHolder.reusableStepsModeStateFlow.collectAsState()
       Row(
         verticalAlignment = Alignment.CenterVertically
       ) {
         RadioButtonRow(
           text = "Scenario",
-          selected = inputActionType == ArbigentScenarioType.Scenario,
+          selected = !reusableStepsMode && inputActionType == ArbigentScenarioType.Scenario,
           onClick = {
+            updatedScenarioStateHolder.onReusableStepsModeChanged(false)
             updatedScenarioStateHolder.scenarioTypeStateFlow.value = ArbigentScenarioType.Scenario
           }
         )
@@ -345,10 +389,23 @@ private fun ScenarioFundamentalOptions(
       ) {
         RadioButtonRow(
           text = "Execution",
-          selected = inputActionType == ArbigentScenarioType.Execution,
+          selected = !reusableStepsMode && inputActionType == ArbigentScenarioType.Execution,
           onClick = {
+            updatedScenarioStateHolder.onReusableStepsModeChanged(false)
             updatedScenarioStateHolder.scenarioTypeStateFlow.value = ArbigentScenarioType.Execution
           }
+        )
+      }
+      Row(
+        verticalAlignment = Alignment.CenterVertically
+      ) {
+        RadioButtonRow(
+          text = "Reusable steps",
+          selected = reusableStepsMode,
+          onClick = {
+            updatedScenarioStateHolder.onReusableStepsModeChanged(true)
+          },
+          modifier = Modifier.testTag("reusable_steps_radio")
         )
       }
     }
@@ -427,17 +484,28 @@ private fun ScenarioFundamentalOptions(
 
 @OptIn(ExperimentalLayoutApi::class, ExperimentalFoundationApi::class)
 @Composable
-private fun ScenarioOptions(
+internal fun ScenarioOptions(
   scenarioStateHolder: ArbigentScenarioStateHolder,
   scenarioCountById: (String) -> Int,
   dependencyScenarioMenu: MenuScope.() -> Unit,
   onShowFixedScenariosDialog: (ArbigentScenarioStateHolder, Int) -> Unit = { _, _ -> },
   getFixedScenarioById: (String) -> FixedScenario? = { null },
-  mcpServerNames: List<String> = emptyList()
+  mcpServerNames: List<String> = emptyList(),
+  isReusableDefinition: Boolean = false,
 ) {
   val updatedScenarioStateHolder by rememberUpdatedState(scenarioStateHolder)
+  val reusableStepsMode by scenarioStateHolder.reusableStepsModeStateFlow.collectAsState()
   GroupHeader("Fundamental options")
-  ScenarioFundamentalOptions(scenarioStateHolder, scenarioCountById, dependencyScenarioMenu)
+  ScenarioFundamentalOptions(scenarioStateHolder, scenarioCountById, dependencyScenarioMenu, isReusableDefinition)
+  if (isReusableDefinition) {
+    GroupHeader("Inputs")
+    ReusableInputsEditor(scenarioStateHolder)
+  }
+  if (reusableStepsMode) {
+    // A call-form scenario has no execution options of its own; what runs is
+    // determined entirely by the reusable definitions it calls.
+    return
+  }
   GroupHeader("Other options")
   FlowRow(modifier = Modifier.padding(4.dp)) {
     Column(
@@ -985,7 +1053,12 @@ fun LaunchAppInitializationSetting(
   }
 }
 
-data class ScenarioSection(val goal: String, val isRunning: Boolean, val steps: List<StepItem>) {
+data class ScenarioSection(
+  val goal: String,
+  val isRunning: Boolean,
+  val steps: List<StepItem>,
+  val callBreadcrumb: String? = null,
+) {
   fun isAchieved(): Boolean {
     return steps.any { it.isAchieved() }
   }
@@ -1012,7 +1085,9 @@ fun buildSections(tasksToAgent: List<ArbigentTaskAssignment>): List<ScenarioSect
     sections += ScenarioSection(
       goal = tasks.goal,
       isRunning = isRunning,
-      steps = steps.map { StepItem(it) })
+      steps = steps.map { StepItem(it) },
+      callBreadcrumb = tasks.callBreadcrumb,
+    )
   }
   return sections
 }
@@ -1064,7 +1139,9 @@ private fun ContentPanel(
       LazyColumn(state = lazyColumnState, modifier = Modifier.weight(1.5f)) {
         sections.forEachIndexed { index, section ->
           stickyHeader {
-            val prefix = if (index + 1 == tasksToAgent.size) {
+            val prefix = if (section.callBreadcrumb != null) {
+              section.callBreadcrumb + ": "
+            } else if (index + 1 == tasksToAgent.size) {
               "Goal: "
             } else {
               "Dependency scenario goal: "

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/Scenario.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/Scenario.kt
@@ -396,6 +396,7 @@ internal fun ScenarioFundamentalOptions(
           }
         )
       }
+      var confirmReusableStepsSwitch by remember { mutableStateOf(false) }
       Row(
         verticalAlignment = Alignment.CenterVertically
       ) {
@@ -403,10 +404,48 @@ internal fun ScenarioFundamentalOptions(
           text = "Reusable steps",
           selected = reusableStepsMode,
           onClick = {
-            updatedScenarioStateHolder.onReusableStepsModeChanged(true)
+            val hasLeafContent = updatedScenarioStateHolder.goal.isNotBlank() ||
+              updatedScenarioStateHolder.initializationMethodStateFlow.value.isNotEmpty() ||
+              updatedScenarioStateHolder.imageAssertionsStateFlow.value.isNotEmpty()
+            if (!reusableStepsMode && hasLeafContent) {
+              confirmReusableStepsSwitch = true
+            } else {
+              updatedScenarioStateHolder.onReusableStepsModeChanged(true)
+            }
           },
           modifier = Modifier.testTag("reusable_steps_radio")
         )
+      }
+      if (confirmReusableStepsSwitch) {
+        Dialog(onDismissRequest = { confirmReusableStepsSwitch = false }) {
+          Column(
+            modifier = Modifier.background(JewelTheme.globalColors.panelBackground).padding(16.dp)
+          ) {
+            Text(
+              "Switching to Reusable steps: the goal, initialization methods and image assertions\n" +
+                "of this scenario will not be saved while in this mode.\n" +
+                "To keep them, use \"Make this reusable\" instead — it moves them into a reusable\n" +
+                "scenario and calls it from here."
+            )
+            Row(modifier = Modifier.padding(top = 8.dp)) {
+              OutlinedButton(
+                onClick = { confirmReusableStepsSwitch = false },
+                modifier = Modifier.padding(end = 8.dp)
+              ) {
+                Text("Cancel")
+              }
+              OutlinedButton(
+                onClick = {
+                  confirmReusableStepsSwitch = false
+                  updatedScenarioStateHolder.onReusableStepsModeChanged(true)
+                },
+                modifier = Modifier.testTag("confirm_reusable_steps_switch")
+              ) {
+                Text("Switch anyway")
+              }
+            }
+          }
+        }
       }
     }
     // Form factor

--- a/arbigent-ui/src/test/kotlin/ReusableScenarioUiStateTest.kt
+++ b/arbigent-ui/src/test/kotlin/ReusableScenarioUiStateTest.kt
@@ -1,0 +1,115 @@
+package io.github.takahirom.arbigent.ui
+
+import io.github.takahirom.arbigent.*
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ReusableScenarioUiStateTest {
+
+  @Before
+  fun setup() {
+    globalKeyStoreFactory = TestKeyStoreFactory()
+  }
+
+  private fun holderOf(content: ArbigentScenarioContent) =
+    ArbigentScenarioStateHolder(id = content.id, tagManager = ArbigentTagManager()).apply {
+      load(content)
+    }
+
+  @Test
+  fun `call-form content round-trips through the state holder`() {
+    val content = ArbigentScenarioContent(
+      id = "combo",
+      steps = listOf(
+        ArbigentScenarioContent.ReusableStep(uses = "login", withValues = mapOf("user" to "paid")),
+        ArbigentScenarioContent.ReusableStep(uses = "play-premium-content"),
+      ),
+    )
+    val holder = holderOf(content)
+    assertTrue(holder.reusableStepsModeStateFlow.value)
+
+    val recreated = holder.createArbigentScenarioContent()
+    assertTrue(recreated.isCallForm())
+    assertEquals(content.callSteps(), recreated.callSteps())
+    assertEquals("", recreated.goal)
+  }
+
+  @Test
+  fun `single uses sugar round-trips through the state holder`() {
+    val content = ArbigentScenarioContent(
+      id = "call-login",
+      uses = "login",
+      withValues = mapOf("user" to "paid"),
+    )
+    val holder = holderOf(content)
+    val recreated = holder.createArbigentScenarioContent()
+    // Single-entry steps are written back using the uses sugar.
+    assertEquals("login", recreated.uses)
+    assertEquals(mapOf("user" to "paid"), recreated.withValues)
+    assertEquals(emptyList<ArbigentScenarioContent.ReusableStep>(), recreated.steps)
+  }
+
+  @Test
+  fun `reusable inputs round-trip through the state holder`() {
+    val content = ArbigentScenarioContent(
+      id = "login",
+      goal = "Log in as {{inputs.user}}",
+      inputs = mapOf(
+        "user" to ArbigentScenarioContent.ReusableInput(required = true),
+        "method" to ArbigentScenarioContent.ReusableInput(default = "email"),
+      ),
+    )
+    val holder = holderOf(content)
+    val recreated = holder.createArbigentScenarioContent()
+    assertEquals(content.inputs, recreated.inputs)
+    assertEquals(content.goal, recreated.goal)
+  }
+
+  @Test
+  fun `make this reusable moves content and converts scenario to call node`() {
+    val appStateHolder = ArbigentAppStateHolder(aiFactory = { FakeAi() })
+    val holder = ArbigentScenarioStateHolder(id = "login-test", tagManager = ArbigentTagManager()).apply {
+      load(
+        ArbigentScenarioContent(
+          id = "login-test",
+          goal = "Log in as paid user",
+          maxStep = 25,
+          initializationMethods = listOf(ArbigentScenarioContent.InitializationMethod.Back(2)),
+        )
+      )
+    }
+
+    appStateHolder.makeScenarioReusable(holder, "login-part")
+
+    val reusable = appStateHolder.getReusableScenarioById("login-part")!!
+    assertEquals("Log in as paid user", reusable.goal)
+    assertEquals(25, reusable.maxStep)
+    assertEquals(
+      listOf<ArbigentScenarioContent.InitializationMethod>(
+        ArbigentScenarioContent.InitializationMethod.Back(2)
+      ),
+      reusable.initializationMethods
+    )
+
+    // The original scenario keeps its id and becomes a call node.
+    assertEquals("login-test", holder.id)
+    assertTrue(holder.reusableStepsModeStateFlow.value)
+    val converted = holder.createArbigentScenarioContent()
+    assertEquals("login-part", converted.callSteps().single().uses)
+    assertEquals("", converted.goal)
+    assertTrue(converted.initializationMethods.isEmpty())
+  }
+
+  @Test
+  fun `reusable scenario references are detected for delete protection`() {
+    val appStateHolder = ArbigentAppStateHolder(aiFactory = { FakeAi() })
+    appStateHolder.addReusableScenario(ArbigentScenarioContent(id = "part", goal = "goal"))
+    appStateHolder.addReusableScenario(
+      ArbigentScenarioContent(id = "composite", steps = listOf(ArbigentScenarioContent.ReusableStep(uses = "part")))
+    )
+    assertEquals(listOf("composite"), appStateHolder.reusableScenarioReferences("part"))
+    assertEquals(emptyList<String>(), appStateHolder.reusableScenarioReferences("composite"))
+  }
+}

--- a/arbigent-ui/src/test/kotlin/ReusableScenarioUiStateTest.kt
+++ b/arbigent-ui/src/test/kotlin/ReusableScenarioUiStateTest.kt
@@ -103,6 +103,31 @@ class ReusableScenarioUiStateTest {
   }
 
   @Test
+  fun `renaming a reusable scenario rewrites references from scenarios and composites`() {
+    val appStateHolder = ArbigentAppStateHolder(aiFactory = { FakeAi() })
+    appStateHolder.addReusableScenario(ArbigentScenarioContent(id = "part", goal = "goal"))
+    appStateHolder.addReusableScenario(
+      ArbigentScenarioContent(id = "composite", steps = listOf(ArbigentScenarioContent.ReusableStep(uses = "part")))
+    )
+    val callerHolder = ArbigentScenarioStateHolder(id = "caller", tagManager = ArbigentTagManager()).apply {
+      load(ArbigentScenarioContent(id = "caller", uses = "part"))
+    }
+    // Register the caller so the rename can reach it (mirrors loadProjectContents wiring).
+    appStateHolder.addScenarioStateHolder(callerHolder)
+
+    appStateHolder.updateReusableScenario(
+      ArbigentScenarioContent(id = "part-renamed", goal = "goal"),
+      originalId = "part"
+    )
+
+    assertEquals(
+      "part-renamed",
+      appStateHolder.getReusableScenarioById("composite")!!.callSteps().single().uses
+    )
+    assertEquals("part-renamed", callerHolder.reusableStepsStateFlow.value.single().uses)
+  }
+
+  @Test
   fun `reusable scenario references are detected for delete protection`() {
     val appStateHolder = ArbigentAppStateHolder(aiFactory = { FakeAi() })
     appStateHolder.addReusableScenario(ArbigentScenarioContent(id = "part", goal = "goal"))

--- a/sample-test/src/main/resources/projects/e2e-test-android.yaml
+++ b/sample-test/src/main/resources/projects/e2e-test-android.yaml
@@ -73,6 +73,24 @@ scenarios:
   tags:
   - name: "EscapedVariable"
   - name: "Settings"
+- id: "reusable-scenario-test"
+  uses: "search-in-settings"
+  with:
+    term: "Battery"
+  tags:
+  - name: "ReusableScenario"
+  - name: "Settings"
+reusableScenarios:
+- id: "search-in-settings"
+  inputs:
+    term:
+      required: true
+  goal: "Search for {{inputs.term}} in the Settings app and verify it appears in search results"
+  initializationMethods:
+  - type: "Back"
+    times: 5
+  - type: "LaunchApp"
+    packageName: "com.android.settings"
 fixedScenarios:
 - id: "3c441e6f-6178-4b4f-b2a2-fbdbf8fa4266"
   title: "launch setting by maestro"


### PR DESCRIPTION
## Overview

Adds **reusable scenarios** — project-level AI scenario parts callable from any scenario with parameters, modeled after GitHub Actions reusable workflows (`uses` / `with` / `inputs`). Design spec: [arbigent-reusable-scenarios-specification.md](../blob/takahirom/reusable-scenarios/arbigent-reusable-scenarios-specification.md).

```yaml
scenarios:
- id: "premium-content-with-paid-user"
  steps:
  - uses: "login"
    with: { user: "paid" }
  - uses: "play-premium-content"
reusableScenarios:
- id: "login"
  inputs:
    user: { required: true }
  goal: "Log in with the {{inputs.user}} account"
```

## What's included

- **Model/serialization**: `reusableScenarios` top-level list; scenarios are either a leaf (`goal` + full option set) or a call (`uses`+`with`, or `steps`; `uses` is sugar for single-entry `steps`)
- **Expansion**: call-form scenarios expand into the existing flat `ArbigentAgentTask` list; composites nest; ordinary and call nodes mix freely along dependency chains
- **Inputs**: declared via `inputs` (`required`/`default`), referenced as `{{inputs.name}}` in goals and in Maestro YAML referenced from a reusable's initialization methods (`yamlContent` is preferred by the initializer when substitution happened). Bare `{{name}}` still resolves project variables at runtime
- **Load-time validation**: unknown refs, cycles, leaf/call field mixing, undeclared `with` keys, missing required inputs, `{{inputs.*}}` misuse, and reserved chars (`/ # @`, kept for future cross-file refs) all fail at project load with an aggregated message
- **Reports**: each expanded task carries a call breadcrumb (`caller › part (key=value)`) shown in the GUI logs and web report
- **GUI**: third "Reusable steps" scenario type radio; steps editor with Browse dialog and `with` fields generated from input declarations; Reusable Scenarios library dialog with full editor (reuses the scenario option editors); "Make this reusable" extraction with confirmation dialog; delete protection while referenced; tree labels for call nodes
- **CLI**: works transparently; invalid projects fail fast

## Testing

- 24 core unit tests (expansion, validation, substitution, round-trip, Maestro substitution executed via fake device) + 5 UI state tests; full `:arbigent-core:test :arbigent-ui:test :arbigent-cli:test` green
- On-device E2E: `reusable-scenario-test` added to `e2e-test-android.yaml` (runs in CI) verified locally on an emulator — goal substitution, breadcrumb in `result.yml`, and goal achievement all confirmed