### PR TITLE
Add scenario graph view to CLI and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,11 @@ arbigent scenarios
 arbigent tags
 ```
 
+**Print the scenario graph as Mermaid** (dependency edges plus reusable calls expanded per call site — paste into GitHub Markdown or [mermaid.live](https://mermaid.live) to view; the same graph is available in the UI via the "Scenario graph" button):
+```bash
+arbigent graph
+```
+
 
 ### Shard Option to Enable Parallel Tests
 

--- a/arbigent-cli/src/main/kotlin/GraphCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GraphCommand.kt
@@ -1,0 +1,27 @@
+@file:OptIn(ArbigentInternalApi::class)
+
+package io.github.takahirom.arbigent.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import io.github.takahirom.arbigent.*
+import java.io.File
+
+/**
+ * Prints the scenario dependency graph (dependency edges and reusable `uses` edges)
+ * as Mermaid text, e.g. for embedding in Markdown.
+ */
+class ArbigentGraphCommand : CliktCommand(name = "graph") {
+  private val projectFile by projectFileOption()
+  private val logLevel by logLevelOption()
+
+  override fun run() {
+    applyLogLevel(logLevel)
+    val projectFilePath = requireProjectFile(projectFile)
+    val projectFileContent = if (isJourneyProjectSource(projectFilePath)) {
+      ArbigentJourneyXmlImporter.loadProjectContent(File(projectFilePath))
+    } else {
+      ArbigentProjectSerializer().load(File(projectFilePath))
+    }
+    echo(ArbigentScenarioGraph.from(projectFileContent).toMermaid())
+  }
+}

--- a/arbigent-cli/src/main/kotlin/main.kt
+++ b/arbigent-cli/src/main/kotlin/main.kt
@@ -73,6 +73,6 @@ fun main(args: Array<String>) {
   LoggingUtils.suppressSlf4jWarnings()
   
   ArbigentCli()
-    .subcommands(ArbigentRunCommand().subcommands(ArbigentRunTaskCommand()), ArbigentScenariosCommand(), ArbigentTagsCommand())
+    .subcommands(ArbigentRunCommand().subcommands(ArbigentRunTaskCommand()), ArbigentScenariosCommand(), ArbigentTagsCommand(), ArbigentGraphCommand())
     .main(args)
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioGraph.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioGraph.kt
@@ -69,6 +69,9 @@ public data class ArbigentScenarioGraph(
       val reusableById = projectFileContent.reusableScenarios.associateBy { it.id }
       val nodes = mutableListOf<Node>()
       val edges = mutableListOf<Edge>()
+      // Call-node keys carry a monotonic counter so they can never collide with a
+      // scenario key (scenario ids are unrestricted and could imitate any path scheme).
+      var callNodeCounter = 0
 
       /**
        * Expands one call step. Leaves become nodes chained after [previousKey]; composites are
@@ -83,11 +86,9 @@ public data class ArbigentScenarioGraph(
         parentBindings: Map<String, String>,
         viaPath: List<String>,
         previousKey: String,
-        keyPrefix: String,
-        index: Int,
         expansionStack: List<String>,
       ): String {
-        val key = "$keyPrefix/$index:${step.uses}"
+        val key = "call#${callNodeCounter++}:${step.uses}"
         val target = reusableById[step.uses]
         val resolvedWith = step.withValues.mapValues { (_, value) ->
           ReusableInputsResolver.resolve(value, parentBindings)
@@ -108,14 +109,12 @@ public data class ArbigentScenarioGraph(
           return key
         }
         var lastKey = previousKey
-        target.callSteps().forEachIndexed { nestedIndex, nestedStep ->
+        target.callSteps().forEach { nestedStep ->
           lastKey = expandStep(
             step = nestedStep,
             parentBindings = bindings,
             viaPath = viaPath + label,
             previousKey = lastKey,
-            keyPrefix = key,
-            index = nestedIndex,
             expansionStack = expansionStack + step.uses,
           )
         }
@@ -144,14 +143,12 @@ public data class ArbigentScenarioGraph(
           }
         }
         var lastKey = scenarioKey(scenario.id)
-        scenario.callSteps().forEachIndexed { index, step ->
+        scenario.callSteps().forEach { step ->
           lastKey = expandStep(
             step = step,
             parentBindings = emptyMap(),
             viaPath = emptyList(),
             previousKey = lastKey,
-            keyPrefix = scenarioKey(scenario.id),
-            index = index,
             expansionStack = emptyList(),
           )
         }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioGraph.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioGraph.kt
@@ -1,0 +1,168 @@
+package io.github.takahirom.arbigent
+
+/**
+ * Execution-structure graph of a project: scenario nodes connected by `dependency` edges,
+ * with reusable calls expanded per call site into the reusable leaves that actually execute
+ * (composites are flattened, mirroring how calls become agent tasks at runtime; the composite
+ * path is kept as the node's subtitle). The same reusable called from two places becomes two
+ * nodes, so each scenario's flow stays separate. Shared by the CLI (`arbigent graph`, Mermaid
+ * output) and the UI (scenario graph dialog).
+ */
+public data class ArbigentScenarioGraph(
+  public val nodes: List<Node>,
+  public val edges: List<Edge>,
+) {
+  public enum class NodeKind { Scenario, ReusableCall }
+  public enum class EdgeKind { Dependency, Call }
+
+  /**
+   * [key] is unique within the graph; call nodes get one key per call site.
+   * For a scenario, [title] is its id and [subtitle] the goal snippet. For a reusable call,
+   * [title] is the call label (`login (user=paid)`, bindings resolved like at runtime) and
+   * [subtitle] the flattened composite path (`via prepare (user=paid)`), empty for direct calls.
+   */
+  public data class Node(
+    public val key: String,
+    public val title: String,
+    public val subtitle: String,
+    public val kind: NodeKind,
+  )
+
+  public data class Edge(
+    public val fromKey: String,
+    public val toKey: String,
+    public val kind: EdgeKind,
+  )
+
+  public fun toMermaid(): String {
+    val mermaidIds = nodes.withIndex().associate { (index, node) -> node.key to "n$index" }
+    val lines = mutableListOf(
+      "graph LR",
+      "  classDef reusable fill:#e8f0fe,stroke:#4285f4",
+    )
+    nodes.forEach { node ->
+      val id = mermaidIds.getValue(node.key)
+      val label = escapeMermaid(node.title) +
+        if (node.subtitle.isEmpty()) "" else "<br/>${escapeMermaid(node.subtitle)}"
+      lines += when (node.kind) {
+        NodeKind.Scenario -> "  $id[\"$label\"]"
+        NodeKind.ReusableCall -> "  $id[[\"$label\"]]:::reusable"
+      }
+    }
+    edges.forEach { edge ->
+      val from = mermaidIds.getValue(edge.fromKey)
+      val to = mermaidIds.getValue(edge.toKey)
+      lines += when (edge.kind) {
+        EdgeKind.Dependency -> "  $from --> $to"
+        EdgeKind.Call -> "  $from -.-> $to"
+      }
+    }
+    return lines.joinToString("\n")
+  }
+
+  private fun escapeMermaid(text: String): String = text.replace("\"", "#quot;")
+
+  public companion object {
+    private const val MAX_GOAL_LENGTH = 60
+
+    public fun from(projectFileContent: ArbigentProjectFileContent): ArbigentScenarioGraph {
+      val reusableById = projectFileContent.reusableScenarios.associateBy { it.id }
+      val nodes = mutableListOf<Node>()
+      val edges = mutableListOf<Edge>()
+
+      /**
+       * Expands one call step. Leaves become nodes chained after [previousKey]; composites are
+       * flattened by recursing into their steps, accumulating the path into [viaPath]. Returns
+       * the key of the last emitted node so the next sibling step can chain from it. Bindings
+       * are resolved like the runtime expansion (`defaults + with` resolved against the caller's
+       * bindings). [expansionStack] guards against cyclic references on content that has not
+       * gone through load-time validation.
+       */
+      fun expandStep(
+        step: ArbigentScenarioContent.ReusableStep,
+        parentBindings: Map<String, String>,
+        viaPath: List<String>,
+        previousKey: String,
+        keyPrefix: String,
+        index: Int,
+        expansionStack: List<String>,
+      ): String {
+        val key = "$keyPrefix/$index:${step.uses}"
+        val target = reusableById[step.uses]
+        val resolvedWith = step.withValues.mapValues { (_, value) ->
+          ReusableInputsResolver.resolve(value, parentBindings)
+        }
+        val defaults = target?.inputs.orEmpty()
+          .mapNotNull { (name, input) -> input.default?.let { name to it } }.toMap()
+        val bindings = defaults + resolvedWith
+        val label = ReusableInputsResolver.breadcrumbLabel(step.uses, bindings)
+        // Unresolved references (target == null) are reported by validation; keep a leaf node.
+        if (target == null || !target.isCallForm() || step.uses in expansionStack) {
+          nodes += Node(
+            key = key,
+            title = label,
+            subtitle = if (viaPath.isEmpty()) "" else "via ${viaPath.joinToString(" › ")}",
+            kind = NodeKind.ReusableCall,
+          )
+          edges += Edge(fromKey = previousKey, toKey = key, kind = EdgeKind.Call)
+          return key
+        }
+        var lastKey = previousKey
+        target.callSteps().forEachIndexed { nestedIndex, nestedStep ->
+          lastKey = expandStep(
+            step = nestedStep,
+            parentBindings = bindings,
+            viaPath = viaPath + label,
+            previousKey = lastKey,
+            keyPrefix = key,
+            index = nestedIndex,
+            expansionStack = expansionStack + step.uses,
+          )
+        }
+        return lastKey
+      }
+
+      fun scenarioKey(id: String) = "scenario:$id"
+
+      projectFileContent.scenarioContents.forEach { scenario ->
+        nodes += Node(
+          key = scenarioKey(scenario.id),
+          title = scenario.id,
+          subtitle = goalSnippet(scenario),
+          kind = NodeKind.Scenario,
+        )
+      }
+      val scenarioIds = projectFileContent.scenarioContents.map { it.id }.toSet()
+      projectFileContent.scenarioContents.forEach { scenario ->
+        scenario.dependencyId?.let { dependencyId ->
+          if (dependencyId in scenarioIds) {
+            edges += Edge(
+              fromKey = scenarioKey(dependencyId),
+              toKey = scenarioKey(scenario.id),
+              kind = EdgeKind.Dependency,
+            )
+          }
+        }
+        var lastKey = scenarioKey(scenario.id)
+        scenario.callSteps().forEachIndexed { index, step ->
+          lastKey = expandStep(
+            step = step,
+            parentBindings = emptyMap(),
+            viaPath = emptyList(),
+            previousKey = lastKey,
+            keyPrefix = scenarioKey(scenario.id),
+            index = index,
+            expansionStack = emptyList(),
+          )
+        }
+      }
+
+      return ArbigentScenarioGraph(nodes = nodes, edges = edges)
+    }
+
+    private fun goalSnippet(scenario: ArbigentScenarioContent): String {
+      val goal = scenario.goal.replace(Regex("\\s+"), " ").trim()
+      return if (goal.length <= MAX_GOAL_LENGTH) goal else goal.take(MAX_GOAL_LENGTH - 1) + "…"
+    }
+  }
+}

--- a/arbigent-core/src/test/java/ArbigentScenarioGraphTest.kt
+++ b/arbigent-core/src/test/java/ArbigentScenarioGraphTest.kt
@@ -1,0 +1,158 @@
+package io.github.takahirom.arbigent.sample.test
+
+import io.github.takahirom.arbigent.ArbigentProjectFileContent
+import io.github.takahirom.arbigent.ArbigentProjectSerializer
+import io.github.takahirom.arbigent.ArbigentScenarioGraph
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ArbigentScenarioGraphTest {
+  private fun load(yaml: String): ArbigentProjectFileContent = ArbigentProjectSerializer().load(yaml)
+
+  @Test
+  fun dependencyEdgesConnectScenarioNodes() {
+    val graph = ArbigentScenarioGraph.from(
+      load(
+        """
+        scenarios:
+        - id: "setup"
+          goal: "Open the app"
+        - id: "buy"
+          goal: "Buy an item"
+          dependency: "setup"
+        """
+      )
+    )
+    assertEquals(listOf("setup", "buy"), graph.nodes.map { it.title })
+    assertEquals(1, graph.edges.size)
+    val edge = graph.edges.single()
+    assertEquals(ArbigentScenarioGraph.EdgeKind.Dependency, edge.kind)
+    assertEquals("scenario:setup", edge.fromKey)
+    assertEquals("scenario:buy", edge.toKey)
+  }
+
+  @Test
+  fun sameReusableCalledTwiceBecomesTwoNodes() {
+    val graph = ArbigentScenarioGraph.from(
+      load(
+        """
+        scenarios:
+        - id: "scenario-a"
+          uses: "login"
+          with:
+            user: "paid"
+        - id: "scenario-b"
+          uses: "login"
+          with:
+            user: "free"
+        reusableScenarios:
+        - id: "login"
+          inputs:
+            user:
+              required: true
+          goal: "Log in as {{inputs.user}}"
+        """
+      )
+    )
+    val callNodes = graph.nodes.filter { it.kind == ArbigentScenarioGraph.NodeKind.ReusableCall }
+    assertEquals(listOf("login (user=paid)", "login (user=free)"), callNodes.map { it.title })
+    assertEquals(2, callNodes.map { it.key }.distinct().size)
+  }
+
+  @Test
+  fun compositesAreFlattenedToExecutedLeavesInOrder() {
+    val graph = ArbigentScenarioGraph.from(
+      load(
+        """
+        scenarios:
+        - id: "combo"
+          steps:
+          - uses: "prepare"
+            with:
+              user: "paid"
+          - uses: "checkout"
+        reusableScenarios:
+        - id: "prepare"
+          inputs:
+            user:
+              required: true
+          steps:
+          - uses: "login"
+            with:
+              user: "{{inputs.user}}"
+          - uses: "add-to-cart"
+        - id: "login"
+          inputs:
+            user:
+              required: true
+          goal: "Log in as {{inputs.user}}"
+        - id: "add-to-cart"
+          goal: "Add an item to the cart"
+        - id: "checkout"
+          goal: "Check out the cart"
+        """
+      )
+    )
+    val callNodes = graph.nodes.filter { it.kind == ArbigentScenarioGraph.NodeKind.ReusableCall }
+    // The composite "prepare" itself has no node; only executed leaves appear,
+    // with bindings resolved through the composite and the path kept as subtitle.
+    assertEquals(
+      listOf("login (user=paid)", "add-to-cart", "checkout"),
+      callNodes.map { it.title }
+    )
+    assertEquals(
+      listOf("via prepare (user=paid)", "via prepare (user=paid)", ""),
+      callNodes.map { it.subtitle }
+    )
+    val chain = graph.edges
+      .filter { it.kind == ArbigentScenarioGraph.EdgeKind.Call }
+      .map { it.fromKey to it.toKey }
+    assertEquals("scenario:combo", chain[0].first)
+    assertTrue(chain[0].second.endsWith(":login"))
+    assertTrue(chain[1].first.endsWith(":login"))
+    assertTrue(chain[1].second.endsWith(":add-to-cart"))
+    assertTrue(chain[2].first.endsWith(":add-to-cart"))
+    assertTrue(chain[2].second.endsWith(":checkout"))
+  }
+
+  @Test
+  fun mermaidOutputEscapesQuotesAndMarksReusableCalls() {
+    val mermaid = ArbigentScenarioGraph.from(
+      load(
+        """
+        scenarios:
+        - id: "search"
+          goal: "Search for \"About\" in settings"
+        - id: "call-login"
+          uses: "login"
+          dependency: "search"
+        reusableScenarios:
+        - id: "login"
+          goal: "Log in"
+        """
+      )
+    ).toMermaid()
+    assertTrue(mermaid.startsWith("graph LR"))
+    assertTrue(mermaid.contains("Search for #quot;About#quot; in settings"))
+    assertTrue(mermaid.contains("[[\"login\"]]:::reusable"))
+    assertTrue(mermaid.contains("n0 --> n1"))
+    assertTrue(mermaid.contains("-.->"))
+  }
+
+  @Test
+  fun longGoalIsTruncatedInSubtitle() {
+    val graph = ArbigentScenarioGraph.from(
+      load(
+        """
+        scenarios:
+        - id: "long"
+          goal: "${"a".repeat(100)}"
+        """
+      )
+    )
+    val subtitle = graph.nodes.single().subtitle
+    assertEquals(60, subtitle.length)
+    assertTrue(subtitle.endsWith("…"))
+  }
+}

--- a/arbigent-core/src/test/java/ArbigentScenarioGraphTest.kt
+++ b/arbigent-core/src/test/java/ArbigentScenarioGraphTest.kt
@@ -117,6 +117,28 @@ class ArbigentScenarioGraphTest {
   }
 
   @Test
+  fun scenarioIdImitatingCallKeySchemeDoesNotCollide() {
+    // "A/0:B" as a scenario id used to collide with the call node of scenario "A"
+    // step 0 using "B" when call keys were path-based.
+    val graph = ArbigentScenarioGraph.from(
+      load(
+        """
+        scenarios:
+        - id: "A/0:B"
+          goal: "A scenario whose id imitates a call key"
+        - id: "A"
+          uses: "B"
+        reusableScenarios:
+        - id: "B"
+          goal: "Reusable goal"
+        """
+      )
+    )
+    assertEquals(3, graph.nodes.size)
+    assertEquals(3, graph.nodes.map { it.key }.distinct().size)
+  }
+
+  @Test
   fun mermaidOutputEscapesQuotesAndMarksReusableCalls() {
     val mermaid = ArbigentScenarioGraph.from(
       load(

--- a/arbigent-ui/build.gradle.kts
+++ b/arbigent-ui/build.gradle.kts
@@ -35,6 +35,8 @@ dependencies {
   implementation("com.charleskorn.kaml:kaml:0.67.0")
   implementation(libs.kotlinx.serialization.json)
   implementation("com.github.javakeyring:java-keyring:1.0.4")
+  // Scenario graph rendering (hierarchical layout + zoom/pan)
+  implementation("io.github.justdeko:kuiver:0.3.0")
   // kotlin-test
   testImplementation(kotlin("test"))
   @OptIn(ExperimentalComposeLibrary::class)

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/App.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/App.kt
@@ -123,6 +123,13 @@ private fun MainScreen(
         appStateHolder.projectDialogState.value = ProjectDialogState.NotSelected
       }
     )
+  } else if (projectDialogState is ProjectDialogState.ShowScenarioGraphDialog) {
+    ScenarioGraphDialog(
+      appStateHolder = appStateHolder,
+      onCloseRequest = {
+        appStateHolder.projectDialogState.value = ProjectDialogState.NotSelected
+      }
+    )
   }
   val scenarioIndex by appStateHolder.selectedScenarioIndex.collectAsState()
   var scenariosWidth by remember { mutableStateOf(200.dp) }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -259,6 +259,7 @@ class ArbigentAppStateHolder(
     data object ShowGenerateScenarioDialog : ProjectDialogState
     data object ShowFixedScenariosDialog : ProjectDialogState
     data object ShowReusableScenariosDialog : ProjectDialogState
+    data object ShowScenarioGraphDialog : ProjectDialogState
   }
 
   val deviceConnectionState: MutableStateFlow<DeviceConnectionState> =
@@ -546,6 +547,9 @@ class ArbigentAppStateHolder(
       fixedScenarios = _fixedScenariosFlow.value
     )
   }
+
+  fun scenarioGraph(): ArbigentScenarioGraph =
+    ArbigentScenarioGraph.from(getCurrentProjectFileContent())
 
   private fun getCurrentContentAsYaml(): String {
     return arbigentProjectSerializer.encodeToString(getCurrentProjectFileContent())

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/LeftScenariosPanel.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/LeftScenariosPanel.kt
@@ -90,6 +90,18 @@ internal fun LeftScenariosPanel(
       }
 
       IconActionButton(
+        key = AllIconsKeys.Graph.Layout,
+        onClick = {
+          appStateHolder.projectDialogState.value = ProjectDialogState.ShowScenarioGraphDialog
+        },
+        contentDescription = "Scenario graph",
+        hint = Size(28),
+        modifier = Modifier.padding(end = 8.dp).testTag("scenario_graph_button")
+      ) {
+        Text("Scenario graph")
+      }
+
+      IconActionButton(
         key = AllIconsKeys.Diff.MagicResolve,
         onClick = {
           appStateHolder.projectDialogState.value = ProjectDialogState.ShowGenerateScenarioDialog

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ScenarioGraphDialog.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ScenarioGraphDialog.kt
@@ -1,0 +1,207 @@
+package io.github.takahirom.arbigent.ui
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.text.style.TextOverflow
+import com.dk.kuiver.model.KuiverEdge
+import com.dk.kuiver.model.KuiverNode
+import com.dk.kuiver.model.NodeDimensions
+import com.dk.kuiver.model.buildKuiver
+import com.dk.kuiver.model.layout.LayoutConfig
+import com.dk.kuiver.model.layout.LayoutDirection
+import com.dk.kuiver.renderer.KuiverViewer
+import com.dk.kuiver.renderer.KuiverViewerConfig
+import com.dk.kuiver.rememberKuiverViewerState
+import com.dk.kuiver.ui.EdgeContent
+import androidx.compose.animation.core.snap
+import io.github.takahirom.arbigent.ArbigentScenarioGraph
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.DefaultButton
+import org.jetbrains.jewel.ui.component.OutlinedButton
+import org.jetbrains.jewel.ui.component.Text
+import org.jetbrains.jewel.ui.typography
+
+private val scenarioNodeColor = Color(0xFFF5F5F5)
+private val scenarioBorderColor = Color(0xFF9E9E9E)
+private val reusableNodeColor = Color(0xFFE8F0FE)
+private val reusableBorderColor = Color(0xFF4285F4)
+private val dependencyEdgeColor = Color(0xFF616161)
+private val callEdgeColor = Color(0xFF4285F4)
+
+/**
+ * Zoomable/pannable view of the scenario graph: dependency edges between scenarios and
+ * reusable calls expanded per call site (same model as `arbigent graph` in the CLI).
+ * Snapshot of the project at open time; reopen to refresh.
+ */
+@Composable
+fun ScenarioGraphDialog(
+  appStateHolder: ArbigentAppStateHolder,
+  onCloseRequest: () -> Unit,
+) {
+  val graph = remember { appStateHolder.scenarioGraph() }
+  TestCompatibleDialog(
+    onCloseRequest = onCloseRequest,
+    title = "Scenario Graph",
+    width = 900.dp,
+    height = 640.dp,
+    content = {
+      Column(modifier = Modifier.padding(8.dp).fillMaxSize().testTag("scenario_graph_dialog")) {
+        ScenarioGraphViewer(
+          graph = graph,
+          modifier = Modifier.weight(1f).fillMaxWidth()
+        )
+        Row(
+          modifier = Modifier.fillMaxWidth().padding(top = 8.dp),
+          horizontalArrangement = Arrangement.SpaceBetween,
+          verticalAlignment = Alignment.CenterVertically
+        ) {
+          Text(
+            text = "Drag to pan, Ctrl+scroll to zoom. Solid arrows: dependency, dashed: reusable call.",
+            color = JewelTheme.globalColors.text.info,
+          )
+          Row {
+            val clipboardManager = LocalClipboardManager.current
+            OutlinedButton(
+              onClick = { clipboardManager.setText(AnnotatedString(graph.toMermaid())) },
+              modifier = Modifier.padding(end = 8.dp).testTag("copy_mermaid_button")
+            ) {
+              Text("Copy Mermaid")
+            }
+            DefaultButton(
+              onClick = onCloseRequest,
+              modifier = Modifier.testTag("close_scenario_graph_button")
+            ) {
+              Text("Close")
+            }
+          }
+        }
+      }
+    }
+  )
+}
+
+@Composable
+private fun ScenarioGraphViewer(
+  graph: ArbigentScenarioGraph,
+  modifier: Modifier = Modifier,
+) {
+  if (graph.nodes.isEmpty()) {
+    Box(modifier, contentAlignment = Alignment.Center) {
+      Text("No scenarios to show yet.")
+    }
+    return
+  }
+  val nodesByKey = remember(graph) { graph.nodes.associateBy { it.key } }
+  val edgeKindByKeys = remember(graph) {
+    graph.edges.associate { (it.fromKey to it.toKey) to it.kind }
+  }
+  val kuiver = remember(graph) {
+    buildKuiver {
+      // Explicit dimensions keep Kuiver out of its SubcomposeLayout auto-measurement,
+      // which never lets ComposeUiTest reach an idle state; GraphNode renders at
+      // exactly this size with ellipsized text.
+      graph.nodes.forEach { node ->
+        addNode(KuiverNode(id = node.key, dimensions = node.dimensions()))
+      }
+      graph.edges.forEach { edge -> addEdge(KuiverEdge(fromId = edge.fromKey, toId = edge.toKey)) }
+    }
+  }
+  val viewerState = rememberKuiverViewerState(
+    initialKuiver = kuiver,
+    layoutConfig = LayoutConfig.Hierarchical(direction = LayoutDirection.HORIZONTAL),
+  )
+  KuiverViewer(
+    state = viewerState,
+    modifier = modifier.background(JewelTheme.globalColors.panelBackground),
+    // Instant transforms: no bouncy springs, and nothing left animating for tests to wait on.
+    config = KuiverViewerConfig(
+      scaleAnimationSpec = snap(),
+      offsetAnimationSpec = snap(),
+      nodeAnimationSpec = snap(),
+      edgeAnimationSpec = snap(),
+      fontLoadingDelayMs = 0,
+    ),
+    nodeContent = { kuiverNode ->
+      val node = nodesByKey[kuiverNode.id] ?: return@KuiverViewer
+      GraphNode(node, kuiverNode.dimensions)
+    },
+    edgeContent = { kuiverEdge, from, to ->
+      val kind = edgeKindByKeys[kuiverEdge.fromId to kuiverEdge.toId]
+      EdgeContent(
+        from = from,
+        to = to,
+        color = if (kind == ArbigentScenarioGraph.EdgeKind.Call) callEdgeColor else dependencyEdgeColor,
+        dashed = kind == ArbigentScenarioGraph.EdgeKind.Call,
+        strokeWidth = 2f,
+      )
+    }
+  )
+}
+
+/**
+ * Estimated size for a graph node. Kuiver's layout needs sizes up front (see the note at
+ * the buildKuiver call); [GraphNode] renders at exactly this size and ellipsizes overflow.
+ */
+private fun ArbigentScenarioGraph.Node.dimensions(): NodeDimensions {
+  val textLength = maxOf(title.length + if (kind == ArbigentScenarioGraph.NodeKind.ReusableCall) 2 else 0, subtitle.length)
+  val width = (textLength * 7 + 24).coerceIn(80, 260)
+  val height = if (subtitle.isEmpty()) 34 else 52
+  return NodeDimensions(width.dp, height.dp)
+}
+
+@Composable
+private fun GraphNode(node: ArbigentScenarioGraph.Node, dimensions: NodeDimensions?) {
+  val isReusable = node.kind == ArbigentScenarioGraph.NodeKind.ReusableCall
+  Column(
+    verticalArrangement = Arrangement.Center,
+    modifier = Modifier
+      .then(
+        if (dimensions != null) Modifier.size(dimensions.width, dimensions.height) else Modifier
+      )
+      .background(
+        color = if (isReusable) reusableNodeColor else scenarioNodeColor,
+        shape = RoundedCornerShape(4.dp)
+      )
+      .border(
+        width = if (isReusable) 2.dp else 1.dp,
+        color = if (isReusable) reusableBorderColor else scenarioBorderColor,
+        shape = RoundedCornerShape(4.dp)
+      )
+      .padding(horizontal = 8.dp, vertical = 4.dp)
+      .testTag("graph_node_${node.key}")
+  ) {
+    Text(
+      text = if (isReusable) "↻ ${node.title}" else node.title,
+      color = Color.Black,
+      maxLines = 1,
+      overflow = TextOverflow.Ellipsis,
+    )
+    if (node.subtitle.isNotEmpty()) {
+      Text(
+        text = node.subtitle,
+        style = JewelTheme.typography.small,
+        color = Color(0xFF5F6368),
+        maxLines = 1,
+        overflow = TextOverflow.Ellipsis,
+      )
+    }
+  }
+}

--- a/arbigent-ui/src/test/kotlin/UiTests.kt
+++ b/arbigent-ui/src/test/kotlin/UiTests.kt
@@ -171,6 +171,16 @@ class UiTests(private val behavior: DescribedBehavior<TestRobot>) {
                 }
               }
             }
+            describe("when show scenario graph") {
+              doIt {
+                clickScenarioGraphButton()
+              }
+              itShould("show the scenario node in the graph") {
+                capture(it)
+                assertScenarioGraphNodeExists("scenario1")
+                closeScenarioGraphDialog()
+              }
+            }
           }
           describe("when enter multiline goal") {
             doIt {
@@ -455,6 +465,22 @@ class UiTests(private val behavior: DescribedBehavior<TestRobot>) {
             }
           }
         }
+        describe("when add dependency and show scenario graph") {
+          doIt {
+            expandOptions()
+            changeScenarioId("scenario1")
+            clickDependencyDropDown()
+            selectDependencyDropDown(firstGoal)
+            collapseOptions()
+            clickScenarioGraphButton()
+          }
+          itShould("show the dependency and the scenario in the graph") {
+            capture(it)
+            assertScenarioGraphNodeExists("scenario1")
+            assertScenarioGraphNodeWithTextExists(firstGoal)
+            closeScenarioGraphDialog()
+          }
+        }
         describe("when add dependency and change dependency id and run") {
           doIt {
             expandOptions()
@@ -553,6 +579,29 @@ class TestRobot(
 
   fun assertScenarioListItemDoesNotExist(goal: String) {
     composeUiTest.onNode(hasText("Goal: $goal", substring = true)).assertDoesNotExist()
+  }
+
+  fun clickScenarioGraphButton() {
+    composeUiTest.onNode(hasTestTag("scenario_graph_button")).performClick()
+    waitALittle()
+  }
+
+  fun assertScenarioGraphNodeExists(scenarioId: String) {
+    composeUiTest.onNode(hasTestTag("scenario_graph_dialog")).assertExists()
+    composeUiTest.onNode(hasTestTag("graph_node_scenario:$scenarioId"), useUnmergedTree = true)
+      .assertExists()
+  }
+
+  fun assertScenarioGraphNodeWithTextExists(text: String) {
+    composeUiTest.onAllNodes(
+      hasText(text, substring = true) and hasAnyAncestor(hasTestTag("scenario_graph_dialog")),
+      useUnmergedTree = true
+    ).onFirst().assertExists()
+  }
+
+  fun closeScenarioGraphDialog() {
+    composeUiTest.onNode(hasTestTag("close_scenario_graph_button")).performClick()
+    waitALittle()
   }
 
   fun enterScenariosToGenerate(scenarios: String) {


### PR DESCRIPTION
Built on #389 (toolchain upgrade, already merged — Kuiver 0.3.0 needs Kotlin 2.3 / Compose 1.10).

## What

A view of the scenario graph, in both the CLI and the UI.

- **Core**: `ArbigentScenarioGraph` — scenario nodes connected by `dependency` edges, with reusable calls **expanded per call site** into the leaves that actually execute (mirroring the runtime agent-task expansion). Composites are flattened; the composite path is kept as a `via prepare (user=paid)` subtitle, and `with` bindings are resolved with the same `defaults + with` rule as the runtime. Includes a Mermaid serializer.
- **CLI**: `arbigent graph` prints the graph as Mermaid to stdout (paste into GitHub Markdown / mermaid.live).
- **UI**: "Scenario graph" button next to "Generate scenario" opens a dialog rendering the same graph with [Kuiver](https://github.com/justdeko/kuiver) (hierarchical layout, drag-to-pan, Ctrl+scroll zoom), plus a "Copy Mermaid" button. Reusable calls are drawn dashed/blue, dependencies solid.

Example CLI output:

```mermaid
graph LR
  classDef reusable fill:#e8f0fe,stroke:#4285f4
  n0["setup-account<br/>Create a fresh test account"]
  n1["buy-flow"]
  n9[["login (user=paid)<br/>via prepare (user=paid)"]]:::reusable
  n0 --> n1
  n1 -.-> n9
```

## Notes

- Kuiver's automatic node measurement (`SubcomposeLayout`) never lets `ComposeUiTest` reach an idle state, hanging `waitForIdle` forever. Nodes therefore get explicit estimated dimensions and render with ellipsized text, which also keeps the layout deterministic.
- Transform animations are `snap()` — instant pan/zoom, nothing left animating for tests to wait on.

## Testing

- Core: `ArbigentScenarioGraphTest` (dependency edges, per-call-site expansion, composite flattening + binding resolution, Mermaid escaping, truncation)
- UI: two new `UiTests` behaviors (single scenario node; dependency edge between two scenarios) with Roborazzi captures
- CLI: `arbigent graph --project-file=...e2e-test-android.yaml` verified manually
