### PR TITLE
Migrate to Maestro 2.7 consumed from the pinned release artifact

### DIFF
--- a/arbigent-core/build.gradle.kts
+++ b/arbigent-core/build.gradle.kts
@@ -28,13 +28,57 @@ buildConfig {
   useKotlinOutput { internalVisibility = false }
 }
 
+// maestro-* jars extracted from the pinned Maestro CLI zip (2.x is not on Maven Central).
+// See gradle/maestro.gradle.kts. api() so downstream modules see the maestro types arbigent
+// re-exposes (MaestroCommand, MaestroException, MaestroFlowParser, ...).
+@Suppress("UNCHECKED_CAST")
+val maestroJars = rootProject.extra["maestroJars"] as FileCollection
+
 dependencies {
   implementation(project(":arbigent-core-web-report"))
-  api(libs.maestro.orchestra)
-  api(libs.maestro.client)
-  implementation("dev.mobile:dadb:1.2.9")
-  api(libs.maestro.ios)
-  api(libs.maestro.ios.driver)
+  api(maestroJars)
+
+  // Transitive dependencies of the maestro-* jars, aligned to the versions bundled in the
+  // pinned Maestro CLI (maestro/lib/) since those jars carry no POM. Only what arbigent needs
+  // to compile and run is declared; Gradle resolves the rest (netty, guava, jackson-core,
+  // truffle, ...) transitively.
+  api("dev.mobile:dadb:2.0.0")
+  api("io.grpc:grpc-stub:1.57.2")
+  implementation("io.grpc:grpc-kotlin-stub:1.4.1")
+  implementation("io.grpc:grpc-netty:1.50.2")
+  implementation("io.grpc:grpc-okhttp:1.50.2")
+  implementation("io.grpc:grpc-protobuf:1.50.2")
+  api("com.google.protobuf:protobuf-kotlin:3.21.9")
+  implementation("com.michael-bull.kotlin-result:kotlin-result:2.0.1")
+  implementation("com.squareup.okhttp3:okhttp:4.12.0")
+  implementation("com.squareup.okhttp3:logging-interceptor:4.12.0")
+  implementation("com.squareup.okio:okio:3.16.2")
+  implementation("com.github.romankh3:image-comparison:4.4.0")
+  implementation("org.rauschig:jarchivelib:1.2.0")
+  implementation("com.fasterxml.jackson.core:jackson-databind:2.17.1")
+  implementation("com.fasterxml.jackson.module:jackson-module-kotlin:2.17.1")
+  implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.17.1")
+  implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:2.17.1")
+  implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.17.1")
+  implementation("net.dongliu:apk-parser:2.6.10")
+  implementation("net.harawata:appdirs:1.2.1")
+  implementation("com.google.code.gson:gson:2.11.0")
+  implementation("commons-io:commons-io:2.16.1")
+  implementation("net.datafaker:datafaker:2.5.3")
+  implementation("io.micrometer:micrometer-core:1.13.4")
+  implementation("org.apache.logging.log4j:log4j-api:2.25.3")
+  implementation("org.apache.logging.log4j:log4j-core:2.25.3")
+  implementation("org.apache.logging.log4j:log4j-slf4j2-impl:2.25.3")
+  implementation("org.apache.logging.log4j:log4j-layout-template-json:2.25.3")
+  // GraalJS runtime that Maestro's Orchestra uses to evaluate JS in flows (runtime-only:
+  // arbigent references no graal type directly).
+  runtimeOnly("org.graalvm.polyglot:polyglot:24.2.0")
+  runtimeOnly("org.graalvm.polyglot:js-community:24.2.0")
+  // Selenium backs Maestro.web() (arbigent's Web device); runtime-only.
+  runtimeOnly("org.seleniumhq.selenium:selenium-java:4.43.0")
+  // jcodec backs Maestro screen recording; runtime-only.
+  runtimeOnly("org.jcodec:jcodec:0.2.5")
+  runtimeOnly("org.jcodec:jcodec-javase:0.2.5")
 
   api(project(":arbigent-core-model"))
   api(project(":arbigent-mcp-client"))

--- a/arbigent-core/build.gradle.kts
+++ b/arbigent-core/build.gradle.kts
@@ -76,11 +76,9 @@ dependencies {
   runtimeOnly("org.graalvm.polyglot:js-community:24.2.0")
   // Selenium backs Maestro.web() (arbigent's Web device); runtime-only.
   runtimeOnly("org.seleniumhq.selenium:selenium-java:4.43.0")
-  // maestro-web's CdpClient speaks CDP over ktor's client websockets; runtime-only.
-  runtimeOnly("io.ktor:ktor-client-core:2.3.13")
-  runtimeOnly("io.ktor:ktor-client-cio:2.3.13")
-  runtimeOnly("io.ktor:ktor-client-content-negotiation:2.3.13")
-  runtimeOnly("io.ktor:ktor-serialization-kotlinx-json:2.3.13")
+  // maestro-web's CdpClient speaks CDP over ktor client websockets, but its ktor is 2.3.13
+  // and conflicts with arbigent's ktor 3.x. That ktor is shaded into the maestro-web jar
+  // itself (see gradle/maestro.gradle.kts), so no ktor 2.x runtime dep is declared here.
   // jcodec backs Maestro screen recording; runtime-only.
   runtimeOnly("org.jcodec:jcodec:0.2.5")
   runtimeOnly("org.jcodec:jcodec-javase:0.2.5")

--- a/arbigent-core/build.gradle.kts
+++ b/arbigent-core/build.gradle.kts
@@ -76,6 +76,11 @@ dependencies {
   runtimeOnly("org.graalvm.polyglot:js-community:24.2.0")
   // Selenium backs Maestro.web() (arbigent's Web device); runtime-only.
   runtimeOnly("org.seleniumhq.selenium:selenium-java:4.43.0")
+  // maestro-web's CdpClient speaks CDP over ktor's client websockets; runtime-only.
+  runtimeOnly("io.ktor:ktor-client-core:2.3.13")
+  runtimeOnly("io.ktor:ktor-client-cio:2.3.13")
+  runtimeOnly("io.ktor:ktor-client-content-negotiation:2.3.13")
+  runtimeOnly("io.ktor:ktor-serialization-kotlinx-json:2.3.13")
   // jcodec backs Maestro screen recording; runtime-only.
   runtimeOnly("org.jcodec:jcodec:0.2.5")
   runtimeOnly("org.jcodec:jcodec-javase:0.2.5")

--- a/arbigent-core/build.gradle.kts
+++ b/arbigent-core/build.gradle.kts
@@ -28,7 +28,7 @@ buildConfig {
   useKotlinOutput { internalVisibility = false }
 }
 
-// maestro-* jars extracted from the pinned Maestro CLI zip (2.x is not on Maven Central).
+// maestro-* jars extracted from the pinned Maestro release artifact (2.x is not on Maven Central).
 // See gradle/maestro.gradle.kts. api() so downstream modules see the maestro types arbigent
 // re-exposes (MaestroCommand, MaestroException, MaestroFlowParser, ...).
 @Suppress("UNCHECKED_CAST")
@@ -43,7 +43,7 @@ dependencies {
   // to compile and run is declared; Gradle resolves the rest (netty, guava, jackson-core,
   // truffle, ...) transitively.
   // The mixed grpc versions below (grpc-api/stub 1.57.2, grpc-core/netty/okhttp/protobuf
-  // 1.50.2) intentionally mirror what the Maestro CLI zip itself bundles; do NOT bump them
+  // 1.50.2) intentionally mirror what the Maestro release artifact itself bundles; do NOT bump them
   // to a single version or the runtime classpath diverges from the one Maestro was built against.
   api("dev.mobile:dadb:2.0.0")
   api("io.grpc:grpc-stub:1.57.2")

--- a/arbigent-core/build.gradle.kts
+++ b/arbigent-core/build.gradle.kts
@@ -42,6 +42,9 @@ dependencies {
   // pinned Maestro CLI (maestro/lib/) since those jars carry no POM. Only what arbigent needs
   // to compile and run is declared; Gradle resolves the rest (netty, guava, jackson-core,
   // truffle, ...) transitively.
+  // The mixed grpc versions below (grpc-api/stub 1.57.2, grpc-core/netty/okhttp/protobuf
+  // 1.50.2) intentionally mirror what the Maestro CLI zip itself bundles; do NOT bump them
+  // to a single version or the runtime classpath diverges from the one Maestro was built against.
   api("dev.mobile:dadb:2.0.0")
   api("io.grpc:grpc-stub:1.57.2")
   implementation("io.grpc:grpc-kotlin-stub:1.4.1")

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -2,11 +2,14 @@ package io.github.takahirom.arbigent
 
 import io.github.takahirom.arbigent.MaestroDevice.OptimizationResult
 import io.github.takahirom.arbigent.result.ArbigentUiTreeStrings
+import kotlinx.coroutines.runBlocking
 import maestro.*
 import maestro.UiElement.Companion.toUiElement
 import maestro.UiElement.Companion.toUiElementOrNull
+import maestro.device.Platform
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.Orchestra
+import okio.sink
 import java.io.File
 import kotlin.math.pow
 import kotlin.system.measureTimeMillis
@@ -204,9 +207,12 @@ public class MaestroDevice(
     arbigentInfoLog("MaestroDevice created: screenshotsDir:${screenshotsDir.absolutePath}")
   }
 
+  // Maestro's Orchestra artifact refactor (#3282) removed the screenshotsDir constructor
+  // parameter; takeScreenshot commands now write under an artifacts dir instead of
+  // screenshotsDir/<path>.png. Arbigent captures screenshots itself in executeActions()
+  // (see below) to keep that path contract, so Orchestra needs no screenshots dir here.
   @Volatile private var orchestra = Orchestra(
     maestro = maestro,
-    screenshotsDir = screenshotsDir,
   )
 
   override fun deviceName(): String {
@@ -217,7 +223,7 @@ public class MaestroDevice(
   private fun ensureConnected() {
     // Try a simple operation to check connection
     try {
-      maestro.viewHierarchy()
+      runBlocking { maestro.viewHierarchy() }
     } catch (e: Exception) {
       // Device appears disconnected, reconnect
       arbigentInfoLog("MaestroDevice failed to fetch view hierarchy: ${e.message}. Reconnect device ${maestro.deviceName}")
@@ -227,29 +233,35 @@ public class MaestroDevice(
 
   override fun executeActions(actions: List<MaestroCommand>) {
     ensureConnected()
+    // A lone takeScreenshot (how arbigent always issues one, see ArbigentAgent) is captured
+    // directly to screenshotsDir/<path>.png. Maestro's Orchestra artifact refactor (#3282)
+    // moved takeScreenshot output under an artifacts dir, which no longer matches where
+    // arbigent reads the file, so screenshots bypass Orchestra to keep the path contract.
+    // Every other command still runs through Orchestra via runFlow (which manages the JS
+    // engine lifecycle internally, replacing the old shouldReinitJsEngine reflection).
+    val screenshot = actions.singleOrNull()?.takeScreenshotCommand
     ArbigentGlobalStatus.onDevice(actions.joinToString { it.toString() }) {
-      // If the jsEngine is already initialized, we don't need to reinitialize it
-      val shouldJsReinit = if (orchestra::class.java.getDeclaredField("jsEngine").apply {
-          isAccessible = true
-        }.get(orchestra) != null) {
-        false
-      } else {
-        true
+      runBlocking {
+        if (screenshot != null) {
+          val file = File(screenshotsDir, "${screenshot.path}.png").apply { parentFile?.mkdirs() }
+          maestro.takeScreenshot(file.sink(), false)
+        } else {
+          orchestra.runFlow(actions)
+        }
       }
-      orchestra.executeCommands(actions, shouldReinitJsEngine = shouldJsReinit)
     }
   }
 
   public override fun waitForAppToSettle(appId: String?) {
     ensureConnected()
-    maestro.waitForAppToSettle(appId = appId)
+    runBlocking { maestro.waitForAppToSettle(appId = appId) }
   }
 
   override fun elements(): ArbigentElementList {
     ensureConnected()
     for (it in 0..2) {
       try {
-        val viewHierarchy = maestro.viewHierarchy(false)
+        val viewHierarchy = runBlocking { maestro.viewHierarchy(false) }
         val deviceInfo = maestro.cachedDeviceInfo
         val elementList = ArbigentElementList.from(viewHierarchy, deviceInfo)
         return elementList
@@ -266,7 +278,7 @@ public class MaestroDevice(
     ensureConnected()
     for (it in 0..2) {
       try {
-        val viewHierarchy = maestro.viewHierarchy(false)
+        val viewHierarchy = runBlocking { maestro.viewHierarchy(false) }
         return ArbigentUiTreeStrings(
           allTreeString = viewHierarchy.toString(),
           optimizedTreeString = viewHierarchy.toOptimizedString(
@@ -362,7 +374,7 @@ public class MaestroDevice(
     ensureConnected()
     moveFocusToElement(
       fetchTarget = {
-        val newElement = maestro.viewHierarchy().refreshedElement(element.identifierData)
+        val newElement = runBlocking { maestro.viewHierarchy() }.refreshedElement(element.identifierData)
         val bounds = newElement?.toUiElement()?.bounds
         if (bounds == null) {
           arbigentInfoLog("Element(${element.treeNode.getIdentifierDataForFocus()}) not found in current ViewHierarchy.")
@@ -522,8 +534,10 @@ public class MaestroDevice(
 
       val direction = directionCandidates.random()
       arbigentDebugLog("directionCandidates: $directionCandidates \ndirection: $direction")
-      maestro.pressKey(direction)
-      maestro.waitForAnimationToEnd(100)
+      runBlocking {
+        maestro.pressKey(direction)
+        maestro.waitForAnimationToEnd("100")
+      }
     }
   }
 
@@ -531,28 +545,30 @@ public class MaestroDevice(
     return when (selector) {
       is ArbigentTvCompatDevice.Selector.ById -> {
         try {
-          val element: FindElementResult = maestro.findElementWithTimeout(
+          val element: FindElementResult = runBlocking { maestro.findElementWithTimeout(
             timeoutMs = 100,
             filter = Filters.compose(
               Filters.idMatches(selector.id.toRegex()),
               Filters.index(selector.index)
             ),
-          ) ?: throw MaestroException.ElementNotFound(
+          ) } ?: throw MaestroException.ElementNotFound(
             "Element not found",
-            maestro.viewHierarchy().root
+            runBlocking { maestro.viewHierarchy() }.root,
+            "Element not found",
           )
           val uiElement: UiElement = element.element
           uiElement
         } catch (e: MaestroException.ElementNotFound) {
-          val element: FindElementResult = maestro.findElementWithTimeout(
+          val element: FindElementResult = runBlocking { maestro.findElementWithTimeout(
             timeoutMs = 100,
             filter = Filters.compose(
               Filters.idMatches((".*" + selector.id + ".*").toRegex()),
               Filters.index(selector.index)
             )
-          ) ?: throw MaestroException.ElementNotFound(
+          ) } ?: throw MaestroException.ElementNotFound(
             "Element not found",
-            maestro.viewHierarchy().root
+            runBlocking { maestro.viewHierarchy() }.root,
+            "Element not found",
           )
           val uiElement: UiElement = element.element
           uiElement
@@ -561,28 +577,30 @@ public class MaestroDevice(
 
       is ArbigentTvCompatDevice.Selector.ByText -> {
         try {
-          val element: FindElementResult = maestro.findElementWithTimeout(
+          val element: FindElementResult = runBlocking { maestro.findElementWithTimeout(
             timeoutMs = 100,
             filter = Filters.compose(
               Filters.textMatches(selector.text.toRegex()),
               Filters.index(selector.index)
             ),
-          ) ?: throw MaestroException.ElementNotFound(
+          ) } ?: throw MaestroException.ElementNotFound(
             "Element not found",
-            maestro.viewHierarchy().root
+            runBlocking { maestro.viewHierarchy() }.root,
+            "Element not found",
           )
           val uiElement: UiElement = element.element
           uiElement
         } catch (e: MaestroException.ElementNotFound) {
-          val element: FindElementResult = maestro.findElementWithTimeout(
+          val element: FindElementResult = runBlocking { maestro.findElementWithTimeout(
             timeoutMs = 100,
             filter = Filters.compose(
               Filters.textMatches((".*" + selector.text + ".*").toRegex()),
               Filters.index(selector.index)
             )
-          ) ?: throw MaestroException.ElementNotFound(
+          ) } ?: throw MaestroException.ElementNotFound(
             "Element not found",
-            maestro.viewHierarchy().root
+            runBlocking { maestro.viewHierarchy() }.root,
+            "Element not found",
           )
           val uiElement: UiElement = element.element
           uiElement
@@ -592,7 +610,7 @@ public class MaestroDevice(
   }
 
   private fun findCurrentFocus(): TreeNode? {
-    val viewHierarchy = maestro.viewHierarchy(false)
+    val viewHierarchy = runBlocking { maestro.viewHierarchy(false) }
     return dfs(viewHierarchy.root) {
       // If keyboard is focused, return the focused node with keyboard
       it.attributes["resource-id"]?.startsWith("com.google.android.inputmethod.latin:id/") == true && it.focused == true
@@ -609,7 +627,7 @@ public class MaestroDevice(
   
   private fun updateConnection(newMaestro: Maestro) {
     this.maestro = newMaestro
-    this.orchestra = Orchestra(maestro = this.maestro, screenshotsDir = this.screenshotsDir)
+    this.orchestra = Orchestra(maestro = this.maestro)
   }
 
   private fun reconnectIfDisconnected() {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -972,8 +972,9 @@ private fun TreeNode.getIdentifierDataForFocus(): List<Any> {
 }
 
 // takeScreenshot paths come from user-authored flows, so they must not escape screenshotsDir.
-// Reject absolute or parent-traversing paths lexically, then canonicalize after creating the
-// parent so a symlinked component that escapes the base is resolved and caught here too.
+// Reject absolute or parent-traversing paths lexically, then canonicalize (without creating any
+// directories) so a symlinked component that escapes the base is resolved and caught before we
+// create the parent directory.
 internal fun resolveScreenshotFile(screenshotsDir: File, path: String): File {
   val base = screenshotsDir.canonicalFile
   val requested = File("$path.png")
@@ -983,10 +984,10 @@ internal fun resolveScreenshotFile(screenshotsDir: File, path: String): File {
   require(requested.invariantSeparatorsPath.split('/').none { it == ".." }) {
     "Screenshot path must not traverse outside the screenshots directory: $path"
   }
-  val target = File(base, requested.path).apply { parentFile?.mkdirs() }
-  val canonical = target.canonicalFile
+  val canonical = File(base, requested.path).canonicalFile
   require(canonical.toPath().startsWith(base.toPath())) {
     "Screenshot path escapes the screenshots directory: $path"
   }
+  canonical.parentFile?.mkdirs()
   return canonical
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -243,7 +243,7 @@ public class MaestroDevice(
     ArbigentGlobalStatus.onDevice(actions.joinToString { it.toString() }) {
       runBlocking {
         if (screenshot != null) {
-          val file = File(screenshotsDir, "${screenshot.path}.png").apply { parentFile?.mkdirs() }
+          val file = resolveScreenshotFile(screenshotsDir, screenshot.path)
           maestro.takeScreenshot(file.sink(), false)
         } else {
           orchestra.runFlow(actions)
@@ -969,4 +969,24 @@ public fun TreeNode.optimizeTree(
 private fun TreeNode.getIdentifierDataForFocus(): List<Any> {
   val sortedAttributes = (attributes - "bounds" - "focused" - "selected").toSortedMap()
   return listOf(sortedAttributes) + children.map { it.getIdentifierDataForFocus() }
+}
+
+// takeScreenshot paths come from user-authored flows, so they must not escape screenshotsDir.
+// Reject absolute or parent-traversing paths lexically, then canonicalize after creating the
+// parent so a symlinked component that escapes the base is resolved and caught here too.
+internal fun resolveScreenshotFile(screenshotsDir: File, path: String): File {
+  val base = screenshotsDir.canonicalFile
+  val requested = File("$path.png")
+  require(!requested.isAbsolute) {
+    "Screenshot path must be relative to the screenshots directory: $path"
+  }
+  require(requested.invariantSeparatorsPath.split('/').none { it == ".." }) {
+    "Screenshot path must not traverse outside the screenshots directory: $path"
+  }
+  val target = File(base, requested.path).apply { parentFile?.mkdirs() }
+  val canonical = target.canonicalFile
+  require(canonical.toPath().startsWith(base.toPath())) {
+    "Screenshot path escapes the screenshots directory: $path"
+  }
+  return canonical
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
@@ -41,8 +41,12 @@ public sealed interface ArbigentAvailableDevice {
       // Maestro's AndroidDeviceConnection refactor (#3372) made AndroidDriver take an
       // AndroidDeviceConnection instead of a raw Dadb. byId() selects the same device by
       // serial that Dadb.list() gave us, so this keeps behavior identical.
-      val connection = AndroidDeviceConnection.byId(dadb.toString())
-        ?: throw RuntimeException("Arbigent could not open an AndroidDeviceConnection for device: $dadb")
+      val serial = dadb.toString()
+      // AndroidDriver/Maestro opens and manages its own connection via byId(serial), so the
+      // Dadb we were handed from Dadb.list() is no longer needed once we have the serial.
+      dadb.close()
+      val connection = AndroidDeviceConnection.byId(serial)
+        ?: throw RuntimeException("Arbigent could not open an AndroidDeviceConnection for device: $serial")
       val driver = AndroidDriver(
         connection,
       )
@@ -52,11 +56,9 @@ public sealed interface ArbigentAvailableDevice {
         )
       } catch (e: java.util.concurrent.TimeoutException) {
         driver.close()
-        dadb.close()
         throw RuntimeException("Arbigent can not connect to device in time. The likely reason why we can't connect is that you have multiple instance of Arbigent like UI and CLI of Arbigent", e)
       } catch (e: Exception) {
         driver.close()
-        dadb.close()
         throw e
       }
       return MaestroDevice(maestro, availableDevice = this)

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
@@ -1,17 +1,25 @@
 package io.github.takahirom.arbigent
 
 import dadb.Dadb
+import kotlinx.coroutines.runBlocking
+import device.SimctlIOSDevice
 import ios.LocalIOSDevice
-import ios.simctl.SimctlIOSDevice
 import ios.xctest.XCTestIOSDevice
 import maestro.Maestro
+import maestro.android.AndroidDeviceConnection
 import maestro.drivers.AndroidDriver
 import maestro.drivers.IOSDriver
+import maestro.utils.NoopInsights
+import maestro.utils.TempFileHandler
+import util.IOSDeviceType
 import util.SimctlList
 import util.XCRunnerCLIUtils
 import xcuitest.XCTestClient
 import xcuitest.XCTestDriverClient
+import xcuitest.installer.Context
 import xcuitest.installer.LocalXCTestInstaller
+import xcuitest.installer.LocalXCTestInstaller.IOSDriverConfig
+import java.io.File
 
 public enum class ArbigentDeviceOs {
   Android, Ios, Web;
@@ -30,8 +38,13 @@ public sealed interface ArbigentAvailableDevice {
     override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Android
     override val name: String = dadb.toString()
     override fun connectToDevice(): ArbigentDevice {
+      // Maestro's AndroidDeviceConnection refactor (#3372) made AndroidDriver take an
+      // AndroidDeviceConnection instead of a raw Dadb. byId() selects the same device by
+      // serial that Dadb.list() gave us, so this keeps behavior identical.
+      val connection = AndroidDeviceConnection.byId(dadb.toString())
+        ?: throw RuntimeException("Arbigent could not open an AndroidDeviceConnection for device: $dadb")
       val driver = AndroidDriver(
-        dadb,
+        connection,
       )
       val maestro = try {
         Maestro.android(
@@ -53,8 +66,8 @@ public sealed interface ArbigentAvailableDevice {
   public class IOS(
     private val device: SimctlList.Device,
     private val port: Int = 8080,
-    // local host
-    private val host: String = "[::1]",
+    // Maestro 2.x's FlyingFox runner binds to 127.0.0.1 (IPv4 only), so [::1] is refused.
+    private val host: String = "127.0.0.1",
   ) : ArbigentAvailableDevice {
     override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Ios
     override val name: String = device.name
@@ -62,22 +75,45 @@ public sealed interface ArbigentAvailableDevice {
       val port = port
       val host = host
 
+      // Maestro's iOS driver refactor split simctl control into a device.SimctlIOSDevice
+      // built from a shared TempFileHandler, and LocalXCTestInstaller now takes an explicit
+      // IOSDriverConfig plus that device controller. This wires up the simulator path with
+      // the same host/port/UDID as before; XCTest output now goes to a logs dir rather than
+      // the removed enableXCTestOutputFileLogging flag.
+      val tempFileHandler = TempFileHandler()
+      val deviceController = SimctlIOSDevice(
+        deviceId = device.udid,
+        tempFileHandler = tempFileHandler,
+      )
+
       val xcTestInstaller = LocalXCTestInstaller(
         deviceId = device.udid, // Use the device's UDID
         host = host,
+        deviceType = IOSDeviceType.SIMULATOR,
         defaultPort = port,
-        enableXCTestOutputFileLogging = true,
+        reinstallDriver = true,
+        iOSDriverConfig = IOSDriverConfig(
+          prebuiltRunner = false,
+          sourceDirectory = "driver-iPhoneSimulator",
+          context = Context.CLI,
+          snapshotKeyHonorModalViews = null,
+        ),
+        deviceController = deviceController,
+        tempFileHandler = tempFileHandler,
+        logsDir = xctestLogsDir(),
       )
 
       val xcTestDriverClient = XCTestDriverClient(
         installer = xcTestInstaller,
         client = XCTestClient(host, port), // Use the same host and port as above
+        reinstallDriver = true,
       )
+      val xcRunnerCLIUtils = XCRunnerCLIUtils(tempFileHandler)
 
       val xcTestDevice = XCTestIOSDevice(
         deviceId = device.udid,
         client = xcTestDriverClient,
-        getInstalledApps = { XCRunnerCLIUtils.listApps(device.udid) },
+        getInstalledApps = { xcRunnerCLIUtils.listApps(device.udid) },
       )
 
       val maestro = Maestro.ios(
@@ -85,7 +121,8 @@ public sealed interface ArbigentAvailableDevice {
           LocalIOSDevice(
             deviceId = device.udid,
             xcTestDevice = xcTestDevice,
-            simctlIOSDevice = SimctlIOSDevice(device.udid)
+            deviceController = deviceController,
+            insights = NoopInsights,
           )
         )
       )
@@ -118,7 +155,7 @@ public sealed interface ArbigentAvailableDevice {
       var responsive = false
       while (System.currentTimeMillis() - start < warmUpTimeoutMs) {
         try {
-          maestro.viewHierarchy()
+          runBlocking { maestro.viewHierarchy() }
           responsive = true
           break
         } catch (e: Exception) {
@@ -134,6 +171,11 @@ public sealed interface ArbigentAvailableDevice {
       Thread.sleep(settleMs)
       arbigentInfoLog("iOS warm-up done")
     }
+
+    // LocalXCTestInstaller writes XCTest runner logs here, replacing the removed
+    // enableXCTestOutputFileLogging flag.
+    private fun xctestLogsDir(): File =
+      File(ArbigentFiles.parentDir, "xctest-logs").apply { mkdirs() }
   }
 
   public class Web : ArbigentAvailableDevice {
@@ -141,7 +183,8 @@ public sealed interface ArbigentAvailableDevice {
     override val name: String = "Chrome"
     public override fun connectToDevice(): ArbigentDevice {
       return MaestroDevice(
-        Maestro.web(false, false),
+        // Maestro.web() gained a third arg (custom Chrome binary path); null keeps the default.
+        Maestro.web(false, false, null),
         availableDevice = this
       )
     }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
@@ -1,6 +1,7 @@
 package io.github.takahirom.arbigent
 
 import dadb.Dadb
+import maestro.utils.TempFileHandler
 import util.LocalSimulatorUtils
 
 @ArbigentInternalApi
@@ -11,7 +12,8 @@ public fun fetchAvailableDevicesByOs(deviceType: ArbigentDeviceOs): List<Arbigen
     }
 
     ArbigentDeviceOs.Ios -> {
-      LocalSimulatorUtils.list()
+      // LocalSimulatorUtils is now a class taking a TempFileHandler instead of an object.
+      LocalSimulatorUtils(TempFileHandler()).list()
         .devices
         .flatMap { runtime ->
           runtime.value

--- a/arbigent-core/src/test/java/ScreenshotPathContainmentTest.kt
+++ b/arbigent-core/src/test/java/ScreenshotPathContainmentTest.kt
@@ -59,4 +59,25 @@ class ScreenshotPathContainmentTest {
       resolveScreenshotFile(base, "link/shot")
     }
   }
+
+  @Test
+  fun symlinkEscapeCreatesNoDirectoryOutsideBase() {
+    val base = newBaseDir()
+    val outside = Files.createTempDirectory("outside").toFile()
+    val link = File(base, "link").toPath()
+    try {
+      Files.createSymbolicLink(link, outside.toPath())
+    } catch (_: UnsupportedOperationException) {
+      return // platform without symlink support (e.g. some Windows configs)
+    }
+    // A nested path under the symlink must be rejected before any parent directory is created,
+    // so the escape target gains no new subdirectory.
+    assertFailsWith<IllegalArgumentException> {
+      resolveScreenshotFile(base, "link/deep/shot")
+    }
+    assertTrue(
+      File(outside, "deep").listFiles() == null,
+      "no directory should be created outside the screenshots base"
+    )
+  }
 }

--- a/arbigent-core/src/test/java/ScreenshotPathContainmentTest.kt
+++ b/arbigent-core/src/test/java/ScreenshotPathContainmentTest.kt
@@ -1,0 +1,62 @@
+package io.github.takahirom.arbigent.test
+
+import io.github.takahirom.arbigent.resolveScreenshotFile
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ScreenshotPathContainmentTest {
+
+  private fun newBaseDir(): File = Files.createTempDirectory("screenshots").toFile()
+
+  @Test
+  fun resolvesSimpleNameInsideBase() {
+    val base = newBaseDir()
+    val file = resolveScreenshotFile(base, "shot")
+    assertEquals(File(base.canonicalFile, "shot.png"), file)
+    assertTrue(file.toPath().startsWith(base.canonicalFile.toPath()))
+  }
+
+  @Test
+  fun resolvesNestedRelativePath() {
+    val base = newBaseDir()
+    val file = resolveScreenshotFile(base, "sub/dir/shot")
+    assertTrue(file.parentFile.isDirectory, "nested parent should be created")
+    assertTrue(file.toPath().startsWith(base.canonicalFile.toPath()))
+  }
+
+  @Test
+  fun rejectsParentTraversal() {
+    val base = newBaseDir()
+    assertFailsWith<IllegalArgumentException> {
+      resolveScreenshotFile(base, "../../etc/passwd")
+    }
+  }
+
+  @Test
+  fun rejectsAbsolutePath() {
+    val base = newBaseDir()
+    assertFailsWith<IllegalArgumentException> {
+      resolveScreenshotFile(base, "/tmp/escape")
+    }
+  }
+
+  @Test
+  fun rejectsSymlinkEscape() {
+    val base = newBaseDir()
+    val outside = Files.createTempDirectory("outside").toFile()
+    // A symlinked subdirectory of base that points outside must not let writes escape.
+    val link = File(base, "link").toPath()
+    try {
+      Files.createSymbolicLink(link, outside.toPath())
+    } catch (_: UnsupportedOperationException) {
+      return // platform without symlink support (e.g. some Windows configs)
+    }
+    assertFailsWith<IllegalArgumentException> {
+      resolveScreenshotFile(base, "link/shot")
+    }
+  }
+}

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/FixedScenariosDialog.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/FixedScenariosDialog.kt
@@ -229,8 +229,12 @@ fun AddFixedScenarioDialog(
                         if (text.isNotBlank()) {
                             yamlError = try {
                                 // Try to parse the YAML to check syntax
+                                // checkSyntax now requires a flow path to resolve relative
+                                // includes; this dialog validates a standalone snippet, so the
+                                // working directory is a sufficient, behavior-preserving base.
                                 MaestroFlowParser.checkSyntax(
-                                    maestroCode = text
+                                    text,
+                                    java.nio.file.Paths.get(".")
                                 )
                                 null
                             } catch (e: Exception) {
@@ -358,8 +362,12 @@ fun EditFixedScenarioDialog(
                         if (text.isNotBlank()) {
                             yamlError = try {
                                 // Try to parse the YAML to check syntax
+                                // checkSyntax now requires a flow path to resolve relative
+                                // includes; this dialog validates a standalone snippet, so the
+                                // working directory is a sufficient, behavior-preserving base.
                                 MaestroFlowParser.checkSyntax(
-                                    maestroCode = text
+                                    text,
+                                    java.nio.file.Paths.get(".")
                                 )
                                 null
                             } catch (e: Exception) {

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/FixedScenariosDialog.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/FixedScenariosDialog.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import io.github.takahirom.arbigent.ArbigentFiles
 import io.github.takahirom.arbigent.FixedScenario
 import maestro.orchestra.yaml.MaestroFlowParser
 import org.jetbrains.jewel.ui.Orientation
@@ -230,11 +231,12 @@ fun AddFixedScenarioDialog(
                             yamlError = try {
                                 // Try to parse the YAML to check syntax
                                 // checkSyntax now requires a flow path to resolve relative
-                                // includes; this dialog validates a standalone snippet, so the
-                                // working directory is a sufficient, behavior-preserving base.
+                                // includes; use the same base the runtime uses (ArbigentAgent
+                                // resolves flows against ArbigentFiles.parentDir) so validation
+                                // agrees with runtime include resolution.
                                 MaestroFlowParser.checkSyntax(
                                     text,
-                                    java.nio.file.Paths.get(".")
+                                    Path(ArbigentFiles.parentDir)
                                 )
                                 null
                             } catch (e: Exception) {
@@ -363,11 +365,12 @@ fun EditFixedScenarioDialog(
                             yamlError = try {
                                 // Try to parse the YAML to check syntax
                                 // checkSyntax now requires a flow path to resolve relative
-                                // includes; this dialog validates a standalone snippet, so the
-                                // working directory is a sufficient, behavior-preserving base.
+                                // includes; use the same base the runtime uses (ArbigentAgent
+                                // resolves flows against ArbigentFiles.parentDir) so validation
+                                // agrees with runtime include resolution.
                                 MaestroFlowParser.checkSyntax(
                                     text,
-                                    java.nio.file.Paths.get(".")
+                                    Path(ArbigentFiles.parentDir)
                                 )
                                 null
                             } catch (e: Exception) {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,10 @@ plugins {
     alias(libs.plugins.buildconfig) apply false
 }
 
+// Registers downloadMaestroZip / extractMaestroJars and exposes the extracted maestro-*
+// jars via rootProject.extra["maestroJars"]. See gradle/maestro.gradle.kts.
+apply(from = "gradle/maestro.gradle.kts")
+
 allprojects {
     tasks.withType(Test::class).configureEach {
         testLogging {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,7 +16,6 @@ kotlinx-datetime = "0.7.1"
 kotlinx-io = "0.3.3"
 webpImageio = "0.3.3"
 identityJvm = "202411.1"
-maestro = "1.40.0"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
@@ -43,11 +42,6 @@ ktor-serialization-json = { module = "io.ktor:ktor-serialization-kotlinx-json", 
 kotlinx-io-core = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinx-io" }
 identity-jvm = { group = "com.android.identity", name = "identity-jvm", version.ref = "identityJvm" }
 webp-imageio = { module = "io.github.darkxanter:webp-imageio", version.ref = "webpImageio" }
-
-maestro-orchestra = { module = "dev.mobile:maestro-orchestra", version.ref = "maestro" }
-maestro-client = { module = "dev.mobile:maestro-client", version.ref = "maestro" }
-maestro-ios = { module = "dev.mobile:maestro-ios", version.ref = "maestro" }
-maestro-ios-driver = { module = "dev.mobile:maestro-ios-driver", version.ref = "maestro" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/gradle/maestro.gradle.kts
+++ b/gradle/maestro.gradle.kts
@@ -63,40 +63,68 @@ fun sha256(file: File): String {
   return digest.digest().joinToString("") { "%02x".format(it) }
 }
 
+// The maestro cache lives under the shared Gradle user home, so concurrent Gradle invocations
+// (CI matrix, parallel module builds) can race to write the same zip/jar while another process
+// reads it. Serialize every write to the cache with a cross-process file lock; the lock file is
+// never a published artifact, so creating it is harmless.
+fun <T> withMaestroCacheLock(block: () -> T): T {
+  maestroCacheDir.mkdirs()
+  val lockFile = maestroCacheDir.resolve(".lock")
+  return java.io.RandomAccessFile(lockFile, "rw").use { raf ->
+    raf.channel.lock().use { block() }
+  }
+}
+
+// Publish a fully-built file into its shared location atomically, so a concurrent reader never
+// observes a half-written target. Copy into a sibling temp in the destination dir first (works
+// even when source and target are on different filesystems), then rename it into place: rename
+// within a filesystem is atomic. The source is left intact so callers can keep it as a build
+// output for up-to-date checking.
+fun publishFileAtomically(source: File, target: File) {
+  target.parentFile.mkdirs()
+  val sibling = File.createTempFile("publish", ".tmp", target.parentFile)
+  try {
+    source.copyTo(sibling, overwrite = true)
+    java.nio.file.Files.move(
+      sibling.toPath(), target.toPath(),
+      java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+      java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+    )
+  } finally {
+    sibling.delete()
+  }
+}
+
 val downloadMaestroZip = tasks.register("downloadMaestroZip") {
   description = "Download the pinned Maestro release artifact and verify its sha256 checksum."
   group = "maestro"
   outputs.file(maestroZipFile)
   outputs.upToDateWhen { maestroZipFile.exists() && sha256(maestroZipFile) == maestroZipSha256 }
   doLast {
-    maestroCacheDir.mkdirs()
-    if (maestroZipFile.exists() && sha256(maestroZipFile) == maestroZipSha256) return@doLast
-    logger.lifecycle("Downloading Maestro $maestroVersion from $maestroZipUrl")
-    val tmp = File.createTempFile("maestro", ".zip", maestroCacheDir)
-    try {
-      uri(maestroZipUrl).toURL().openStream().use { input ->
-        tmp.outputStream().use { output -> input.copyTo(output) }
+    withMaestroCacheLock {
+      if (maestroZipFile.exists() && sha256(maestroZipFile) == maestroZipSha256) return@withMaestroCacheLock
+      logger.lifecycle("Downloading Maestro $maestroVersion from $maestroZipUrl")
+      val tmp = File.createTempFile("maestro", ".zip", maestroCacheDir)
+      try {
+        uri(maestroZipUrl).toURL().openStream().use { input ->
+          tmp.outputStream().use { output -> input.copyTo(output) }
+        }
+        val actual = sha256(tmp)
+        check(actual == maestroZipSha256) {
+          "Maestro zip checksum mismatch for $maestroZipUrl: expected $maestroZipSha256 but got $actual"
+        }
+        publishFileAtomically(tmp, maestroZipFile)
+      } finally {
+        tmp.delete()
       }
-      val actual = sha256(tmp)
-      check(actual == maestroZipSha256) {
-        "Maestro zip checksum mismatch for $maestroZipUrl: expected $maestroZipSha256 but got $actual"
-      }
-      // Publish atomically: rename is atomic within a filesystem, so a concurrent build never
-      // observes a half-written zip the way an incremental copyTo could expose. tmp lives in
-      // maestroCacheDir alongside the target, so rename succeeds here; fall back to copy+delete
-      // only if it fails (e.g. across filesystems).
-      if (!tmp.renameTo(maestroZipFile)) {
-        tmp.copyTo(maestroZipFile, overwrite = true)
-      }
-    } finally {
-      tmp.delete()
     }
   }
 }
 
-// Extracts the maestro-* jars into a flat directory. A later PR adding real-device support
-// can extract the zip's driver-iphoneos/ products here too by registering a sibling task
-// against the same downloaded zip.
+// Extract into the (per-build, non-shared) build directory so Gradle's own up-to-date checking
+// applies, then publish each jar into the shared cache atomically via publishMaestroJars. A
+// later PR adding real-device support can extract the zip's driver-iphoneos/ products here too.
+val maestroJarsStagingDir: File = layout.buildDirectory.dir("maestro/jars-staging").get().asFile
 val extractMaestroJars = tasks.register<Copy>("extractMaestroJars") {
   description = "Extract the maestro-* jars arbigent depends on from the pinned release artifact."
   group = "maestro"
@@ -106,7 +134,21 @@ val extractMaestroJars = tasks.register<Copy>("extractMaestroJars") {
     eachFile { path = name } // flatten maestro/lib/<jar> -> <jar>
   }
   includeEmptyDirs = false
-  into(maestroJarsDir)
+  into(maestroJarsStagingDir)
+}
+
+val publishMaestroJars = tasks.register("publishMaestroJars") {
+  description = "Atomically publish the extracted maestro-* jars into the shared cache."
+  group = "maestro"
+  dependsOn(extractMaestroJars)
+  outputs.dir(maestroJarsDir)
+  doLast {
+    withMaestroCacheLock {
+      maestroJarsStagingDir.listFiles()?.forEach { jar ->
+        publishFileAtomically(jar, maestroJarsDir.resolve(jar.name))
+      }
+    }
+  }
 }
 
 // maestro-web.jar's CdpClient is compiled against ktor 2.3.13, but arbigent-mcp-client pulls
@@ -132,30 +174,48 @@ val maestroWebKtor2Jars: FileCollection = maestroWebKtor2.incoming.artifactView 
   componentFilter { it is ModuleComponentIdentifier && it.group == "io.ktor" }
 }.files
 
+// Shade into the (per-build, non-shared) build directory so Gradle's own up-to-date checking
+// applies and concurrent builds never write the same shared jar; publishShadedMaestroWeb then
+// moves it into the shared cache atomically. Read the plain maestro-web.jar from the extraction
+// staging dir rather than the shared cache to avoid reading a jar another build is publishing.
+val maestroShadedStagingDir: File = layout.buildDirectory.dir("maestro/shaded-staging").get().asFile
 val shadeMaestroWeb = tasks.register<ShadowJar>("shadeMaestroWeb") {
   description = "Relocate ktor 2.3.13 inside maestro-web to avoid clashing with arbigent's ktor 3.x."
   group = "maestro"
   dependsOn(extractMaestroJars)
-  from(zipTree(maestroJarsDir.resolve("maestro-web.jar")))
+  from(zipTree(maestroJarsStagingDir.resolve("maestro-web.jar")))
   from({ maestroWebKtor2Jars.map { zipTree(it) } })
   relocate("io.ktor", "arbigent.shaded.io.ktor")
   mergeServiceFiles() // ktor engines register via META-INF/services; merge + relocate their entries
   exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "**/module-info.class")
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
   archiveFileName.set("maestro-web-shaded.jar")
-  destinationDirectory.set(maestroShadedDir)
+  destinationDirectory.set(maestroShadedStagingDir)
+}
+
+val shadedMaestroWebJar: File = maestroShadedDir.resolve("maestro-web-shaded.jar")
+val publishShadedMaestroWeb = tasks.register("publishShadedMaestroWeb") {
+  description = "Atomically publish the shaded maestro-web jar into the shared cache."
+  group = "maestro"
+  dependsOn(shadeMaestroWeb)
+  outputs.file(shadedMaestroWebJar)
+  doLast {
+    withMaestroCacheLock {
+      publishFileAtomically(maestroShadedStagingDir.resolve("maestro-web-shaded.jar"), shadedMaestroWebJar)
+    }
+  }
 }
 
 // Individual jars (not the directory) so they land on the compile/runtime classpath as
-// libraries. builtBy carries the extraction task dependency to any consumer that uses this
+// libraries. builtBy carries the publication task dependency to any consumer that uses this
 // collection as a dependency. The plain maestro-web.jar is excluded in favour of the shaded one.
 val maestroJars: FileCollection = files(
   fileTree(maestroJarsDir) {
     include("*.jar")
     exclude("maestro-web.jar")
-    builtBy(extractMaestroJars)
+    builtBy(publishMaestroJars)
   },
-  shadeMaestroWeb,
+  files(shadedMaestroWebJar).builtBy(publishShadedMaestroWeb),
 )
 
 // Consumed by modules via rootProject.extra: dependencies { api(rootMaestroJars()) }.

--- a/gradle/maestro.gradle.kts
+++ b/gradle/maestro.gradle.kts
@@ -24,6 +24,7 @@ val maestroJarEntries = listOf(
   "maestro/lib/maestro-ios-driver.jar",
   "maestro/lib/maestro-utils.jar",
   "maestro/lib/maestro-ai.jar",
+  "maestro/lib/maestro-web.jar",
 )
 
 // Cache under the Gradle user home so the download survives `clean` and is shared across

--- a/gradle/maestro.gradle.kts
+++ b/gradle/maestro.gradle.kts
@@ -121,10 +121,17 @@ val downloadMaestroZip = tasks.register("downloadMaestroZip") {
   }
 }
 
-// Extract into the (per-build, non-shared) build directory so Gradle's own up-to-date checking
-// applies, then publish each jar into the shared cache atomically via publishMaestroJars. A
-// later PR adding real-device support can extract the zip's driver-iphoneos/ products here too.
-val maestroJarsStagingDir: File = layout.buildDirectory.dir("maestro/jars-staging").get().asFile
+// Stage into a unique temp directory under the (per-checkout) build directory rather than a fixed
+// path, so two Gradle invocations sharing the same checkout never overwrite each other's staging
+// jars while one is mid-extract/shade. Each staged jar is then published into the shared cache
+// atomically. The temp dirs are created lazily (only when a maestro task actually runs) so
+// unrelated builds don't litter the build directory. A later PR adding real-device support can
+// extract the zip's driver-iphoneos/ products into the same staging area.
+val maestroStagingBase: File = layout.buildDirectory.dir("maestro").get().asFile
+val maestroJarsStagingDir: File by lazy {
+  maestroStagingBase.mkdirs()
+  java.nio.file.Files.createTempDirectory(maestroStagingBase.toPath(), "jars-staging").toFile()
+}
 val extractMaestroJars = tasks.register<Copy>("extractMaestroJars") {
   description = "Extract the maestro-* jars arbigent depends on from the pinned release artifact."
   group = "maestro"
@@ -134,7 +141,7 @@ val extractMaestroJars = tasks.register<Copy>("extractMaestroJars") {
     eachFile { path = name } // flatten maestro/lib/<jar> -> <jar>
   }
   includeEmptyDirs = false
-  into(maestroJarsStagingDir)
+  into(java.util.concurrent.Callable { maestroJarsStagingDir })
 }
 
 val publishMaestroJars = tasks.register("publishMaestroJars") {
@@ -143,8 +150,9 @@ val publishMaestroJars = tasks.register("publishMaestroJars") {
   dependsOn(extractMaestroJars)
   outputs.dir(maestroJarsDir)
   doLast {
+    val staged = maestroJarsStagingDir.listFiles().orEmpty()
     withMaestroCacheLock {
-      maestroJarsStagingDir.listFiles()?.forEach { jar ->
+      staged.forEach { jar ->
         publishFileAtomically(jar, maestroJarsDir.resolve(jar.name))
       }
     }
@@ -174,23 +182,26 @@ val maestroWebKtor2Jars: FileCollection = maestroWebKtor2.incoming.artifactView 
   componentFilter { it is ModuleComponentIdentifier && it.group == "io.ktor" }
 }.files
 
-// Shade into the (per-build, non-shared) build directory so Gradle's own up-to-date checking
-// applies and concurrent builds never write the same shared jar; publishShadedMaestroWeb then
-// moves it into the shared cache atomically. Read the plain maestro-web.jar from the extraction
-// staging dir rather than the shared cache to avoid reading a jar another build is publishing.
-val maestroShadedStagingDir: File = layout.buildDirectory.dir("maestro/shaded-staging").get().asFile
+// Shade into a unique temp directory under the build directory (as for extraction) so concurrent
+// builds in the same checkout never write the same staging jar; publishShadedMaestroWeb then moves
+// it into the shared cache atomically. Read the plain maestro-web.jar from the extraction staging
+// dir rather than the shared cache to avoid reading a jar another build is publishing.
+val maestroShadedStagingDir: File by lazy {
+  maestroStagingBase.mkdirs()
+  java.nio.file.Files.createTempDirectory(maestroStagingBase.toPath(), "shaded-staging").toFile()
+}
 val shadeMaestroWeb = tasks.register<ShadowJar>("shadeMaestroWeb") {
   description = "Relocate ktor 2.3.13 inside maestro-web to avoid clashing with arbigent's ktor 3.x."
   group = "maestro"
   dependsOn(extractMaestroJars)
-  from(zipTree(maestroJarsStagingDir.resolve("maestro-web.jar")))
+  from({ zipTree(maestroJarsStagingDir.resolve("maestro-web.jar")) })
   from({ maestroWebKtor2Jars.map { zipTree(it) } })
   relocate("io.ktor", "arbigent.shaded.io.ktor")
   mergeServiceFiles() // ktor engines register via META-INF/services; merge + relocate their entries
   exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "**/module-info.class")
   duplicatesStrategy = DuplicatesStrategy.EXCLUDE
   archiveFileName.set("maestro-web-shaded.jar")
-  destinationDirectory.set(maestroShadedStagingDir)
+  destinationDirectory.set(layout.dir(provider { maestroShadedStagingDir }))
 }
 
 val shadedMaestroWebJar: File = maestroShadedDir.resolve("maestro-web-shaded.jar")

--- a/gradle/maestro.gradle.kts
+++ b/gradle/maestro.gradle.kts
@@ -1,5 +1,19 @@
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import java.io.File
 import java.security.MessageDigest
+
+// Shadow (gradleup fork) provides the ShadowJar task type used below to relocate ktor
+// inside maestro-web. It works on arbitrary jar/config inputs, so no project sources are shaded.
+buildscript {
+  repositories {
+    mavenCentral()
+    gradlePluginPortal()
+  }
+  dependencies {
+    classpath("com.gradleup.shadow:shadow-gradle-plugin:8.3.6")
+  }
+}
 
 // Single source of truth for the pinned Maestro release consumed by arbigent.
 //
@@ -32,6 +46,9 @@ val maestroJarEntries = listOf(
 val maestroCacheDir: File = gradle.gradleUserHomeDir.resolve("caches/arbigent-maestro/$maestroVersion")
 val maestroZipFile: File = maestroCacheDir.resolve("maestro.zip")
 val maestroJarsDir: File = maestroCacheDir.resolve("jars")
+// Shaded maestro-web lives outside maestroJarsDir so the maestroJars fileTree doesn't pick up
+// the plain jar; only the shaded one reaches the classpath.
+val maestroShadedDir: File = maestroCacheDir.resolve("shaded")
 
 fun sha256(file: File): String {
   val digest = MessageDigest.getInstance("SHA-256")
@@ -86,13 +103,54 @@ val extractMaestroJars = tasks.register<Copy>("extractMaestroJars") {
   into(maestroJarsDir)
 }
 
+// maestro-web.jar's CdpClient is compiled against ktor 2.3.13, but arbigent-mcp-client pulls
+// the MCP kotlin-sdk which requires ktor 3.x, so Gradle bumps ktor to 3.x on the shared
+// classpath. ktor 3 dropped io.ktor.client.plugins.contentnegotiation.ContentNegotiation (and
+// more), so maestro-web hits NoClassDefFoundError at runtime. maestro-client's CdpWebDriver
+// touches no ktor type across the boundary (it only calls maestro.web.* ), so relocating ktor
+// *inside* maestro-web is safe: we bundle the matching ktor 2.3.13 classes under a private
+// package and rewrite maestro-web's references to point at them, leaving the rest of arbigent
+// on ktor 3.x. Nothing else in the maestro jars references ktor except maestro-ai, which
+// arbigent never loads.
+val maestroWebKtor2: Configuration = configurations.detachedConfiguration(
+  dependencies.create("io.ktor:ktor-client-core:2.3.13"),
+  dependencies.create("io.ktor:ktor-client-cio:2.3.13"),
+  dependencies.create("io.ktor:ktor-client-content-negotiation:2.3.13"),
+  dependencies.create("io.ktor:ktor-client-websockets:2.3.13"),
+  dependencies.create("io.ktor:ktor-serialization-kotlinx-json:2.3.13"),
+)
+
+// Only the io.ktor artifacts from the resolved graph get shaded in; kotlinx/kotlin/slf4j stay
+// as ordinary (unrelocated) classpath deps supplied by arbigent so we don't ship duplicates.
+val maestroWebKtor2Jars: FileCollection = maestroWebKtor2.incoming.artifactView {
+  componentFilter { it is ModuleComponentIdentifier && it.group == "io.ktor" }
+}.files
+
+val shadeMaestroWeb = tasks.register<ShadowJar>("shadeMaestroWeb") {
+  description = "Relocate ktor 2.3.13 inside maestro-web to avoid clashing with arbigent's ktor 3.x."
+  group = "maestro"
+  dependsOn(extractMaestroJars)
+  from(zipTree(maestroJarsDir.resolve("maestro-web.jar")))
+  from({ maestroWebKtor2Jars.map { zipTree(it) } })
+  relocate("io.ktor", "arbigent.shaded.io.ktor")
+  mergeServiceFiles() // ktor engines register via META-INF/services; merge + relocate their entries
+  exclude("META-INF/*.SF", "META-INF/*.DSA", "META-INF/*.RSA", "**/module-info.class")
+  duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+  archiveFileName.set("maestro-web-shaded.jar")
+  destinationDirectory.set(maestroShadedDir)
+}
+
 // Individual jars (not the directory) so they land on the compile/runtime classpath as
 // libraries. builtBy carries the extraction task dependency to any consumer that uses this
-// collection as a dependency.
-val maestroJars: FileCollection = fileTree(maestroJarsDir) {
-  include("*.jar")
-  builtBy(extractMaestroJars)
-}
+// collection as a dependency. The plain maestro-web.jar is excluded in favour of the shaded one.
+val maestroJars: FileCollection = files(
+  fileTree(maestroJarsDir) {
+    include("*.jar")
+    exclude("maestro-web.jar")
+    builtBy(extractMaestroJars)
+  },
+  shadeMaestroWeb,
+)
 
 // Consumed by modules via rootProject.extra: dependencies { api(rootMaestroJars()) }.
 extra["maestroJars"] = maestroJars

--- a/gradle/maestro.gradle.kts
+++ b/gradle/maestro.gradle.kts
@@ -1,0 +1,97 @@
+import java.io.File
+import java.security.MessageDigest
+
+// Single source of truth for the pinned Maestro release consumed by arbigent.
+//
+// Maestro stopped publishing its `dev.mobile:maestro-*` artifacts to Maven Central at
+// 1.40.0; 2.x is distributed only as jars bundled inside the official CLI zip. We pin
+// that zip by version + sha256, download and verify it once, extract the maestro-* jars
+// arbigent needs, and expose them as file dependencies (see arbigent-core/build.gradle.kts).
+// The maestro jars' own transitive dependencies (grpc, jackson, okhttp, dadb, ...) are on
+// Maven Central and are declared explicitly by the consuming modules.
+val maestroVersion = "2.7.0"
+val maestroZipSha256 = "a4ccab6b604617e7aef6db4f885666056eabe5cfa32befaa3bc994041b8fcbb5"
+val maestroZipUrl =
+  "https://github.com/mobile-dev-inc/Maestro/releases/download/cli-$maestroVersion/maestro.zip"
+
+// maestro-* jars we consume; none are published to Maven Central for 2.x. Paths are as they
+// appear inside the zip under maestro/lib/.
+val maestroJarEntries = listOf(
+  "maestro/lib/maestro-orchestra.jar",
+  "maestro/lib/maestro-orchestra-models.jar",
+  "maestro/lib/maestro-client.jar",
+  "maestro/lib/maestro-ios.jar",
+  "maestro/lib/maestro-ios-driver.jar",
+  "maestro/lib/maestro-utils.jar",
+  "maestro/lib/maestro-ai.jar",
+)
+
+// Cache under the Gradle user home so the download survives `clean` and is shared across
+// builds and modules. Keyed by version so bumping the pin naturally invalidates the cache.
+val maestroCacheDir: File = gradle.gradleUserHomeDir.resolve("caches/arbigent-maestro/$maestroVersion")
+val maestroZipFile: File = maestroCacheDir.resolve("maestro.zip")
+val maestroJarsDir: File = maestroCacheDir.resolve("jars")
+
+fun sha256(file: File): String {
+  val digest = MessageDigest.getInstance("SHA-256")
+  file.inputStream().use { input ->
+    val buffer = ByteArray(1 shl 16)
+    while (true) {
+      val read = input.read(buffer)
+      if (read < 0) break
+      digest.update(buffer, 0, read)
+    }
+  }
+  return digest.digest().joinToString("") { "%02x".format(it) }
+}
+
+val downloadMaestroZip = tasks.register("downloadMaestroZip") {
+  description = "Download the pinned Maestro CLI release zip and verify its sha256 checksum."
+  group = "maestro"
+  outputs.file(maestroZipFile)
+  outputs.upToDateWhen { maestroZipFile.exists() && sha256(maestroZipFile) == maestroZipSha256 }
+  doLast {
+    maestroCacheDir.mkdirs()
+    if (maestroZipFile.exists() && sha256(maestroZipFile) == maestroZipSha256) return@doLast
+    logger.lifecycle("Downloading Maestro $maestroVersion from $maestroZipUrl")
+    val tmp = File.createTempFile("maestro", ".zip", maestroCacheDir)
+    try {
+      uri(maestroZipUrl).toURL().openStream().use { input ->
+        tmp.outputStream().use { output -> input.copyTo(output) }
+      }
+      val actual = sha256(tmp)
+      check(actual == maestroZipSha256) {
+        "Maestro zip checksum mismatch for $maestroZipUrl: expected $maestroZipSha256 but got $actual"
+      }
+      tmp.copyTo(maestroZipFile, overwrite = true)
+    } finally {
+      tmp.delete()
+    }
+  }
+}
+
+// Extracts the maestro-* jars into a flat directory. A later PR adding real-device support
+// can extract the zip's driver-iphoneos/ products here too by registering a sibling task
+// against the same downloaded zip.
+val extractMaestroJars = tasks.register<Copy>("extractMaestroJars") {
+  description = "Extract the maestro-* jars arbigent depends on from the pinned CLI zip."
+  group = "maestro"
+  dependsOn(downloadMaestroZip)
+  from(zipTree(maestroZipFile)) {
+    include(maestroJarEntries)
+    eachFile { path = name } // flatten maestro/lib/<jar> -> <jar>
+  }
+  includeEmptyDirs = false
+  into(maestroJarsDir)
+}
+
+// Individual jars (not the directory) so they land on the compile/runtime classpath as
+// libraries. builtBy carries the extraction task dependency to any consumer that uses this
+// collection as a dependency.
+val maestroJars: FileCollection = fileTree(maestroJarsDir) {
+  include("*.jar")
+  builtBy(extractMaestroJars)
+}
+
+// Consumed by modules via rootProject.extra: dependencies { api(rootMaestroJars()) }.
+extra["maestroJars"] = maestroJars

--- a/gradle/maestro.gradle.kts
+++ b/gradle/maestro.gradle.kts
@@ -81,7 +81,13 @@ val downloadMaestroZip = tasks.register("downloadMaestroZip") {
       check(actual == maestroZipSha256) {
         "Maestro zip checksum mismatch for $maestroZipUrl: expected $maestroZipSha256 but got $actual"
       }
-      tmp.copyTo(maestroZipFile, overwrite = true)
+      // Publish atomically: rename is atomic within a filesystem, so a concurrent build never
+      // observes a half-written zip the way an incremental copyTo could expose. tmp lives in
+      // maestroCacheDir alongside the target, so rename succeeds here; fall back to copy+delete
+      // only if it fails (e.g. across filesystems).
+      if (!tmp.renameTo(maestroZipFile)) {
+        tmp.copyTo(maestroZipFile, overwrite = true)
+      }
     } finally {
       tmp.delete()
     }

--- a/gradle/maestro.gradle.kts
+++ b/gradle/maestro.gradle.kts
@@ -18,7 +18,7 @@ buildscript {
 // Single source of truth for the pinned Maestro release consumed by arbigent.
 //
 // Maestro stopped publishing its `dev.mobile:maestro-*` artifacts to Maven Central at
-// 1.40.0; 2.x is distributed only as jars bundled inside the official CLI zip. We pin
+// 1.40.0; 2.x is distributed only as jars bundled inside the official release artifact. We pin
 // that zip by version + sha256, download and verify it once, extract the maestro-* jars
 // arbigent needs, and expose them as file dependencies (see arbigent-core/build.gradle.kts).
 // The maestro jars' own transitive dependencies (grpc, jackson, okhttp, dadb, ...) are on
@@ -64,7 +64,7 @@ fun sha256(file: File): String {
 }
 
 val downloadMaestroZip = tasks.register("downloadMaestroZip") {
-  description = "Download the pinned Maestro CLI release zip and verify its sha256 checksum."
+  description = "Download the pinned Maestro release artifact and verify its sha256 checksum."
   group = "maestro"
   outputs.file(maestroZipFile)
   outputs.upToDateWhen { maestroZipFile.exists() && sha256(maestroZipFile) == maestroZipSha256 }
@@ -98,7 +98,7 @@ val downloadMaestroZip = tasks.register("downloadMaestroZip") {
 // can extract the zip's driver-iphoneos/ products here too by registering a sibling task
 // against the same downloaded zip.
 val extractMaestroJars = tasks.register<Copy>("extractMaestroJars") {
-  description = "Extract the maestro-* jars arbigent depends on from the pinned CLI zip."
+  description = "Extract the maestro-* jars arbigent depends on from the pinned release artifact."
   group = "maestro"
   dependsOn(downloadMaestroZip)
   from(zipTree(maestroZipFile)) {

--- a/sample-test/build.gradle.kts
+++ b/sample-test/build.gradle.kts
@@ -16,8 +16,9 @@ tasks.withType<Test> {
 dependencies {
     implementation(project(":arbigent-core"))
     implementation(project(":arbigent-ai-openai"))
-    // maestro client
-    api(libs.maestro.client)
+    // maestro client (jars extracted from the pinned Maestro CLI zip; see gradle/maestro.gradle.kts)
+    @Suppress("UNCHECKED_CAST")
+    api(rootProject.extra["maestroJars"] as FileCollection)
     testImplementation(kotlin("test"))
     // coroutine test
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.5.2")

--- a/sample-test/build.gradle.kts
+++ b/sample-test/build.gradle.kts
@@ -16,7 +16,7 @@ tasks.withType<Test> {
 dependencies {
     implementation(project(":arbigent-core"))
     implementation(project(":arbigent-ai-openai"))
-    // maestro client (jars extracted from the pinned Maestro CLI zip; see gradle/maestro.gradle.kts)
+    // maestro client (jars extracted from the pinned Maestro release artifact; see gradle/maestro.gradle.kts)
     @Suppress("UNCHECKED_CAST")
     api(rootProject.extra["maestroJars"] as FileCollection)
     testImplementation(kotlin("test"))


### PR DESCRIPTION
## Why
Maestro stopped publishing `dev.mobile:maestro-*` to Maven Central at 1.40.0; 2.x ships only as jars inside the official release artifact. This PR moves arbigent to Maestro 2.7.0 by pinning that artifact (version + sha256) and consuming its jars, as groundwork for iOS real-device support (2.7 already contains the devicectl/`IOSDeviceType.REAL` infrastructure and the XCTest runner orientation fix we need).

## How
- `gradle/maestro.gradle.kts`: downloads the pinned `cli-2.7.0/maestro.zip`, verifies sha256, extracts the maestro-* jars into the Gradle user-home cache, exposes them via `rootProject.extra["maestroJars"]`
- maestro jars carry no POM, so their transitive deps (grpc, okhttp, dadb 2.0.0, jackson, graal/selenium/jcodec runtime-only, ...) are declared explicitly, aligned to the versions bundled in the release artifact
- API churn: many Maestro entry points became `suspend` (wrapped in `runBlocking`), `Orchestra` lost `screenshotsDir`/`executeCommands` (screenshots are now captured directly to keep the `screenshotsDir/<stepId>.png` contract; other commands go through `runFlow`), `AndroidDriver` takes `AndroidDeviceConnection`, simulator wiring uses `IOSDriverConfig`/`device.SimctlIOSDevice`/`TempFileHandler`, `MaestroFlowParser.checkSyntax` gained a flow path arg
- iOS runner host changed `[::1]` → `127.0.0.1`: Maestro 2.x's FlyingFox runner binds IPv4 loopback only, `[::1]` is refused

No feature changes intended.

## Verification
- `./gradlew test installDist`: green (all unit/UI tests pass)
- Android regression: `open-model-page` scenario on `medium_phone` emulator — SUCCESS
- iOS simulator regression: both `e2e-test-ios.yaml` scenarios on iPhone 17 (iOS 26.2) — SUCCESS
