### PR TITLE
Upgrade to Kotlin 2.3.21, Compose 1.10.3 and Jewel 0.37

### DIFF
--- a/.github/workflows/build-ui.yaml
+++ b/.github/workflows/build-ui.yaml
@@ -29,7 +29,8 @@ jobs:
       - uses: actions/setup-java@v4
         with:
           distribution: 'jetbrains'
-          java-version: '17'
+          # Jewel 0.32+ requires Java 21; jpackage bundles this JDK into the app.
+          java-version: '21'
           java-package: 'jdk' # optional (jdk, jre, jdk+jcef, jre+jcef, jdk+ft, or jre+ft) - defaults to jdk
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/arbigent-cli/build.gradle.kts
+++ b/arbigent-cli/build.gradle.kts
@@ -95,7 +95,7 @@ tasks.test {
 
 dependencies {
   implementation("com.github.ajalt.clikt:clikt:5.0.2")
-  implementation("com.jakewharton.mosaic:mosaic-runtime:0.17.0")
+  implementation("com.jakewharton.mosaic:mosaic-runtime:0.18.0")
   implementation("com.charleskorn.kaml:kaml:0.83.0")
   implementation(project(":arbigent-core"))
   implementation(project(":arbigent-ai-openai"))

--- a/arbigent-core-web-report/build.gradle.kts
+++ b/arbigent-core-web-report/build.gradle.kts
@@ -11,7 +11,7 @@ plugins {
 kotlin {
   explicitApi()
   js(IR) {
-    moduleName = "arbigentreport"
+    outputModuleName.set("arbigentreport")
     browser {
     }
     binaries.executable()

--- a/arbigent-ui/build.gradle.kts
+++ b/arbigent-ui/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
   id("org.jetbrains.kotlin.jvm") version libs.versions.kotlin
   id("org.jetbrains.compose")
   id("org.jetbrains.kotlin.plugin.compose")
-  id("io.github.takahirom.roborazzi") version "1.44.0-alpha02"
+  id("io.github.takahirom.roborazzi") version "1.68.0"
   id("org.jetbrains.kotlin.plugin.serialization")
   id("com.palantir.git-version") version "0.15.0"
 }
@@ -15,7 +15,8 @@ version = gitVersion()
 
 kotlin {
   java.toolchain {
-    languageVersion.set(JavaLanguageVersion.of(17))
+    // Jewel 0.32+ ships class files compiled for Java 21.
+    languageVersion.set(JavaLanguageVersion.of(21))
   }
 }
 
@@ -28,9 +29,9 @@ dependencies {
   implementation(compose.desktop.currentOs) {
     exclude(group = "org.jetbrains.compose.material")
   }
-  implementation("org.jetbrains.jewel:jewel-int-ui-standalone-243:0.27.0")
-  implementation("org.jetbrains.jewel:jewel-int-ui-decorated-window-243:0.27.0")
-  implementation("com.jetbrains.intellij.platform:icons:243.22562.218")
+  implementation("org.jetbrains.jewel:jewel-int-ui-standalone:0.37.0-261.26222.65")
+  implementation("org.jetbrains.jewel:jewel-int-ui-decorated-window:0.37.0-261.26222.65")
+  implementation("com.jetbrains.intellij.platform:icons:261.26222.65")
   implementation("com.charleskorn.kaml:kaml:0.67.0")
   implementation(libs.kotlinx.serialization.json)
   implementation("com.github.javakeyring:java-keyring:1.0.4")
@@ -40,7 +41,7 @@ dependencies {
   testImplementation(compose.uiTest)
   testImplementation("io.github.takahirom.robospec:robospec:0.2.0")
   // roborazzi
-  testImplementation("io.github.takahirom.roborazzi:roborazzi-compose-desktop:1.44.0-alpha03")
+  testImplementation("io.github.takahirom.roborazzi:roborazzi-compose-desktop:1.68.0")
   implementation(project(":arbigent-core"))
   implementation(project(":arbigent-ai-openai"))
   implementation("io.github.takahirom.rin:rin:0.3.0")

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/App.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/App.kt
@@ -286,11 +286,9 @@ fun ScenarioControls(appStateHolder: ArbigentAppStateHolder) {
       Column {
         ArbigentDeviceOs.entries.forEach { item ->
           val isSelected = item == deviceOs
-          val isItemHovered = false
-          val isPreviewSelection = false
           SimpleListItem(
             text = item.name,
-            state = ListItemState(isSelected, isItemHovered, isPreviewSelection),
+            state = ListItemState(isSelected),
             modifier = Modifier
               .clickable {
                 devicesStateHolder.selectedDeviceOs.value = item
@@ -298,7 +296,6 @@ fun ScenarioControls(appStateHolder: ArbigentAppStateHolder) {
                 devicesStateHolder.onSelectedDeviceChanged(null)
               },
             style = JewelTheme.simpleListItemStyle,
-            contentDescription = item.name,
           )
         }
       }
@@ -315,11 +312,9 @@ fun ScenarioControls(appStateHolder: ArbigentAppStateHolder) {
       Column {
         items.forEach { itemText ->
           val isSelected = itemText == selectedDevice?.name
-          val isItemHovered = false
-          val isPreviewSelection = false
           SimpleListItem(
             text = itemText,
-            state = ListItemState(isSelected, isItemHovered, isPreviewSelection),
+            state = ListItemState(isSelected),
             modifier = Modifier
               .clickable {
                 devicesStateHolder.onSelectedDeviceChanged(devicesStateHolder.devices.value.firstOrNull { it.name == itemText })
@@ -328,7 +323,6 @@ fun ScenarioControls(appStateHolder: ArbigentAppStateHolder) {
                 }
               },
             style = JewelTheme.simpleListItemStyle,
-            contentDescription = itemText,
           )
         }
       }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ReusableScenarioComponents.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ReusableScenarioComponents.kt
@@ -96,15 +96,16 @@ internal fun ReusableStepsEditor(
             text = name + if (input.required && input.default == null) " *" else "",
             modifier = Modifier.width(120.dp)
           )
-          TextField(
+          ValueTextField(
             value = step.withValues[name] ?: "",
             onValueChange = { newValue ->
               val newWith = step.withValues.toMutableMap()
               if (newValue.isEmpty()) newWith.remove(name) else newWith[name] = newValue
               scenarioStateHolder.onReusableStepChanged(index, step.copy(withValues = newWith))
             },
-            placeholder = { Text(input.default ?: "") },
-            modifier = Modifier.width(200.dp).testTag("reusable_step_with_${index}_$name")
+            placeholder = input.default ?: "",
+            modifier = Modifier.width(200.dp).testTag("reusable_step_with_${index}_$name"),
+            resetKey = "$index:${step.uses}:$name",
           )
         }
       }
@@ -133,11 +134,12 @@ internal fun ReusableInputsEditor(
         verticalAlignment = Alignment.CenterVertically,
         modifier = Modifier.padding(vertical = 2.dp)
       ) {
-        TextField(
+        ValueTextField(
           value = name,
           onValueChange = { scenarioStateHolder.onReusableInputChanged(index, it, input) },
-          placeholder = { Text("Input name") },
-          modifier = Modifier.width(160.dp).testTag("reusable_input_name_$index")
+          placeholder = "Input name",
+          modifier = Modifier.width(160.dp).testTag("reusable_input_name_$index"),
+          resetKey = index,
         )
         Checkbox(
           checked = input.required,
@@ -147,15 +149,16 @@ internal fun ReusableInputsEditor(
           modifier = Modifier.padding(start = 8.dp)
         )
         Text("required")
-        TextField(
+        ValueTextField(
           value = input.default ?: "",
           onValueChange = {
             scenarioStateHolder.onReusableInputChanged(
               index, name, input.copy(default = it.ifEmpty { null })
             )
           },
-          placeholder = { Text("Default value") },
-          modifier = Modifier.width(160.dp).padding(start = 8.dp)
+          placeholder = "Default value",
+          modifier = Modifier.width(160.dp).padding(start = 8.dp),
+          resetKey = index,
         )
         IconActionButton(
           key = AllIconsKeys.General.Delete,

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/Scenario.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/Scenario.kt
@@ -702,17 +702,18 @@ internal fun ScenarioOptions(
               modifier = Modifier.padding(4.dp),
               text = "Image assertion ${index + 1}"
             )
-            TextField(
+            ValueTextField(
               modifier = Modifier
                 .padding(4.dp)
                 .testTag("image_assertion"),
-              placeholder = { Text("XX button should exist") },
+              placeholder = "XX button should exist",
               value = imageAssertion.assertionPrompt,
               onValueChange = {
                 val newImageAssertions = imageAssertions.toMutableList()
                 newImageAssertions[index] = imageAssertion.copy(assertionPrompt = it)
                 updatedScenarioStateHolder.imageAssertionsStateFlow.value = newImageAssertions
               },
+              resetKey = index,
             )
           }
 
@@ -804,7 +805,7 @@ private fun InitializationOptions(
       verticalAlignment = Alignment.CenterVertically
     ) {
       if (initializeMethod is ArbigentScenarioContent.InitializationMethod.CleanupData) {
-        TextField(
+        ValueTextField(
           modifier = Modifier
             .testTag("cleanup_pacakge")
             .padding(4.dp),
@@ -815,52 +816,43 @@ private fun InitializationOptions(
               index,
               ArbigentScenarioContent.InitializationMethod.CleanupData(it)
             )
-          }
+          },
+          resetKey = index,
         )
       }
       Column {
         if (initializeMethod is ArbigentScenarioContent.InitializationMethod.Back) {
-          var editingText by remember(initializeMethod) {
-            mutableStateOf(
-              (initializeMethod as? ArbigentScenarioContent.InitializationMethod.Back)?.times.toString()
-            )
-          }
-          TextField(
+          ValueTextField(
             modifier = Modifier
               .padding(4.dp),
-            value = editingText,
-            placeholder = { Text("Times") },
+            value = initializeMethod.times.toString(),
+            placeholder = "Times",
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             onValueChange = {
-              editingText = it
               scenarioStateHolder.onInitializationMethodChanged(
                 index,
                 ArbigentScenarioContent.InitializationMethod.Back(it.toIntOrNull() ?: 1)
               )
             },
+            resetKey = index,
           )
         }
       }
       Row {
         if (initializeMethod is ArbigentScenarioContent.InitializationMethod.Wait) {
-          var editingText by remember(initializeMethod) {
-            mutableStateOf(
-              (initializeMethod as? ArbigentScenarioContent.InitializationMethod.Wait)?.durationMs.toString()
-            )
-          }
-          TextField(
+          ValueTextField(
             modifier = Modifier
               .padding(4.dp),
-            value = editingText,
-            placeholder = { Text("Duration(ms)") },
+            value = initializeMethod.durationMs.toString(),
+            placeholder = "Duration(ms)",
             keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
             onValueChange = {
-              editingText = it
               scenarioStateHolder.onInitializationMethodChanged(
                 index,
                 ArbigentScenarioContent.InitializationMethod.Wait(it.toLongOrNull() ?: 0)
               )
             },
+            resetKey = index,
           )
           Text(
             "ms",
@@ -902,17 +894,17 @@ private fun InitializationOptions(
       }
       Column {
         if (initializeMethod is ArbigentScenarioContent.InitializationMethod.OpenLink) {
-          TextField(
+          ValueTextField(
             modifier = Modifier
               .padding(4.dp),
-            value = (initializeMethod as? ArbigentScenarioContent.InitializationMethod.OpenLink)?.link
-              ?: "",
+            value = initializeMethod.link,
             onValueChange = {
               scenarioStateHolder.onInitializationMethodChanged(
                 index,
                 ArbigentScenarioContent.InitializationMethod.OpenLink(it)
               )
             },
+            resetKey = index,
           )
         }
       }
@@ -974,10 +966,10 @@ fun LaunchAppInitializationSetting(
 ) {
   Column {
     if (initializeMethod is ArbigentScenarioContent.InitializationMethod.LaunchApp) {
-      TextField(
+      ValueTextField(
         modifier = Modifier.padding(4.dp).testTag("launch_app_package"),
         value = editingText,
-        placeholder = { Text("Package name") },
+        placeholder = "Package name",
         onValueChange = onPackageChange
       )
       val arguments by rememberUpdatedState(
@@ -986,10 +978,10 @@ fun LaunchAppInitializationSetting(
       )
       arguments.forEach { (key, value: ArbigentScenarioContent.InitializationMethod.LaunchApp.ArgumentValue) ->
         Row {
-          TextField(
+          ValueTextField(
             modifier = Modifier.weight(1f).padding(4.dp),
             value = key,
-            placeholder = { Text("key") },
+            placeholder = "key",
             onValueChange = { newKey ->
               val newArguments = arguments.toMutableMap()
               newArguments.remove(key)
@@ -1042,10 +1034,11 @@ fun LaunchAppInitializationSetting(
               }
             )
           } else {
-            TextField(
+            ValueTextField(
               modifier = Modifier.weight(1f).padding(4.dp),
               value = value.value.toString(),
-              placeholder = { Text("value") },
+              placeholder = "value",
+              resetKey = value::class,
               onValueChange = { newValue ->
                 val newArguments = arguments.toMutableMap()
                 newArguments[key] = when (value) {

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ValueTextField.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ValueTextField.kt
@@ -1,0 +1,46 @@
+package io.github.takahirom.arbigent.ui
+
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.component.TextField
+
+/**
+ * Value/callback-style text field on top of Jewel's state-based [TextField] (the
+ * `value`/`onValueChange` overload was removed from Jewel). Edits flow one way, from the
+ * field into [onValueChange]; [resetKey] recreates the field when the backing model is
+ * replaced from outside (e.g. a Browse pick changing the row's target).
+ */
+@Composable
+internal fun ValueTextField(
+  value: String,
+  onValueChange: (String) -> Unit,
+  modifier: Modifier = Modifier,
+  placeholder: String? = null,
+  keyboardOptions: KeyboardOptions = KeyboardOptions.Default,
+  resetKey: Any? = null,
+) {
+  val textFieldState = remember(resetKey) { TextFieldState(value) }
+  val currentValue by rememberUpdatedState(value)
+  val currentOnValueChange by rememberUpdatedState(onValueChange)
+  LaunchedEffect(textFieldState) {
+    snapshotFlow { textFieldState.text.toString() }.collect { newValue ->
+      if (newValue != currentValue) {
+        currentOnValueChange(newValue)
+      }
+    }
+  }
+  TextField(
+    state = textFieldState,
+    placeholder = placeholder?.let { { Text(it) } },
+    keyboardOptions = keyboardOptions,
+    modifier = modifier,
+  )
+}

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/components/AiOptionsComponent.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/components/AiOptionsComponent.kt
@@ -116,11 +116,9 @@ fun AiOptionsComponent(
                 Column {
                     ImageDetailLevel.entries.forEach { item ->
                         val isSelected = item == detail
-                        val isItemHovered = false
-                        val isPreviewSelection = false
                         SimpleListItem(
                             text = item.name.lowercase(),
-                            state = ListItemState(isSelected, isItemHovered, isPreviewSelection),
+                            state = ListItemState(isSelected),
                             modifier = Modifier
                                 .testTag("image_detail_level_item_${item.name.lowercase()}")
                                 .clickable {
@@ -129,7 +127,6 @@ fun AiOptionsComponent(
                                     )
                                 },
                             style = JewelTheme.simpleListItemStyle,
-                            contentDescription = item.name.lowercase()
                         )
                     }
                 }
@@ -168,11 +165,9 @@ fun AiOptionsComponent(
                 Column {
                     listOf(ImageFormat.PNG, ImageFormat.WEBP, ImageFormat.LOSSY_WEBP).forEach { item ->
                         val isSelected = item == updatedOptions.imageFormat
-                        val isItemHovered = false
-                        val isPreviewSelection = false
                         SimpleListItem(
                             text = item.name.lowercase().replace("_", " "),
-                            state = ListItemState(isSelected, isItemHovered, isPreviewSelection),
+                            state = ListItemState(isSelected),
                             modifier = Modifier
                                 .testTag("image_format_item_${item.name.lowercase()}")
                                 .clickable {
@@ -181,7 +176,6 @@ fun AiOptionsComponent(
                                     )
                                 },
                             style = JewelTheme.simpleListItemStyle,
-                            contentDescription = item.name.lowercase().replace("_", " ")
                         )
                     }
                 }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/components/McpOptionsComponent.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/components/McpOptionsComponent.kt
@@ -139,14 +139,13 @@ fun McpOptionsComponent(
                 val isSelected = serverName == selectedServerToAdd
                 SimpleListItem(
                   text = serverName,
-                  state = ListItemState(isSelected, false, false),
+                  state = ListItemState(isSelected),
                   modifier = Modifier
                     .testTag("mcp_add_server_item_$serverName")
                     .clickable {
                       selectedServerToAdd = serverName
                     },
                   style = JewelTheme.simpleListItemStyle,
-                  contentDescription = serverName
                 )
               }
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,8 +22,8 @@ kotlin.code.style=official
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
 
-kotlin.version=2.0.21
-compose.version=1.7.1
+kotlin.version=2.3.21
+compose.version=1.10.3
 
 roborazzi.test.record=true
 roborazzi.record.filePathStrategy=relativePathFromRoborazziContextOutputDirectory

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.7.2"
-kotlin = "2.1.10"
+kotlin = "2.3.21"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,6 +18,10 @@ pluginManagement {
         id("org.jetbrains.kotlin.plugin.compose").version(extra["kotlin.version"] as String)
     }
 }
+plugins {
+    // Auto-provisions the JDK 21 toolchain required by arbigent-ui (Jewel) on CI.
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
+}
 dependencyResolutionManagement {
     repositoriesMode.set(RepositoriesMode.PREFER_PROJECT)
     repositories {


### PR DESCRIPTION
## Why

The upcoming scenario-graph feature uses [Kuiver](https://github.com/justdeko/kuiver) (a Compose Multiplatform graph library) in the UI. Kuiver 0.3.0 is built with Kotlin 2.3.21 / Compose Multiplatform 1.10.3, which our previous toolchain (Kotlin 2.1.10 / Compose 1.7.1 / Jewel 0.27) cannot consume. This PR upgrades the toolchain only, with no behavior changes; the graph feature comes in a follow-up stacked PR.

## What

- Kotlin 2.1.10 → 2.3.21, Compose Multiplatform 1.7.1 → 1.10.3 (`gradle.properties`, version catalog)
- Jewel `jewel-int-ui-standalone-243:0.27.0` → `jewel-int-ui-standalone:0.37.0-261.26222.65` (new Maven Central coordinates) + matching `intellij.platform:icons:261.26222.65`
- Mosaic 0.17.0 → 0.18.0, Roborazzi 1.44.0-alpha → 1.68.0
- Jewel API migrations:
  - `TextField(value, onValueChange)` overload was removed → new `ValueTextField` wrapper bridging value/callback style onto the state-based `TextField`
  - `ListItemState` lost `isItemHovered`/`isPreviewSelection`; `SimpleListItem` lost `contentDescription`
- arbigent-ui toolchain 17 → 21 (Jewel 0.32+ ships Java 21 class files); added foojay-resolver so CI auto-provisions JDK 21; `build-ui.yaml` bundles JDK 21 via jpackage
- `outputModuleName` migration in arbigent-core-web-report (hard error in Kotlin 2.3)

## Testing

- `./gradlew test`: 264 tests, 0 failures (UiTests 30/30 green on JDK 21)
- CLI `installDist` + `--help` works
- Desktop app launched, connected to an Android emulator and ran a scenario to "Goal achieved" (manual)