### PR TITLE
Extract ComboBoxItem composable and restore item content descriptions

### DIFF
--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/App.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/App.kt
@@ -2,7 +2,6 @@ package io.github.takahirom.arbigent.ui
 
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.gestures.detectDragGestures
 import androidx.compose.foundation.layout.*
 import androidx.compose.runtime.*
@@ -17,13 +16,13 @@ import io.github.takahirom.arbigent.ArbigentDeviceOs
 import io.github.takahirom.arbigent.arbigentDebugLog
 import io.github.takahirom.arbigent.ui.ArbigentAppStateHolder.DeviceConnectionState
 import io.github.takahirom.arbigent.ui.ArbigentAppStateHolder.ProjectDialogState
+import io.github.takahirom.arbigent.ui.components.ComboBoxItem
 import kotlinx.coroutines.launch
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.Orientation
 import org.jetbrains.jewel.ui.component.*
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import org.jetbrains.jewel.ui.painter.hints.Size
-import org.jetbrains.jewel.ui.theme.simpleListItemStyle
 
 @Composable
 fun App(
@@ -293,16 +292,14 @@ fun ScenarioControls(appStateHolder: ArbigentAppStateHolder) {
       Column {
         ArbigentDeviceOs.entries.forEach { item ->
           val isSelected = item == deviceOs
-          SimpleListItem(
+          ComboBoxItem(
             text = item.name,
-            state = ListItemState(isSelected),
-            modifier = Modifier
-              .clickable {
-                devicesStateHolder.selectedDeviceOs.value = item
-                devicesStateHolder.fetchDevices()
-                devicesStateHolder.onSelectedDeviceChanged(null)
-              },
-            style = JewelTheme.simpleListItemStyle,
+            isSelected = isSelected,
+            onClick = {
+              devicesStateHolder.selectedDeviceOs.value = item
+              devicesStateHolder.fetchDevices()
+              devicesStateHolder.onSelectedDeviceChanged(null)
+            },
           )
         }
       }
@@ -319,17 +316,15 @@ fun ScenarioControls(appStateHolder: ArbigentAppStateHolder) {
       Column {
         items.forEach { itemText ->
           val isSelected = itemText == selectedDevice?.name
-          SimpleListItem(
+          ComboBoxItem(
             text = itemText,
-            state = ListItemState(isSelected),
-            modifier = Modifier
-              .clickable {
-                devicesStateHolder.onSelectedDeviceChanged(devicesStateHolder.devices.value.firstOrNull { it.name == itemText })
-                devicesStateHolder.selectedDevice.value?.let {
-                  appStateHolder.onClickConnect(devicesStateHolder)
-                }
-              },
-            style = JewelTheme.simpleListItemStyle,
+            isSelected = isSelected,
+            onClick = {
+              devicesStateHolder.onSelectedDeviceChanged(devicesStateHolder.devices.value.firstOrNull { it.name == itemText })
+              devicesStateHolder.selectedDevice.value?.let {
+                appStateHolder.onClickConnect(devicesStateHolder)
+              }
+            },
           )
         }
       }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/components/AiOptionsComponent.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/components/AiOptionsComponent.kt
@@ -1,7 +1,6 @@
 package io.github.takahirom.arbigent.ui.components
 
 import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
@@ -31,7 +30,6 @@ import org.jetbrains.jewel.ui.component.*
 import org.jetbrains.jewel.ui.theme.colorPalette
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import org.jetbrains.jewel.ui.painter.hints.Size
-import org.jetbrains.jewel.ui.theme.simpleListItemStyle
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -116,17 +114,16 @@ fun AiOptionsComponent(
                 Column {
                     ImageDetailLevel.entries.forEach { item ->
                         val isSelected = item == detail
-                        SimpleListItem(
+                        ComboBoxItem(
                             text = item.name.lowercase(),
-                            state = ListItemState(isSelected),
+                            isSelected = isSelected,
+                            onClick = {
+                                updatedOptionsChanged(
+                                    updatedOptions.copy(imageDetail = item)
+                                )
+                            },
                             modifier = Modifier
                                 .testTag("image_detail_level_item_${item.name.lowercase()}")
-                                .clickable {
-                                    updatedOptionsChanged(
-                                        updatedOptions.copy(imageDetail = item)
-                                    )
-                                },
-                            style = JewelTheme.simpleListItemStyle,
                         )
                     }
                 }
@@ -165,17 +162,16 @@ fun AiOptionsComponent(
                 Column {
                     listOf(ImageFormat.PNG, ImageFormat.WEBP, ImageFormat.LOSSY_WEBP).forEach { item ->
                         val isSelected = item == updatedOptions.imageFormat
-                        SimpleListItem(
+                        ComboBoxItem(
                             text = item.name.lowercase().replace("_", " "),
-                            state = ListItemState(isSelected),
+                            isSelected = isSelected,
+                            onClick = {
+                                updatedOptionsChanged(
+                                    updatedOptions.copy(imageFormat = item)
+                                )
+                            },
                             modifier = Modifier
                                 .testTag("image_format_item_${item.name.lowercase()}")
-                                .clickable {
-                                    updatedOptionsChanged(
-                                        updatedOptions.copy(imageFormat = item)
-                                    )
-                                },
-                            style = JewelTheme.simpleListItemStyle,
                         )
                     }
                 }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/components/ComboBoxItem.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/components/ComboBoxItem.kt
@@ -1,0 +1,32 @@
+package io.github.takahirom.arbigent.ui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import org.jetbrains.jewel.foundation.theme.JewelTheme
+import org.jetbrains.jewel.ui.component.ListItemState
+import org.jetbrains.jewel.ui.component.SimpleListItem
+import org.jetbrains.jewel.ui.theme.simpleListItemStyle
+
+/**
+ * A selectable item inside a ComboBox popup. Carries contentDescription semantics,
+ * which Jewel's SimpleListItem no longer exposes as a parameter.
+ */
+@Composable
+fun ComboBoxItem(
+  text: String,
+  isSelected: Boolean,
+  onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+) {
+  SimpleListItem(
+    text = text,
+    state = ListItemState(isSelected),
+    modifier = modifier
+      .semantics { contentDescription = text }
+      .clickable(onClick = onClick),
+    style = JewelTheme.simpleListItemStyle,
+  )
+}

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/components/McpOptionsComponent.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/components/McpOptionsComponent.kt
@@ -22,13 +22,10 @@ import io.github.takahirom.arbigent.McpServerOption
 import org.jetbrains.jewel.foundation.theme.JewelTheme
 import org.jetbrains.jewel.ui.component.CheckboxRow
 import org.jetbrains.jewel.ui.component.IconActionButton
-import org.jetbrains.jewel.ui.component.ListItemState
-import org.jetbrains.jewel.ui.component.SimpleListItem
 import org.jetbrains.jewel.ui.component.Text
 import org.jetbrains.jewel.ui.component.ComboBox
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import org.jetbrains.jewel.ui.painter.hints.Size
-import org.jetbrains.jewel.ui.theme.simpleListItemStyle
 
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
@@ -137,15 +134,14 @@ fun McpOptionsComponent(
             Column {
               availableToAdd.forEach { serverName ->
                 val isSelected = serverName == selectedServerToAdd
-                SimpleListItem(
+                ComboBoxItem(
                   text = serverName,
-                  state = ListItemState(isSelected),
+                  isSelected = isSelected,
+                  onClick = {
+                    selectedServerToAdd = serverName
+                  },
                   modifier = Modifier
                     .testTag("mcp_add_server_item_$serverName")
-                    .clickable {
-                      selectedServerToAdd = serverName
-                    },
-                  style = JewelTheme.simpleListItemStyle,
                 )
               }
             }


### PR DESCRIPTION
# What
Extract the five duplicated `SimpleListItem` dropdown-item blocks (device OS / device selection in App.kt, image detail level / image format in AiOptionsComponent.kt, MCP server in McpOptionsComponent.kt) into a shared `ComboBoxItem` composable, and re-apply `contentDescription` semantics to each item.

# Why
The Jewel 0.37 upgrade (#389) removed `SimpleListItem`'s `contentDescription` parameter, silently dropping accessibility semantics from every dropdown item, and left the same five-line item shape repeated at five call sites. One composable keeps them consistent and brings the semantics back.