### PR TITLE
Fix non-deterministic scenario graph screenshot by fixing dependency scenario id

### DIFF
--- a/arbigent-ui/src/test/kotlin/UiTests.kt
+++ b/arbigent-ui/src/test/kotlin/UiTests.kt
@@ -429,6 +429,11 @@ class UiTests(private val behavior: DescribedBehavior<TestRobot>) {
       describe("when add scenarios $secondGoal") {
         doIt {
           enterGoal(firstGoal)
+          // Fix the id here: the scenario graph shows scenario ids, and the random
+          // default id would make the graph screenshot non-deterministic.
+          expandOptions()
+          changeScenarioId("first_scenario")
+          collapseOptions()
           clickAddScenarioButton()
           enterGoal(secondGoal)
         }


### PR DESCRIPTION
# What
Give the first (dependency) scenario a fixed id `first_scenario` in the `describeEnterDependencyGoal` UI test setup.

# Why
Scenario graph nodes are titled by scenario id, and the first scenario kept its randomly generated UUID id, so the two "show scenario graph" screenshots produced a diff on every run (e.g. [this report](https://github.com/takahirom/arbigent/pull/393#issuecomment-4954132030) on an unrelated PR). Verified determinism locally: two clean `recordRoborazzi` runs now produce byte-identical images for all three graph screenshots.