### PR TITLE
Add instruction command to print AI reproduction steps for a scenario

### DIFF
--- a/arbigent-cli/src/main/kotlin/GuideCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GuideCommand.kt
@@ -369,4 +369,50 @@ Done when: you can state the root cause (selection, environment, starting state,
 wording, or assertion), not just that the run went red.
 """.trimIndent(),
   ),
+  ArbigentGuideTopic(
+    name = "reproducing-manually",
+    description = "How to get AI-oriented reproduction instructions for a scenario",
+    body = """
+# Reproducing a scenario manually
+
+When you want to reproduce a scenario on a device yourself (instead of letting
+`arbigent run` drive it), print its reproduction instructions:
+
+    arbigent instruction --scenario-ids=open-about-page
+
+This prints Markdown listing, in order, every scenario from the root dependency down
+to the target. Each step has a concrete goal describing what to accomplish on the
+device, plus its initialization (app launch, data cleanup, etc.), any human note, and
+verification checks. Reusable `uses`/`steps` calls are expanded so every step is a
+concrete goal, with `{{inputs.*}}` bindings already resolved.
+
+- Pass multiple ids: `--scenario-ids=first,second` prints one section per id.
+- `--include-app-ui-structure` also prints the project's `appUiStructure` (when set),
+  giving the agent a map of the app before it starts.
+- Bare `{{name}}` placeholders that are not reusable inputs stay unresolved and are
+  listed in a "Variables" section; supply them at runtime with `run --variables`.
+
+Discover ids first with `arbigent scenarios`. For the example scenario below:
+
+    arbigent instruction --scenario-ids=open-about-page --project-file=project.yaml
+
+```yaml
+scenarios:
+- id: "launch-settings"
+  goal: "Open the Settings app and confirm the top screen is shown"
+  initializationMethods:
+  - type: "CleanupData"
+    packageName: "com.android.settings"
+  - type: "LaunchApp"
+    packageName: "com.android.settings"
+- id: "open-about-page"
+  goal: "Scroll down and open the 'About emulated device' page"
+  dependency: "launch-settings"
+  imageAssertions:
+  - assertionPrompt: "The About page is displayed"
+```
+
+Done when: you have an ordered, human-readable step list you can follow on the device.
+""".trimIndent(),
+  ),
 )

--- a/arbigent-cli/src/main/kotlin/GuideCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GuideCommand.kt
@@ -389,8 +389,11 @@ concrete goal, with `{{inputs.*}}` bindings already resolved.
 - Pass multiple ids: `--scenario-ids=first,second` prints one section per id.
 - `--include-app-ui-structure` also prints the project's `appUiStructure` (when set),
   giving the agent a map of the app before it starts.
-- Bare `{{name}}` placeholders that are not reusable inputs stay unresolved and are
-  listed in a "Variables" section; supply them at runtime with `run --variables`.
+- Bare `{{name}}` placeholders left unresolved in any rendered field (goal, note,
+  verification, or an initialization field such as `packageName`/`link`) are listed in a
+  "Variables" section; supply them at runtime with `run --variables`. Leftover
+  `{{inputs.*}}` reusable inputs are listed separately as "Unbound reusable inputs";
+  bind them with `with:` at the call site.
 
 Discover ids first with `arbigent scenarios`. For the example scenario below:
 

--- a/arbigent-cli/src/main/kotlin/InstructionCommand.kt
+++ b/arbigent-cli/src/main/kotlin/InstructionCommand.kt
@@ -1,0 +1,255 @@
+@file:OptIn(ArbigentInternalApi::class)
+
+package io.github.takahirom.arbigent.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.CliktError
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.help
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.required
+import com.github.ajalt.clikt.parameters.options.split
+import io.github.takahirom.arbigent.*
+import io.github.takahirom.arbigent.result.ArbigentScenarioDeviceFormFactor
+import java.io.File
+
+/**
+ * Prints AI-oriented reproduction instructions for one or more scenarios: the ordered chain of
+ * scenarios from the root dependency to the target, so an AI agent can manually reproduce the
+ * flow on a device. Read-only; needs no AI key and no device.
+ */
+class ArbigentInstructionCommand : CliktCommand(name = "instruction") {
+  private val projectFile by projectFileOption()
+  private val logLevel by logLevelOption()
+  private val scenarioIds by option(
+    "--scenario-ids",
+    help = "Comma-separated scenario ids to print reproduction instructions for"
+  ).split(",").required()
+  private val includeAppUiStructure by option(
+    "--include-app-ui-structure",
+    help = "Include the project's appUiStructure in the output when it is non-empty"
+  ).flag(default = false)
+
+  /** One resolved leaf in a scenario chain, ready to render as a numbered step. */
+  private data class ResolvedStep(
+    val id: String,
+    val goal: String,
+    val initializationMethods: List<ArbigentScenarioContent.InitializationMethod>,
+    val note: String,
+    val imageAssertions: List<ArbigentImageAssertion>,
+  )
+
+  override fun run() {
+    applyLogLevel(logLevel)
+    val projectFilePath = requireProjectFile(projectFile)
+    val projectFileContent = if (isJourneyProjectSource(projectFilePath)) {
+      ArbigentJourneyXmlImporter.loadProjectContent(File(projectFilePath))
+    } else {
+      ArbigentProjectSerializer().load(File(projectFilePath))
+    }
+
+    val scenariosById = projectFileContent.scenarioContents.associateBy { it.id }
+    val reusableById = projectFileContent.reusableScenarios.associateBy { it.id }
+
+    scenarioIds.forEachIndexed { index, targetId ->
+      val target = scenariosById[targetId] ?: throw CliktError(
+        "Unknown scenario id '$targetId'. Available scenario ids: " +
+          projectFileContent.scenarioContents.joinToString(", ") { it.id }
+      )
+      if (index > 0) echo("")
+      echo(renderInstructions(projectFileContent, scenariosById, reusableById, target))
+    }
+  }
+
+  private fun renderInstructions(
+    projectFileContent: ArbigentProjectFileContent,
+    scenariosById: Map<String, ArbigentScenarioContent>,
+    reusableById: Map<String, ArbigentScenarioContent>,
+    target: ArbigentScenarioContent,
+  ): String {
+    val steps = resolveChain(scenariosById, reusableById, target)
+
+    val out = StringBuilder()
+    out.appendLine("# Instructions to reach scenario: ${target.id}")
+    out.appendLine()
+    out.appendLine("Execute the following scenarios in order. Each goal describes what to")
+    out.appendLine("accomplish on the device; explore the UI as needed to achieve it.")
+
+    if (includeAppUiStructure) {
+      val appUiStructure = projectFileContent.settings.prompt.appUiStructure
+      if (appUiStructure.isNotBlank()) {
+        out.appendLine()
+        out.appendLine("## App UI structure")
+        out.appendLine()
+        out.appendLine(appUiStructure.trim())
+      }
+    }
+
+    val unresolvedVariables = steps
+      .flatMap { unresolvedPlaceholders(it.goal) }
+      .distinct()
+    if (unresolvedVariables.isNotEmpty()) {
+      out.appendLine()
+      out.appendLine("Variables (unresolved; provide with `run --variables`):")
+      unresolvedVariables.forEach { out.appendLine("- $it") }
+    }
+
+    steps.forEachIndexed { index, step ->
+      out.appendLine()
+      out.appendLine("## Step ${index + 1}: ${step.id}")
+      val initLines = step.initializationMethods.mapNotNull { renderInitializationMethod(it) }
+      if (initLines.isNotEmpty()) {
+        out.appendLine("- Initialization:")
+        initLines.forEach { out.appendLine("  - $it") }
+      }
+      out.appendLine("- Goal: ${step.goal}")
+      if (step.note.isNotBlank()) {
+        out.appendLine("- Note: ${step.note.trim()}")
+      }
+      step.imageAssertions.forEach { assertion ->
+        out.appendLine("- Verification: ${assertion.assertionPrompt}")
+      }
+    }
+
+    out.appendLine()
+    out.append("Device form factor: ${effectiveDeviceFormFactorName(projectFileContent, target)}")
+    return out.toString()
+  }
+
+  /**
+   * Walks [target]'s dependency chain (dependency-first) and expands reusable `uses`/`steps` calls
+   * into the concrete leaves that actually execute, resolving `{{inputs.*}}` bindings along the way.
+   * Mirrors the runtime expansion in `createArbigentScenario`, but keeps each leaf's own
+   * initialization methods and image assertions so they can be rendered.
+   */
+  private fun resolveChain(
+    scenariosById: Map<String, ArbigentScenarioContent>,
+    reusableById: Map<String, ArbigentScenarioContent>,
+    target: ArbigentScenarioContent,
+  ): List<ResolvedStep> {
+    val steps = mutableListOf<ResolvedStep>()
+    val visited = mutableSetOf<String>()
+
+    fun leaf(content: ArbigentScenarioContent, bindings: Map<String, String>) {
+      @Suppress("DEPRECATION")
+      val rawInitializationMethods =
+        content.initializationMethods.ifEmpty { listOf(content.initializeMethods) }
+      steps.add(
+        ResolvedStep(
+          id = content.id,
+          goal = ReusableInputsResolver.resolve(content.goal, bindings),
+          initializationMethods = rawInitializationMethods.map { resolveInitializationMethod(it, bindings) },
+          note = ReusableInputsResolver.resolve(content.noteForHumans, bindings),
+          imageAssertions = content.imageAssertions.map {
+            it.copy(assertionPrompt = ReusableInputsResolver.resolve(it.assertionPrompt, bindings))
+          },
+        )
+      )
+    }
+
+    fun expandStep(
+      step: ArbigentScenarioContent.ReusableStep,
+      parentBindings: Map<String, String>,
+      expansionStack: List<String>,
+    ) {
+      if (expansionStack.contains(step.uses)) {
+        throw CliktError(
+          "Cyclic reusable scenario reference detected: ${(expansionStack + step.uses).joinToString(" -> ")}"
+        )
+      }
+      val reusable = reusableById[step.uses] ?: throw CliktError(
+        "Reusable scenario '${step.uses}' is not defined in reusableScenarios"
+      )
+      val resolvedWith = step.withValues.mapValues { (_, value) ->
+        ReusableInputsResolver.resolve(value, parentBindings)
+      }
+      val defaults = reusable.inputs.mapNotNull { (name, input) -> input.default?.let { name to it } }.toMap()
+      val bindings = defaults + resolvedWith
+      if (reusable.isCallForm()) {
+        reusable.callSteps().forEach { expandStep(it, bindings, expansionStack + step.uses) }
+      } else {
+        leaf(reusable, bindings)
+      }
+    }
+
+    fun dfs(scenario: ArbigentScenarioContent) {
+      if (!visited.add(scenario.id)) return
+      scenario.dependencyId?.let { dependencyId ->
+        val dependency = scenariosById[dependencyId] ?: throw CliktError(
+          "Scenario '${scenario.id}' depends on unknown scenario '$dependencyId'."
+        )
+        dfs(dependency)
+      }
+      if (scenario.isCallForm()) {
+        scenario.callSteps().forEach { expandStep(it, emptyMap(), emptyList()) }
+      } else {
+        leaf(scenario, emptyMap())
+      }
+    }
+
+    dfs(target)
+    return steps
+  }
+
+  private fun resolveInitializationMethod(
+    method: ArbigentScenarioContent.InitializationMethod,
+    bindings: Map<String, String>,
+  ): ArbigentScenarioContent.InitializationMethod = when (method) {
+    is ArbigentScenarioContent.InitializationMethod.LaunchApp ->
+      method.copy(packageName = ReusableInputsResolver.resolve(method.packageName, bindings))
+    is ArbigentScenarioContent.InitializationMethod.CleanupData ->
+      method.copy(packageName = ReusableInputsResolver.resolve(method.packageName, bindings))
+    is ArbigentScenarioContent.InitializationMethod.OpenLink ->
+      method.copy(link = ReusableInputsResolver.resolve(method.link, bindings))
+    else -> method
+  }
+
+  /** Human-readable one-line description of an initialization method, or null for no-ops. */
+  private fun renderInitializationMethod(
+    method: ArbigentScenarioContent.InitializationMethod,
+  ): String? = when (method) {
+    is ArbigentScenarioContent.InitializationMethod.LaunchApp -> {
+      val args = method.launchArguments
+        .takeIf { it.isNotEmpty() }
+        ?.let { args -> ", arguments=" + args.entries.joinToString(", ") { "${it.key}=${it.value.value}" } }
+        .orEmpty()
+      "Launch app: package=${method.packageName}$args"
+    }
+
+    is ArbigentScenarioContent.InitializationMethod.CleanupData ->
+      "Cleanup app data: package=${method.packageName}"
+
+    is ArbigentScenarioContent.InitializationMethod.Back ->
+      "Press back: times=${method.times}"
+
+    is ArbigentScenarioContent.InitializationMethod.Wait ->
+      "Wait: ${method.durationMs}ms"
+
+    is ArbigentScenarioContent.InitializationMethod.OpenLink ->
+      "Open link: ${method.link}"
+
+    is ArbigentScenarioContent.InitializationMethod.MaestroYaml ->
+      "Run Maestro flow: scenarioId=${method.scenarioId}"
+
+    ArbigentScenarioContent.InitializationMethod.Noop -> null
+  }
+
+  private fun effectiveDeviceFormFactorName(
+    projectFileContent: ArbigentProjectFileContent,
+    target: ArbigentScenarioContent,
+  ): String {
+    val effective = when {
+      !target.deviceFormFactor.isUnspecified() -> target.deviceFormFactor
+      !projectFileContent.settings.deviceFormFactor.isUnspecified() -> projectFileContent.settings.deviceFormFactor
+      else -> ArbigentScenarioDeviceFormFactor.Mobile
+    }
+    return if (effective.isTv()) "Tv" else "Mobile"
+  }
+
+  private fun unresolvedPlaceholders(text: String): List<String> =
+    PLACEHOLDER_PATTERN.findAll(text).map { it.value }.toList()
+
+  private companion object {
+    private val PLACEHOLDER_PATTERN = """(?<!\\)\{\{\s*[^}]+\}\}""".toRegex()
+  }
+}

--- a/arbigent-cli/src/main/kotlin/InstructionCommand.kt
+++ b/arbigent-cli/src/main/kotlin/InstructionCommand.kt
@@ -85,13 +85,20 @@ class ArbigentInstructionCommand : CliktCommand(name = "instruction") {
       }
     }
 
-    val unresolvedVariables = steps
-      .flatMap { unresolvedPlaceholders(it.goal) }
+    val unresolved = steps
+      .flatMap { step -> renderedTexts(step).flatMap { unresolvedPlaceholders(it) } }
       .distinct()
+    val unboundInputs = unresolved.filter { isInputPlaceholder(it) }
+    val unresolvedVariables = unresolved.filterNot { isInputPlaceholder(it) }
     if (unresolvedVariables.isNotEmpty()) {
       out.appendLine()
       out.appendLine("Variables (unresolved; provide with `run --variables`):")
       unresolvedVariables.forEach { out.appendLine("- $it") }
+    }
+    if (unboundInputs.isNotEmpty()) {
+      out.appendLine()
+      out.appendLine("Unbound reusable inputs (provide via `with:` at the call site):")
+      unboundInputs.forEach { out.appendLine("- $it") }
     }
 
     steps.forEachIndexed { index, step ->
@@ -172,13 +179,18 @@ class ArbigentInstructionCommand : CliktCommand(name = "instruction") {
       }
     }
 
-    fun dfs(scenario: ArbigentScenarioContent) {
+    fun dfs(scenario: ArbigentScenarioContent, dependencyStack: List<String>) {
+      if (dependencyStack.contains(scenario.id)) {
+        throw CliktError(
+          "Cyclic scenario dependency detected: ${(dependencyStack + scenario.id).joinToString(" -> ")}"
+        )
+      }
       if (!visited.add(scenario.id)) return
       scenario.dependencyId?.let { dependencyId ->
         val dependency = scenariosById[dependencyId] ?: throw CliktError(
           "Scenario '${scenario.id}' depends on unknown scenario '$dependencyId'."
         )
-        dfs(dependency)
+        dfs(dependency, dependencyStack + scenario.id)
       }
       if (scenario.isCallForm()) {
         scenario.callSteps().forEach { expandStep(it, emptyMap(), emptyList()) }
@@ -187,7 +199,7 @@ class ArbigentInstructionCommand : CliktCommand(name = "instruction") {
       }
     }
 
-    dfs(target)
+    dfs(target, emptyList())
     return steps
   }
 
@@ -196,7 +208,16 @@ class ArbigentInstructionCommand : CliktCommand(name = "instruction") {
     bindings: Map<String, String>,
   ): ArbigentScenarioContent.InitializationMethod = when (method) {
     is ArbigentScenarioContent.InitializationMethod.LaunchApp ->
-      method.copy(packageName = ReusableInputsResolver.resolve(method.packageName, bindings))
+      method.copy(
+        packageName = ReusableInputsResolver.resolve(method.packageName, bindings),
+        launchArguments = method.launchArguments.mapValues { (_, value) ->
+          when (value) {
+            is ArbigentScenarioContent.InitializationMethod.LaunchApp.ArgumentValue.StringVal ->
+              value.copy(value = ReusableInputsResolver.resolve(value.value, bindings))
+            else -> value
+          }
+        },
+      )
     is ArbigentScenarioContent.InitializationMethod.CleanupData ->
       method.copy(packageName = ReusableInputsResolver.resolve(method.packageName, bindings))
     is ArbigentScenarioContent.InitializationMethod.OpenLink ->
@@ -249,7 +270,31 @@ class ArbigentInstructionCommand : CliktCommand(name = "instruction") {
   private fun unresolvedPlaceholders(text: String): List<String> =
     PLACEHOLDER_PATTERN.findAll(text).map { it.value }.toList()
 
+  private fun isInputPlaceholder(placeholder: String): Boolean =
+    INPUT_PLACEHOLDER_PATTERN.matches(placeholder)
+
+  /** Every rendered string of a step, so leftover placeholders anywhere get surfaced. */
+  private fun renderedTexts(step: ResolvedStep): List<String> = buildList {
+    add(step.goal)
+    add(step.note)
+    step.imageAssertions.forEach { add(it.assertionPrompt) }
+    step.initializationMethods.forEach { addAll(initializationMethodTexts(it)) }
+  }
+
+  private fun initializationMethodTexts(
+    method: ArbigentScenarioContent.InitializationMethod,
+  ): List<String> = when (method) {
+    is ArbigentScenarioContent.InitializationMethod.LaunchApp ->
+      listOf(method.packageName) + method.launchArguments.values.mapNotNull {
+        (it as? ArbigentScenarioContent.InitializationMethod.LaunchApp.ArgumentValue.StringVal)?.value
+      }
+    is ArbigentScenarioContent.InitializationMethod.CleanupData -> listOf(method.packageName)
+    is ArbigentScenarioContent.InitializationMethod.OpenLink -> listOf(method.link)
+    else -> emptyList()
+  }
+
   private companion object {
     private val PLACEHOLDER_PATTERN = """(?<!\\)\{\{\s*[^}]+\}\}""".toRegex()
+    private val INPUT_PLACEHOLDER_PATTERN = """\{\{\s*inputs\.[^}]+\}\}""".toRegex()
   }
 }

--- a/arbigent-cli/src/main/kotlin/ScenariosCommand.kt
+++ b/arbigent-cli/src/main/kotlin/ScenariosCommand.kt
@@ -39,5 +39,6 @@ class ArbigentScenariosCommand : CliktCommand(name = "scenarios") {
     arbigentProject.scenarios.forEach { scenario ->
       arbigentInfoLog("- ${scenario.id}: ${scenario.agentTasks.lastOrNull()?.goal?.take(80)}...")
     }
+    arbigentInfoLog("Run 'arbigent instruction --scenario-ids=<id>' to get reproduction instructions for a scenario.")
   }
 }

--- a/arbigent-cli/src/main/kotlin/main.kt
+++ b/arbigent-cli/src/main/kotlin/main.kt
@@ -77,6 +77,7 @@ fun arbigentCli(): ArbigentCli = ArbigentCli()
     ArbigentScenariosCommand(),
     ArbigentTagsCommand(),
     ArbigentGraphCommand(),
+    ArbigentInstructionCommand(),
     ArbigentGuideCommand(),
   )
 

--- a/arbigent-cli/src/test/kotlin/InstructionCommandTest.kt
+++ b/arbigent-cli/src/test/kotlin/InstructionCommandTest.kt
@@ -130,6 +130,77 @@ scenarios:
   }
 
   @Test
+  fun `cyclic dependency fails with the chain in the message`() {
+    yaml.writeText(
+      """
+scenarios:
+- id: "a"
+  goal: "First"
+  dependency: "b"
+- id: "b"
+  goal: "Second"
+  dependency: "a"
+      """.trimIndent()
+    )
+    val result = run("--scenario-ids=a")
+    assertNotEquals(0, result.statusCode, result.output)
+    assertContains(result.output, "Cyclic scenario dependency detected")
+    assertContains(result.output, "a -> b -> a")
+  }
+
+  @Test
+  fun `self dependency fails as a cycle`() {
+    yaml.writeText(
+      """
+scenarios:
+- id: "selfie"
+  goal: "Loop"
+  dependency: "selfie"
+      """.trimIndent()
+    )
+    val result = run("--scenario-ids=selfie")
+    assertNotEquals(0, result.statusCode, result.output)
+    assertContains(result.output, "Cyclic scenario dependency detected")
+  }
+
+  @Test
+  fun `classifies unbound inputs and scans placeholders beyond goal`() {
+    yaml.writeText(
+      """
+scenarios:
+- id: "prep"
+  goal: "Prepare the device"
+  noteForHumans: "Ask {{owner}} before running"
+  initializationMethods:
+  - type: "LaunchApp"
+    packageName: "{{app_package}}"
+- id: "unbound-call"
+  dependency: "prep"
+  uses: "search"
+reusableScenarios:
+- id: "search"
+  inputs:
+    term:
+      required: false
+  goal: "Search for {{inputs.term}}"
+      """.trimIndent()
+    )
+    val result = run("--scenario-ids=unbound-call")
+    assertEquals(0, result.statusCode, result.output)
+    val output = result.output
+
+    // Unbound reusable input goes to its own section with `with:` guidance.
+    assertContains(output, "Unbound reusable inputs (provide via `with:` at the call site):")
+    assertContains(output, "{{inputs.term}}")
+
+    // Placeholders in initialization fields are surfaced, not only those in goals.
+    val variablesSection = output.substringAfter("Variables (unresolved")
+      .substringBefore("Unbound reusable inputs")
+    assertContains(variablesSection, "{{app_package}}")
+    assertContains(variablesSection, "{{owner}}")
+  }
+
+  @Test
   fun `renders legacy singular initializeMethods field`() {
     yaml.writeText(
       """

--- a/arbigent-cli/src/test/kotlin/InstructionCommandTest.kt
+++ b/arbigent-cli/src/test/kotlin/InstructionCommandTest.kt
@@ -1,0 +1,161 @@
+@file:OptIn(ArbigentInternalApi::class)
+
+package io.github.takahirom.arbigent.cli
+
+import com.github.ajalt.clikt.testing.test
+import io.github.takahirom.arbigent.ArbigentInternalApi
+import java.io.File
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+
+class InstructionCommandTest {
+  private val yaml = File("build/arbigent/instruction-project.yaml")
+
+  @BeforeTest
+  fun setup() {
+    yaml.parentFile.mkdirs()
+    yaml.writeText(
+      """
+settings:
+  prompt:
+    appUiStructure: "Home > Settings > About emulated device"
+scenarios:
+- id: "launch"
+  goal: "Open the app and confirm the top screen is shown"
+  noteForHumans: "Use the shared test account"
+  initializationMethods:
+  - type: "CleanupData"
+    packageName: "com.example.app"
+  - type: "LaunchApp"
+    packageName: "com.example.app"
+- id: "login"
+  goal: "Log in as {{username}}"
+  dependency: "launch"
+- id: "do-search"
+  dependency: "login"
+  uses: "search"
+  with:
+    term: "wifi"
+reusableScenarios:
+- id: "search"
+  inputs:
+    term:
+      required: true
+  goal: "Search for {{inputs.term}} and verify it appears in results"
+  initializationMethods:
+  - type: "LaunchApp"
+    packageName: "com.example.app"
+  imageAssertions:
+  - assertionPrompt: "Results for {{inputs.term}} are shown"
+      """.trimIndent()
+    )
+  }
+
+  private fun run(vararg args: String) =
+    ArbigentInstructionCommand().test(
+      (listOf("--project-file=${yaml.absolutePath}") + args).joinToString(" ")
+    )
+
+  @Test
+  fun `prints ordered chain with resolved goal init note and verification`() {
+    val result = run("--scenario-ids=do-search")
+    assertEquals(0, result.statusCode, result.output)
+    val output = result.output
+
+    assertContains(output, "# Instructions to reach scenario: do-search")
+
+    // Ordered: launch -> login -> search (dependency-first, target last)
+    val launchIndex = output.indexOf("## Step 1: launch")
+    val loginIndex = output.indexOf("## Step 2: login")
+    val searchIndex = output.indexOf("## Step 3: search")
+    assertTrue(launchIndex >= 0, output)
+    assertTrue(loginIndex > launchIndex, output)
+    assertTrue(searchIndex > loginIndex, output)
+
+    // Reusable goal expanded and {{inputs.term}} resolved.
+    assertContains(output, "Search for wifi and verify it appears in results")
+
+    // Initialization rendered in YAML order.
+    assertContains(output, "Cleanup app data: package=com.example.app")
+    assertContains(output, "Launch app: package=com.example.app")
+
+    assertContains(output, "Note: Use the shared test account")
+
+    // Image assertion resolved and rendered as verification.
+    assertContains(output, "Verification: Results for wifi are shown")
+
+    // Bare project variable stays unresolved and is listed.
+    assertContains(output, "{{username}}")
+    assertContains(output, "Variables")
+
+    assertContains(output, "Device form factor: Mobile")
+  }
+
+  @Test
+  fun `accepts multiple scenario ids`() {
+    val result = run("--scenario-ids=launch,do-search")
+    assertEquals(0, result.statusCode, result.output)
+    assertContains(result.output, "# Instructions to reach scenario: launch")
+    assertContains(result.output, "# Instructions to reach scenario: do-search")
+  }
+
+  @Test
+  fun `unknown scenario id fails and lists available ids`() {
+    val result = run("--scenario-ids=missing")
+    assertNotEquals(0, result.statusCode, result.output)
+    assertContains(result.output, "Unknown scenario id 'missing'")
+    assertContains(result.output, "launch")
+    assertContains(result.output, "do-search")
+  }
+
+  @Test
+  fun `dangling dependency fails and names both scenarios`() {
+    yaml.writeText(
+      """
+scenarios:
+- id: "child"
+  goal: "Do the thing"
+  dependency: "missing-parent"
+      """.trimIndent()
+    )
+    val result = run("--scenario-ids=child")
+    assertNotEquals(0, result.statusCode, result.output)
+    assertContains(result.output, "child")
+    assertContains(result.output, "missing-parent")
+  }
+
+  @Test
+  fun `renders legacy singular initializeMethods field`() {
+    yaml.writeText(
+      """
+scenarios:
+- id: "legacy"
+  goal: "Open the app"
+  initializeMethods:
+    type: "LaunchApp"
+    packageName: "com.legacy.app"
+      """.trimIndent()
+    )
+    val result = run("--scenario-ids=legacy")
+    assertEquals(0, result.statusCode, result.output)
+    assertContains(result.output, "- Initialization:")
+    assertContains(result.output, "Launch app: package=com.legacy.app")
+  }
+
+  @Test
+  fun `include app ui structure flag toggles the section`() {
+    val without = run("--scenario-ids=launch")
+    assertEquals(0, without.statusCode, without.output)
+    assertFalse(without.output.contains("Home > Settings > About emulated device"), without.output)
+
+    val with = run("--scenario-ids=launch", "--include-app-ui-structure")
+    assertEquals(0, with.statusCode, with.output)
+    assertContains(with.output, "## App UI structure")
+    assertContains(with.output, "Home > Settings > About emulated device")
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new read-only CLI subcommand that prints AI-oriented reproduction instructions for a scenario: the ordered chain of scenarios from the root dependency to the target, so an AI agent (e.g. Claude Code driving adb) can manually reproduce the flow on a device.

```
arbigent instruction --scenario-ids=open-model-page
```

Intended flow: find a scenario with `arbigent scenarios` → run `arbigent instruction --scenario-ids=<id>` → the AI agent follows the printed goals/initialization on the device.

## Details

- New `ArbigentInstructionCommand`, modeled on `graph` (no AI key or device needed; supports journey XML and YAML projects).
- Output is Markdown: one section per requested id, steps ordered dependency-first; each step shows initialization methods (launch app, cleanup data, etc.), the goal with reusable `{{inputs.*}}` bindings resolved, `noteForHumans`, and `imageAssertions` as verification lines. No adb command examples are emitted.
- Reusable `uses`/`steps` calls are expanded with a dedicated resolution walk mirroring `createArbigentScenario` (the runtime `agentTasks` bake init methods/assertions into `AgentConfig`, so they can't be recovered from there for rendering). Falls back to the deprecated singular `initializeMethods` field like the runtime.
- Unresolved bare `{{name}}` placeholders are listed in a Variables section; escaped `\{{...}}` is excluded.
- `--include-app-ui-structure` optionally prints the project's `appUiStructure` (off by default to keep output compact).
- Unknown scenario ids and dangling dependencies fail with a non-zero exit and a helpful message (available ids / both scenario names).
- Discoverability: `arbigent scenarios` now prints a hint about the new command, and a `reproducing-manually` topic was added to `arbigent guide`.

## Test plan

- `InstructionCommandTest` (6 tests): ordered chain with resolved goal/init/note/verification, multiple ids, unknown id error, dangling dependency error, legacy `initializeMethods`, `--include-app-ui-structure` toggle.
- `./gradlew :arbigent-cli:test` green; smoke-tested the installed binary against `sample-test/.../e2e-test-android.yaml` (dependency chain, reusable expansion, Maestro/Back init rendering).
