### PR TITLE
Start dependency edges from the dependency's last call node in scenario graph

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioGraph.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioGraph.kt
@@ -5,8 +5,12 @@ package io.github.takahirom.arbigent
  * with reusable calls expanded per call site into the reusable leaves that actually execute
  * (composites are flattened, mirroring how calls become agent tasks at runtime; the composite
  * path is kept as the node's subtitle). The same reusable called from two places becomes two
- * nodes, so each scenario's flow stays separate. Shared by the CLI (`arbigent graph`, Mermaid
- * output) and the UI (scenario graph dialog).
+ * nodes, so each scenario's flow stays separate — every node has at most one incoming edge,
+ * making the graph a forest. A dependency edge starts from the last node the dependency
+ * scenario executes (its last call node, or the scenario itself when it has no calls), so
+ * edges read as execution order: `A -.-> login --> B` means B runs after A including its
+ * calls. Shared by the CLI (`arbigent graph`, Mermaid output) and the UI (scenario graph
+ * dialog).
  */
 public data class ArbigentScenarioGraph(
   public val nodes: List<Node>,
@@ -131,17 +135,10 @@ public data class ArbigentScenarioGraph(
           kind = NodeKind.Scenario,
         )
       }
-      val scenarioIds = projectFileContent.scenarioContents.map { it.id }.toSet()
+      // First expand every scenario's call chain and remember where it ends, because a
+      // dependency edge starts from the dependency scenario's last executed node.
+      val lastKeyByScenarioId = mutableMapOf<String, String>()
       projectFileContent.scenarioContents.forEach { scenario ->
-        scenario.dependencyId?.let { dependencyId ->
-          if (dependencyId in scenarioIds) {
-            edges += Edge(
-              fromKey = scenarioKey(dependencyId),
-              toKey = scenarioKey(scenario.id),
-              kind = EdgeKind.Dependency,
-            )
-          }
-        }
         var lastKey = scenarioKey(scenario.id)
         scenario.callSteps().forEach { step ->
           lastKey = expandStep(
@@ -151,6 +148,18 @@ public data class ArbigentScenarioGraph(
             previousKey = lastKey,
             expansionStack = emptyList(),
           )
+        }
+        lastKeyByScenarioId[scenario.id] = lastKey
+      }
+      projectFileContent.scenarioContents.forEach { scenario ->
+        scenario.dependencyId?.let { dependencyId ->
+          lastKeyByScenarioId[dependencyId]?.let { fromKey ->
+            edges += Edge(
+              fromKey = fromKey,
+              toKey = scenarioKey(scenario.id),
+              kind = EdgeKind.Dependency,
+            )
+          }
         }
       }
 

--- a/arbigent-core/src/test/java/ArbigentScenarioGraphTest.kt
+++ b/arbigent-core/src/test/java/ArbigentScenarioGraphTest.kt
@@ -33,6 +33,57 @@ class ArbigentScenarioGraphTest {
   }
 
   @Test
+  fun dependencyEdgeStartsFromLastCallNodeOfDependency() {
+    // "setup" executes "login", so "buy" runs after "login":
+    // setup -.-> login --> buy, not a parallel-looking branch off "setup".
+    val graph = ArbigentScenarioGraph.from(
+      load(
+        """
+        scenarios:
+        - id: "setup"
+          uses: "login"
+        - id: "buy"
+          goal: "Buy an item"
+          dependency: "setup"
+        reusableScenarios:
+        - id: "login"
+          goal: "Log in"
+        """
+      )
+    )
+    val callEdge = graph.edges.single { it.kind == ArbigentScenarioGraph.EdgeKind.Call }
+    val dependencyEdge = graph.edges.single { it.kind == ArbigentScenarioGraph.EdgeKind.Dependency }
+    assertEquals("scenario:setup", callEdge.fromKey)
+    assertTrue(callEdge.toKey.endsWith(":login"))
+    assertEquals(callEdge.toKey, dependencyEdge.fromKey)
+    assertEquals("scenario:buy", dependencyEdge.toKey)
+  }
+
+  @Test
+  fun everyNodeHasAtMostOneIncomingEdge() {
+    val graph = ArbigentScenarioGraph.from(
+      load(
+        """
+        scenarios:
+        - id: "setup"
+          uses: "login"
+        - id: "buy"
+          goal: "Buy an item"
+          dependency: "setup"
+        - id: "browse"
+          goal: "Browse items"
+          dependency: "setup"
+        reusableScenarios:
+        - id: "login"
+          goal: "Log in"
+        """
+      )
+    )
+    val incomingCounts = graph.edges.groupingBy { it.toKey }.eachCount()
+    assertTrue(incomingCounts.values.all { it == 1 })
+  }
+
+  @Test
   fun sameReusableCalledTwiceBecomesTwoNodes() {
     val graph = ArbigentScenarioGraph.from(
       load(


### PR DESCRIPTION
# What
Dependency edges in the scenario graph now start from the last node the dependency scenario executes (its last reusable call node), instead of always from the scenario node itself.

Before: `A --> B` and `A -.-> login` branched in parallel off `A`.
After: `A -.-> login --> B`, so edges read as execution order.

# Why
When a scenario calls reusables, its dependents actually run after those calls complete. The parallel branches made it look like B and the reusable call were unrelated, hiding the real execution order. Every node now has at most one incoming edge, so the graph stays a simple forest.