### PR TITLE
Add search by goal and note to scenario list panel

### DIFF
--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/LeftScenariosPanel.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/LeftScenariosPanel.kt
@@ -62,6 +62,8 @@ internal fun LeftScenariosPanel(
 ) {
   // Map to manage expanded/collapsed state (scenario holder -> expanded state)
   val expandedStates = remember { mutableStateMapOf<ArbigentScenarioStateHolder, Boolean>() }
+  var isSearchVisible by remember { mutableStateOf(false) }
+  val searchTextState = rememberTextFieldState()
   Column(
     Modifier
       .run {
@@ -93,10 +95,33 @@ internal fun LeftScenariosPanel(
           appStateHolder.projectDialogState.value = ProjectDialogState.ShowGenerateScenarioDialog
         },
         contentDescription = "Generate",
-        hint = Size(28)
+        hint = Size(28),
+        modifier = Modifier.padding(end = 8.dp)
       ) {
         Text("Generate scenario")
       }
+
+      IconActionButton(
+        key = AllIconsKeys.Actions.Find,
+        onClick = {
+          isSearchVisible = !isSearchVisible
+        },
+        contentDescription = "Search",
+        hint = Size(28),
+        modifier = Modifier.testTag("scenario_search_button")
+      ) {
+        Text("Search scenarios")
+      }
+    }
+    if (isSearchVisible) {
+      TextField(
+        state = searchTextState,
+        placeholder = { Text("Search by goal or note") },
+        modifier = Modifier
+          .fillMaxWidth()
+          .padding(start = 8.dp, end = 8.dp, bottom = 8.dp)
+          .testTag("scenario_search_field")
+      )
     }
     Box {
       if (scenarioAndDepths.isNotEmpty()) {
@@ -115,9 +140,10 @@ internal fun LeftScenariosPanel(
       // Pre-compute visibility using derivedStateOf to avoid recomputation on unrelated recompositions
       val visibleIndices by remember(scenarioAndDepths, expandedStates) {
         derivedStateOf {
+          val query = if (isSearchVisible) searchTextState.text.toString().trim() else ""
           val indices = mutableSetOf<Int>()
           val ancestorStack = mutableListOf<Pair<Int, ArbigentScenarioStateHolder>>()
-          
+
           scenarioAndDepths.forEachIndexed { index, (scenarioHolder, depth) ->
             // Pop ancestors that are at same or deeper level
             while (ancestorStack.isNotEmpty()) {
@@ -128,16 +154,27 @@ internal fun LeftScenariosPanel(
                 break
               }
             }
-            
-            // Check if all ancestors are expanded
-            val allAncestorsExpanded = ancestorStack.all { (_, ancestorHolder) ->
-              expandedStates.getOrDefault(ancestorHolder, true)
+
+            if (query.isNotEmpty()) {
+              // While searching, show matches (by goal or note) and their ancestors,
+              // ignoring the collapsed state so matches are never hidden
+              val matches = scenarioHolder.goalState.text.contains(query, ignoreCase = true) ||
+                scenarioHolder.noteForHumans.text.contains(query, ignoreCase = true)
+              if (matches) {
+                indices.add(index)
+                ancestorStack.forEach { (ancestorIndex, _) -> indices.add(ancestorIndex) }
+              }
+            } else {
+              // Check if all ancestors are expanded
+              val allAncestorsExpanded = ancestorStack.all { (_, ancestorHolder) ->
+                expandedStates.getOrDefault(ancestorHolder, true)
+              }
+
+              if (allAncestorsExpanded) {
+                indices.add(index)
+              }
             }
-            
-            if (allAncestorsExpanded) {
-              indices.add(index)
-            }
-            
+
             // Add current item to ancestor stack for its potential children
             ancestorStack.add(index to scenarioHolder)
           }

--- a/arbigent-ui/src/test/kotlin/UiTests.kt
+++ b/arbigent-ui/src/test/kotlin/UiTests.kt
@@ -92,6 +92,23 @@ class UiTests(private val behavior: DescribedBehavior<TestRobot>) {
           }
         }
 
+        describe("when search scenarios") {
+          doIt {
+            clickConnectToDeviceButton()
+            clickAddScenarioButton()
+            enterGoal("Login with valid account")
+            clickAddScenarioButton()
+            enterGoal("Open settings screen")
+            clickSearchScenariosButton()
+            enterSearchQuery("login")
+          }
+          itShould("show only matching scenario") {
+            capture(it)
+            assertScenarioListItemExists("Login with valid account")
+            assertScenarioListItemDoesNotExist("Open settings screen")
+          }
+        }
+
         describe("when add scenario") {
           doIt {
             clickConnectToDeviceButton()
@@ -518,6 +535,24 @@ class TestRobot(
   fun clickGenerateScenarioButton() {
     composeUiTest.onNode(hasContentDescription("Generate")).performClick()
     waitALittle()
+  }
+
+  fun clickSearchScenariosButton() {
+    composeUiTest.onNode(hasTestTag("scenario_search_button")).performClick()
+    waitALittle()
+  }
+
+  fun enterSearchQuery(query: String) {
+    composeUiTest.onNode(hasTestTag("scenario_search_field")).performTextInput(query)
+    waitALittle()
+  }
+
+  fun assertScenarioListItemExists(goal: String) {
+    composeUiTest.onNode(hasText("Goal: $goal", substring = true)).assertExists()
+  }
+
+  fun assertScenarioListItemDoesNotExist(goal: String) {
+    composeUiTest.onNode(hasText("Goal: $goal", substring = true)).assertDoesNotExist()
   }
 
   fun enterScenariosToGenerate(scenarios: String) {


### PR DESCRIPTION
# What
Add a search toggle button next to "Generate scenario" in the left scenarios panel. It opens a text field that filters the scenario list by goal or note (case-insensitive). Ancestors of matching scenarios stay visible so the tree structure is preserved, and collapsed state is ignored while searching so matches are never hidden.

# Why
Projects with many scenarios make it hard to locate a specific one in the list; filtering by goal and note makes navigation faster.