### PR TITLE
Add iOS real-device support via devicectl, signed XCTest runner, and iproxy

### DIFF
--- a/arbigent-cli/src/main/kotlin/CliExtensions.kt
+++ b/arbigent-cli/src/main/kotlin/CliExtensions.kt
@@ -70,7 +70,8 @@ fun ParameterHolder.defaultOption(
  */
 internal fun isSensitiveOptionKey(optionKey: String): Boolean {
     val lower = optionKey.lowercase()
-    return listOf("key", "token", "secret", "password").any { lower.contains(it) }
+    // "team" covers the Apple developer team id, which is treated as sensitive and never shown.
+    return listOf("key", "token", "secret", "password", "team").any { lower.contains(it) }
 }
 
 /**

--- a/arbigent-cli/src/main/kotlin/CommonOptions.kt
+++ b/arbigent-cli/src/main/kotlin/CommonOptions.kt
@@ -192,7 +192,7 @@ fun connectDevice(
       throw IllegalArgumentException(
         "Multiple connected iPhones found. Set --ios-real-device-id (or ${ArbigentIosRealDeviceSettings.ENV_DEVICE_ID}) " +
           "to choose one. Candidates: " +
-          realCandidates.joinToString(", ") { it.maskedUdid }
+          ArbigentAvailableDevice.IosReal.maskedUdidLabels(realCandidates).joinToString(", ")
       )
     }
   }

--- a/arbigent-cli/src/main/kotlin/CommonOptions.kt
+++ b/arbigent-cli/src/main/kotlin/CommonOptions.kt
@@ -159,7 +159,12 @@ fun loadArbigentProject(
   }
 }
 
-fun connectDevice(os: String): ArbigentDevice {
+fun connectDevice(
+  os: String,
+  iosAppleTeamId: String? = null,
+  iosRealDeviceId: String? = null,
+  iosRealDevicePort: Int? = null,
+): ArbigentDevice {
   val deviceOs =
     ArbigentDeviceOs.entries.find { it.name.toLowerCasePreservingASCIIRules() == os.toLowerCasePreservingASCIIRules() }
       ?: throw IllegalArgumentException(
@@ -167,6 +172,13 @@ fun connectDevice(os: String): ArbigentDevice {
           ArbigentDeviceOs.entries
             .joinToString(", ") { it.name.toLowerCasePreservingASCIIRules() }
         }")
+  // Publish iOS real-device options for discovery/connection to read. Only relevant for --os=ios
+  // with a physical iPhone; simulators and other OSes ignore it.
+  ArbigentIosRealDeviceSettings.current = ArbigentIosRealDeviceConfiguration(
+    appleTeamId = iosAppleTeamId?.takeIf { it.isNotBlank() },
+    deviceId = iosRealDeviceId?.takeIf { it.isNotBlank() },
+    port = iosRealDevicePort,
+  )
   return fetchAvailableDevicesByOs(deviceOs).firstOrNull()?.connectToDevice()
     ?: throw IllegalArgumentException("No available device found")
 }

--- a/arbigent-cli/src/main/kotlin/CommonOptions.kt
+++ b/arbigent-cli/src/main/kotlin/CommonOptions.kt
@@ -179,6 +179,35 @@ fun connectDevice(
     deviceId = iosRealDeviceId?.takeIf { it.isNotBlank() },
     port = iosRealDevicePort,
   )
-  return fetchAvailableDevicesByOs(deviceOs).firstOrNull()?.connectToDevice()
-    ?: throw IllegalArgumentException("No available device found")
+  val candidates = fetchAvailableDevicesByOs(deviceOs)
+  val chosen = candidates.firstOrNull() ?: throw IllegalArgumentException("No available device found")
+  // When the device we would connect is a physical iPhone and the user gave no explicit id, refuse to
+  // guess between several connected iPhones (devicectl ordering is not stable). List the candidates by
+  // a short, masked UDID prefix so the user can pick one with --ios-real-device-id.
+  if (chosen is ArbigentAvailableDevice.IosReal &&
+    ArbigentIosRealDeviceSettings.resolvedDeviceId() == null
+  ) {
+    val realCandidates = candidates.filterIsInstance<ArbigentAvailableDevice.IosReal>()
+    if (realCandidates.size > 1) {
+      throw IllegalArgumentException(
+        "Multiple connected iPhones found. Set --ios-real-device-id (or ${ArbigentIosRealDeviceSettings.ENV_DEVICE_ID}) " +
+          "to choose one. Candidates: " +
+          realCandidates.joinToString(", ") { it.maskedUdid }
+      )
+    }
+  }
+  return chosen.connectToDevice()
+}
+
+// Parses the --ios-real-device-port string option, failing loudly on a non-integer or out-of-range
+// value instead of silently falling back to the default (which would hide a typo'd port).
+internal fun parseIosRealDevicePort(raw: String?): Int? {
+  val trimmed = raw?.trim()
+  if (trimmed.isNullOrEmpty()) return null
+  val port = trimmed.toIntOrNull()
+    ?: throw CliktError("--ios-real-device-port must be an integer in 1..65535 but was \"$trimmed\"")
+  if (port !in 1..65535) {
+    throw CliktError("--ios-real-device-port must be in 1..65535 but was $port")
+  }
+  return port
 }

--- a/arbigent-cli/src/main/kotlin/RunCommand.kt
+++ b/arbigent-cli/src/main/kotlin/RunCommand.kt
@@ -56,6 +56,20 @@ class ArbigentRunCommand : CliktCommand(name = "run") {
     .choice("android", "ios", "web")
     .default("android")
 
+  private val iosAppleTeamId by defaultOption(
+    "--ios-xctest-apple-team-id",
+    help = "Apple developer team id used to sign the XCTest runner for a physical iPhone (--os=ios). " +
+      "Falls back to ${ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID}, then single-identity auto-detect."
+  )
+  private val iosRealDeviceId by defaultOption(
+    "--ios-real-device-id",
+    help = "Hardware UDID selecting a specific physical iPhone (--os=ios)."
+  )
+  private val iosRealDevicePort by defaultOption(
+    "--ios-real-device-port",
+    help = "Host/device port for the XCTest runner on a physical iPhone (default 22087)."
+  )
+
   // Common options using extension functions with automatic property file detection
   private val projectFile by projectFileOption()
   private val logLevel by logLevelOption()
@@ -183,7 +197,12 @@ class ArbigentRunCommand : CliktCommand(name = "run") {
       return
     }
 
-    device = connectDevice(os)
+    device = connectDevice(
+      os = os,
+      iosAppleTeamId = iosAppleTeamId,
+      iosRealDeviceId = iosRealDeviceId,
+      iosRealDevicePort = iosRealDevicePort?.trim()?.toIntOrNull(),
+    )
     Runtime.getRuntime().addShutdownHook(object : Thread() {
       override fun run() {
         arbigentProject.cancel()

--- a/arbigent-cli/src/main/kotlin/RunCommand.kt
+++ b/arbigent-cli/src/main/kotlin/RunCommand.kt
@@ -201,7 +201,7 @@ class ArbigentRunCommand : CliktCommand(name = "run") {
       os = os,
       iosAppleTeamId = iosAppleTeamId,
       iosRealDeviceId = iosRealDeviceId,
-      iosRealDevicePort = iosRealDevicePort?.trim()?.toIntOrNull(),
+      iosRealDevicePort = parseIosRealDevicePort(iosRealDevicePort),
     )
     Runtime.getRuntime().addShutdownHook(object : Thread() {
       override fun run() {

--- a/arbigent-cli/src/main/kotlin/RunTaskCommand.kt
+++ b/arbigent-cli/src/main/kotlin/RunTaskCommand.kt
@@ -51,6 +51,20 @@ class ArbigentRunTaskCommand : CliktCommand(name = "task") {
     .choice("android", "ios", "web")
     .default("android")
 
+  private val iosAppleTeamId by defaultOption(
+    "--ios-xctest-apple-team-id",
+    help = "Apple developer team id used to sign the XCTest runner for a physical iPhone (--os=ios). " +
+      "Falls back to ${ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID}, then single-identity auto-detect."
+  )
+  private val iosRealDeviceId by defaultOption(
+    "--ios-real-device-id",
+    help = "Hardware UDID selecting a specific physical iPhone (--os=ios)."
+  )
+  private val iosRealDevicePort by defaultOption(
+    "--ios-real-device-port",
+    help = "Host/device port for the XCTest runner on a physical iPhone (default 22087)."
+  )
+
   private val logLevel by logLevelOption()
   private val logFile by logFileOption()
   private val workingDirectory by workingDirectoryOption()
@@ -61,7 +75,12 @@ class ArbigentRunTaskCommand : CliktCommand(name = "task") {
 
     val (resultDir, resultFile) = setupArbigentFiles(workingDirectory, logFile)
     val ai = createAi(aiType, aiApiLoggingEnabled)
-    val device = connectDevice(os)
+    val device = connectDevice(
+      os = os,
+      iosAppleTeamId = iosAppleTeamId,
+      iosRealDeviceId = iosRealDeviceId,
+      iosRealDevicePort = iosRealDevicePort?.trim()?.toIntOrNull(),
+    )
 
     try {
       val scenarioContent = ArbigentScenarioContent(

--- a/arbigent-cli/src/main/kotlin/RunTaskCommand.kt
+++ b/arbigent-cli/src/main/kotlin/RunTaskCommand.kt
@@ -79,7 +79,7 @@ class ArbigentRunTaskCommand : CliktCommand(name = "task") {
       os = os,
       iosAppleTeamId = iosAppleTeamId,
       iosRealDeviceId = iosRealDeviceId,
-      iosRealDevicePort = iosRealDevicePort?.trim()?.toIntOrNull(),
+      iosRealDevicePort = parseIosRealDevicePort(iosRealDevicePort),
     )
 
     try {

--- a/arbigent-core/build.gradle.kts
+++ b/arbigent-core/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
 buildConfig {
   packageName("io.github.takahirom.arbigent")
   buildConfigField("VERSION_NAME", version.toString())
+  buildConfigField("MAESTRO_VERSION", rootProject.extra["maestroVersion"] as String)
   useKotlinOutput { internalVisibility = false }
 }
 
@@ -33,6 +34,21 @@ buildConfig {
 // re-exposes (MaestroCommand, MaestroException, MaestroFlowParser, ...).
 @Suppress("UNCHECKED_CAST")
 val maestroJars = rootProject.extra["maestroJars"] as FileCollection
+
+// iOS XCTest runner source (driver/ios/**), packaged as a resource under ios-real-driver/ so
+// the real-device runner builder can copy it out and run xcodebuild build-for-testing at
+// runtime. See gradle/maestro.gradle.kts.
+@Suppress("UNCHECKED_CAST")
+val maestroIosDriverSource = rootProject.extra["maestroIosDriverSource"] as FileCollection
+
+tasks.named<ProcessResources>("processResources") {
+  // Final resource layout: ios-real-driver/driver/ios/** (the fileTree preserves the
+  // driver/ios/** relative paths). The FileCollection's builtBy carries the extraction task
+  // dependency so the source is materialized before packaging.
+  from(maestroIosDriverSource) {
+    into("ios-real-driver")
+  }
+}
 
 dependencies {
   implementation(project(":arbigent-core-web-report"))

--- a/arbigent-core/build.gradle.kts
+++ b/arbigent-core/build.gradle.kts
@@ -42,11 +42,11 @@ val maestroJars = rootProject.extra["maestroJars"] as FileCollection
 val maestroIosDriverSource = rootProject.extra["maestroIosDriverSource"] as FileCollection
 
 tasks.named<ProcessResources>("processResources") {
-  // Final resource layout: ios-real-driver/driver/ios/** (the fileTree preserves the
-  // driver/ios/** relative paths). The FileCollection's builtBy carries the extraction task
-  // dependency so the source is materialized before packaging.
+  // Final resource layout: ios-real-driver/runner/** (maestro-driver-ios.xcodeproj + sources at
+  // the top). The FileCollection's builtBy carries the extraction task dependency so the source
+  // is materialized before packaging.
   from(maestroIosDriverSource) {
-    into("ios-real-driver")
+    into("ios-real-driver/runner")
   }
 }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentCommandExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentCommandExecutor.kt
@@ -1,0 +1,51 @@
+package io.github.takahirom.arbigent
+
+import java.util.concurrent.TimeUnit
+
+/** Result of running an external command. */
+public data class ArbigentCommandResult(
+  public val exitCode: Int,
+  public val stdout: String,
+  public val stderr: String,
+) {
+  public val isSuccess: Boolean get() = exitCode == 0
+}
+
+/**
+ * Thin abstraction over running host CLI tools (`xcrun devicectl`, `security`, `xcodebuild`,
+ * `lsof`, ...). A single seam so the iOS real-device logic can be unit-tested with a fake executor
+ * instead of shelling out.
+ */
+public interface ArbigentCommandExecutor {
+  public fun execute(command: List<String>, timeoutMs: Long = 120_000): ArbigentCommandResult
+}
+
+/** Runs commands with [ProcessBuilder], capturing stdout/stderr and enforcing a timeout. */
+public class DefaultArbigentCommandExecutor : ArbigentCommandExecutor {
+  override fun execute(command: List<String>, timeoutMs: Long): ArbigentCommandResult {
+    val process = ProcessBuilder(command)
+      .redirectErrorStream(false)
+      .start()
+    // Drain both streams concurrently so a chatty tool can't deadlock on a full pipe buffer.
+    val stdout = StringBuilder()
+    val stderr = StringBuilder()
+    val outThread = Thread { process.inputStream.bufferedReader().forEachLine { stdout.appendLine(it) } }
+    val errThread = Thread { process.errorStream.bufferedReader().forEachLine { stderr.appendLine(it) } }
+    outThread.start()
+    errThread.start()
+    val finished = process.waitFor(timeoutMs, TimeUnit.MILLISECONDS)
+    if (!finished) {
+      process.destroyForcibly()
+      outThread.join(1_000)
+      errThread.join(1_000)
+      return ArbigentCommandResult(
+        exitCode = -1,
+        stdout = stdout.toString(),
+        stderr = stderr.toString() + "\nCommand timed out after ${timeoutMs}ms: ${command.joinToString(" ")}",
+      )
+    }
+    outThread.join(1_000)
+    errThread.join(1_000)
+    return ArbigentCommandResult(process.exitValue(), stdout.toString(), stderr.toString())
+  }
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentCommandExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentCommandExecutor.kt
@@ -87,6 +87,10 @@ public class DefaultArbigentCommandExecutor : ArbigentCommandExecutor {
   // Snapshot the descendant handles before killing so we can await them afterwards: once the parent
   // is destroyed its children are reparented and no longer enumerate as its descendants, but the
   // captured ProcessHandles stay valid for awaiting termination.
+  //
+  // Accepted tradeoff: a grandchild spawned by a descendant *between* this snapshot and the destroy
+  // can escape teardown. Killing a process tree race-free needs OS process groups, which the JDK
+  // Process API does not expose; this is intentionally bounded-effort teardown, not a guarantee.
   private fun destroyTree(process: Process): List<ProcessHandle> {
     val descendants = runCatching { process.descendants().toList() }.getOrDefault(emptyList())
     descendants.forEach { runCatching { it.destroyForcibly() } }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentCommandExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentCommandExecutor.kt
@@ -41,10 +41,19 @@ public class DefaultArbigentCommandExecutor : ArbigentCommandExecutor {
     try {
       timedOut = !process.waitFor(timeoutMs, TimeUnit.MILLISECONDS)
     } finally {
-      // Guaranteed cleanup: kill the whole process tree, wait for it to actually die, and join the
-      // drain threads — closing the pipes to unblock them if they are still stuck.
-      if (timedOut) destroyTree(process)
-      if (!process.waitFor(5, TimeUnit.SECONDS)) destroyTree(process)
+      // Guaranteed cleanup within a bounded ~5s budget: kill the whole process tree, then wait for
+      // the process AND its descendants to actually die — re-enumerating descendants once so a child
+      // spawned or reparented during teardown is also awaited — before joining the drain threads
+      // (closing the pipes to unblock any that are still stuck). Anything still alive past the budget
+      // is abandoned deliberately: readers are daemon threads, so we never block the caller
+      // indefinitely on a wedged external tool.
+      val deadline = System.currentTimeMillis() + TEARDOWN_BUDGET_MS
+      var descendants = if (timedOut) destroyTree(process) else emptyList()
+      if (!process.waitFor(remainingMs(deadline), TimeUnit.MILLISECONDS)) {
+        descendants = destroyTree(process)
+      }
+      awaitHandles(descendants, deadline)
+      awaitHandles(runCatching { process.descendants().toList() }.getOrDefault(emptyList()), deadline)
       joinQuietly(outThread, 2_000)
       joinQuietly(errThread, 2_000)
       if (outThread.isAlive || errThread.isAlive) {
@@ -75,10 +84,26 @@ public class DefaultArbigentCommandExecutor : ArbigentCommandExecutor {
       }
     }.apply { isDaemon = true; this.name = name }
 
-  private fun destroyTree(process: Process) {
-    runCatching { process.descendants().forEach { it.destroyForcibly() } }
+  // Snapshot the descendant handles before killing so we can await them afterwards: once the parent
+  // is destroyed its children are reparented and no longer enumerate as its descendants, but the
+  // captured ProcessHandles stay valid for awaiting termination.
+  private fun destroyTree(process: Process): List<ProcessHandle> {
+    val descendants = runCatching { process.descendants().toList() }.getOrDefault(emptyList())
+    descendants.forEach { runCatching { it.destroyForcibly() } }
     process.destroyForcibly()
+    return descendants
   }
+
+  private fun awaitHandles(handles: List<ProcessHandle>, deadline: Long) {
+    handles.forEach { handle ->
+      val timeLeft = remainingMs(deadline)
+      if (timeLeft <= 0L) return
+      runCatching { handle.onExit().get(timeLeft, TimeUnit.MILLISECONDS) }
+    }
+  }
+
+  private fun remainingMs(deadline: Long): Long =
+    (deadline - System.currentTimeMillis()).coerceAtLeast(0L)
 
   private fun joinQuietly(thread: Thread, millis: Long) {
     try {
@@ -86,5 +111,9 @@ public class DefaultArbigentCommandExecutor : ArbigentCommandExecutor {
     } catch (e: InterruptedException) {
       Thread.currentThread().interrupt()
     }
+  }
+
+  private companion object {
+    const val TEARDOWN_BUDGET_MS = 5_000L
   }
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentCommandExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentCommandExecutor.kt
@@ -26,26 +26,65 @@ public class DefaultArbigentCommandExecutor : ArbigentCommandExecutor {
     val process = ProcessBuilder(command)
       .redirectErrorStream(false)
       .start()
-    // Drain both streams concurrently so a chatty tool can't deadlock on a full pipe buffer.
+    // Drain both streams concurrently so a chatty tool can't deadlock on a full pipe buffer. Daemon
+    // threads so a reader stuck on a pipe inherited by a surviving descendant can never keep the JVM
+    // alive. Appends/reads on each StringBuilder are guarded so the final read is safe even if a
+    // reader has not finished.
     val stdout = StringBuilder()
     val stderr = StringBuilder()
-    val outThread = Thread { process.inputStream.bufferedReader().forEachLine { stdout.appendLine(it) } }
-    val errThread = Thread { process.errorStream.bufferedReader().forEachLine { stderr.appendLine(it) } }
+    val outThread = drainThread("arbigent-cmd-stdout", process.inputStream, stdout)
+    val errThread = drainThread("arbigent-cmd-stderr", process.errorStream, stderr)
     outThread.start()
     errThread.start()
-    val finished = process.waitFor(timeoutMs, TimeUnit.MILLISECONDS)
-    if (!finished) {
-      process.destroyForcibly()
-      outThread.join(1_000)
-      errThread.join(1_000)
-      return ArbigentCommandResult(
-        exitCode = -1,
-        stdout = stdout.toString(),
-        stderr = stderr.toString() + "\nCommand timed out after ${timeoutMs}ms: ${command.joinToString(" ")}",
-      )
+
+    var timedOut = false
+    try {
+      timedOut = !process.waitFor(timeoutMs, TimeUnit.MILLISECONDS)
+    } finally {
+      // Guaranteed cleanup: kill the whole process tree, wait for it to actually die, and join the
+      // drain threads — closing the pipes to unblock them if they are still stuck.
+      if (timedOut) destroyTree(process)
+      if (!process.waitFor(5, TimeUnit.SECONDS)) destroyTree(process)
+      joinQuietly(outThread, 2_000)
+      joinQuietly(errThread, 2_000)
+      if (outThread.isAlive || errThread.isAlive) {
+        runCatching { process.inputStream.close() }
+        runCatching { process.errorStream.close() }
+        joinQuietly(outThread, 1_000)
+        joinQuietly(errThread, 1_000)
+      }
     }
-    outThread.join(1_000)
-    errThread.join(1_000)
-    return ArbigentCommandResult(process.exitValue(), stdout.toString(), stderr.toString())
+
+    val out = synchronized(stdout) { stdout.toString() }
+    val err = synchronized(stderr) { stderr.toString() }
+    return if (timedOut) {
+      ArbigentCommandResult(
+        exitCode = -1,
+        stdout = out,
+        stderr = err + "\nCommand timed out after ${timeoutMs}ms: ${command.joinToString(" ")}",
+      )
+    } else {
+      ArbigentCommandResult(process.exitValue(), out, err)
+    }
+  }
+
+  private fun drainThread(name: String, stream: java.io.InputStream, sink: StringBuilder): Thread =
+    Thread {
+      runCatching {
+        stream.bufferedReader().forEachLine { line -> synchronized(sink) { sink.appendLine(line) } }
+      }
+    }.apply { isDaemon = true; this.name = name }
+
+  private fun destroyTree(process: Process) {
+    runCatching { process.descendants().forEach { it.destroyForcibly() } }
+    process.destroyForcibly()
+  }
+
+  private fun joinQuietly(thread: Thread, millis: Long) {
+    try {
+      thread.join(millis)
+    } catch (e: InterruptedException) {
+      Thread.currentThread().interrupt()
+    }
   }
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -199,24 +199,37 @@ public data class ArbigentElementList(
 }
 
 public class MaestroDevice(
-  @Volatile private var maestro: Maestro,
+  maestro: Maestro,
   private val screenshotsDir: File = ArbigentFiles.screenshotsDir,
   private val availableDevice: ArbigentAvailableDevice? = null,
   // Extra teardown tied to this connection (e.g. the iproxy port forwarder for a physical
   // iPhone), run after maestro.close() so session-scoped child processes stop with the device.
-  private val onClose: (() -> Unit)? = null,
+  onClose: (() -> Unit)? = null,
 ) : ArbigentDevice, ArbigentTvCompatDevice {
-  init {
-    arbigentInfoLog("MaestroDevice created: screenshotsDir:${screenshotsDir.absolutePath}")
-  }
-
+  // maestro, its Orchestra and the connection-scoped teardown are swapped together as one
+  // Connection, so a reconnect can never pair the new maestro with the old cleanup (which would
+  // leak the replacement device's iproxy) or keep invoking the stale one on close().
+  //
   // Maestro's Orchestra artifact refactor (#3282) removed the screenshotsDir constructor
   // parameter; takeScreenshot commands now write under an artifacts dir instead of
   // screenshotsDir/<path>.png. Arbigent captures screenshots itself in executeActions()
   // (see below) to keep that path contract, so Orchestra needs no screenshots dir here.
-  @Volatile private var orchestra = Orchestra(
-    maestro = maestro,
+  private class Connection(
+    val maestro: Maestro,
+    val orchestra: Orchestra,
+    val onClose: (() -> Unit)?,
   )
+
+  @Volatile private var connection: Connection =
+    Connection(maestro, Orchestra(maestro = maestro), onClose)
+
+  // Volatile read of the live connection so callers keep using `maestro`/`orchestra` unchanged.
+  private val maestro: Maestro get() = connection.maestro
+  private val orchestra: Orchestra get() = connection.orchestra
+
+  init {
+    arbigentInfoLog("MaestroDevice created: screenshotsDir:${screenshotsDir.absolutePath}")
+  }
 
   override fun deviceName(): String {
     return maestro.deviceName
@@ -627,11 +640,6 @@ public class MaestroDevice(
   private var reconnectAttempts = 0
   private val maxReconnectAttempts = 6  // Allows retries with exponential backoff up to ~64 seconds
   private val reconnectLock = Any()
-  
-  private fun updateConnection(newMaestro: Maestro) {
-    this.maestro = newMaestro
-    this.orchestra = Orchestra(maestro = this.maestro)
-  }
 
   private fun reconnectIfDisconnected() {
     synchronized(reconnectLock) {
@@ -661,8 +669,8 @@ public class MaestroDevice(
         }
         
         reconnectAttempts++
-        
-        val oldMaestro = this.maestro
+
+        val oldConnection = this.connection
 
         // Try to reconnect
         val newDevice = try {
@@ -679,15 +687,16 @@ public class MaestroDevice(
           continue // Try again
         }
 
-        // Update to new connection
-        updateConnection(newDevice.maestro)
-
-        // Close old connection after successful reconnection
+        // Adopt the new device's whole Connection (maestro + orchestra + its onClose, which owns the
+        // new iproxy) in one volatile swap, then tear down the old connection exactly once — closing
+        // the old maestro AND running the old onClose so the previous iproxy is not leaked.
+        this.connection = newDevice.connection
         try {
-          oldMaestro.close()
+          oldConnection.maestro.close()
         } catch (_: Exception) {
           // Ignore close errors, device might already be disconnected
         }
+        runCatching { oldConnection.onClose?.invoke() }
 
         // Reset counter on successful reconnection
         reconnectAttempts = 0
@@ -702,8 +711,14 @@ public class MaestroDevice(
 
   override fun close() {
     isClosed = true
-    maestro.close()
-    runCatching { onClose?.invoke() }
+    val current = connection
+    // onClose owns the iproxy forwarder; run it in finally so a failure closing maestro still tears
+    // the forwarder down instead of leaking it.
+    try {
+      current.maestro.close()
+    } finally {
+      runCatching { current.onClose?.invoke() }
+    }
   }
 
   override fun isClosed(): Boolean {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -201,7 +201,10 @@ public data class ArbigentElementList(
 public class MaestroDevice(
   @Volatile private var maestro: Maestro,
   private val screenshotsDir: File = ArbigentFiles.screenshotsDir,
-  private val availableDevice: ArbigentAvailableDevice? = null
+  private val availableDevice: ArbigentAvailableDevice? = null,
+  // Extra teardown tied to this connection (e.g. the iproxy port forwarder for a physical
+  // iPhone), run after maestro.close() so session-scoped child processes stop with the device.
+  private val onClose: (() -> Unit)? = null,
 ) : ArbigentDevice, ArbigentTvCompatDevice {
   init {
     arbigentInfoLog("MaestroDevice created: screenshotsDir:${screenshotsDir.absolutePath}")
@@ -700,6 +703,7 @@ public class MaestroDevice(
   override fun close() {
     isClosed = true
     maestro.close()
+    runCatching { onClose?.invoke() }
   }
 
   override fun isClosed(): Boolean {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -11,6 +11,7 @@ import maestro.orchestra.MaestroCommand
 import maestro.orchestra.Orchestra
 import okio.sink
 import java.io.File
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.pow
 import kotlin.system.measureTimeMillis
 
@@ -218,7 +219,12 @@ public class MaestroDevice(
     val maestro: Maestro,
     val orchestra: Orchestra,
     val onClose: (() -> Unit)?,
-  )
+  ) {
+    // Teardown runs at most once per Connection: a failed reconnect closes the broken connection up
+    // front and then a later close() would otherwise close the same object again (double maestro.close
+    // + double onClose, freeing a port a newer connection may already own).
+    val closed = AtomicBoolean(false)
+  }
 
   @Volatile private var connection: Connection =
     Connection(maestro, Orchestra(maestro = maestro), onClose)
@@ -637,6 +643,10 @@ public class MaestroDevice(
   }
 
   @Volatile private var isClosed = false
+  // Set once a full reconnect sequence has exhausted every attempt: the current connection is torn
+  // down and no replacement was installed, so the device is unusable. Further operations fail fast
+  // with a clear error instead of endlessly re-tearing-down the already-closed connection.
+  @Volatile private var connectionLost = false
   private var reconnectAttempts = 0
   private val maxReconnectAttempts = 6  // Allows retries with exponential backoff up to ~64 seconds
   // Guards the connection swap in reconnect against close(): whoever holds it either replaces the
@@ -646,8 +656,11 @@ public class MaestroDevice(
 
   // Close a connection exactly once: shut down maestro, then always run its onClose (which stops
   // and de-registers the iproxy forwarder) even if maestro.close() throws, so the forwarder and
-  // its port are released rather than leaked.
+  // its port are released rather than leaked. The compareAndSet guard makes this idempotent per
+  // Connection so a close() after a failed reconnect (which already tore this connection down)
+  // never double-closes maestro or double-runs onClose.
   private fun closeConnection(target: Connection) {
+    if (!target.closed.compareAndSet(false, true)) return
     try {
       target.maestro.close()
     } catch (_: Exception) {
@@ -664,6 +677,9 @@ public class MaestroDevice(
       }
       if (isClosed) {
         throw IllegalStateException("Cannot reconnect: device is closed")
+      }
+      if (connectionLost) {
+        throw IllegalStateException("Device connection lost: reconnection already failed permanently")
       }
 
       // Tear down the current (broken) connection up front — closing its maestro and running its
@@ -720,8 +736,11 @@ public class MaestroDevice(
         return // Success!
       }
 
-      // All attempts failed - reset counter for future retry sequences
+      // All attempts failed. The broken connection was already torn down above and no replacement
+      // was installed, so mark the device permanently lost: further operations throw the clear
+      // "connection lost" error rather than re-closing the dead connection.
       reconnectAttempts = 0
+      connectionLost = true
       throw RuntimeException("Failed to reconnect after $maxReconnectAttempts attempts", lastException)
     }
   }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -636,10 +636,25 @@ public class MaestroDevice(
     }
   }
 
-  private var isClosed = false
+  @Volatile private var isClosed = false
   private var reconnectAttempts = 0
   private val maxReconnectAttempts = 6  // Allows retries with exponential backoff up to ~64 seconds
+  // Guards the connection swap in reconnect against close(): whoever holds it either replaces the
+  // connection or tears it down, never both at once, so close() can't capture the old connection
+  // while reconnect installs a new one (which would leak the replacement's iproxy forwarder).
   private val reconnectLock = Any()
+
+  // Close a connection exactly once: shut down maestro, then always run its onClose (which stops
+  // and de-registers the iproxy forwarder) even if maestro.close() throws, so the forwarder and
+  // its port are released rather than leaked.
+  private fun closeConnection(target: Connection) {
+    try {
+      target.maestro.close()
+    } catch (_: Exception) {
+      // Ignore close errors, device might already be disconnected
+    }
+    runCatching { target.onClose?.invoke() }
+  }
 
   private fun reconnectIfDisconnected() {
     synchronized(reconnectLock) {
@@ -647,9 +662,20 @@ public class MaestroDevice(
       if (availableDevice == null) {
         throw IllegalStateException("Cannot reconnect: no available device reference")
       }
+      if (isClosed) {
+        throw IllegalStateException("Cannot reconnect: device is closed")
+      }
+
+      // Tear down the current (broken) connection up front — closing its maestro and running its
+      // onClose, which stops the iproxy forwarder and frees the port — BEFORE building the
+      // replacement. Building first would start a second forwarder on the same port, and the
+      // ownership check would reject it because this very JVM still owns the port, so reconnect
+      // could never succeed. Readers are serialized behind ensureConnected()'s monitor, so no one
+      // observes the closed connection during the swap; a transient failure that retries is fine.
+      closeConnection(this.connection)
 
       var lastException: Exception? = null
-      
+
       // Retry with exponential backoff
       while (reconnectAttempts < maxReconnectAttempts) {
         // Exponential backoff: 2^attempt seconds (2s, 4s, 8s, 16s, 32s, 64s...)
@@ -667,10 +693,8 @@ public class MaestroDevice(
           arbigentInfoLog("Waiting ${actualWaitTimeMs}ms before reconnection attempt ${reconnectAttempts + 1}")
           Thread.sleep(actualWaitTimeMs)
         }
-        
-        reconnectAttempts++
 
-        val oldConnection = this.connection
+        reconnectAttempts++
 
         // Try to reconnect
         val newDevice = try {
@@ -688,21 +712,14 @@ public class MaestroDevice(
         }
 
         // Adopt the new device's whole Connection (maestro + orchestra + its onClose, which owns the
-        // new iproxy) in one volatile swap, then tear down the old connection exactly once — closing
-        // the old maestro AND running the old onClose so the previous iproxy is not leaked.
+        // new iproxy) in one volatile swap. The old connection was already torn down above.
         this.connection = newDevice.connection
-        try {
-          oldConnection.maestro.close()
-        } catch (_: Exception) {
-          // Ignore close errors, device might already be disconnected
-        }
-        runCatching { oldConnection.onClose?.invoke() }
 
         // Reset counter on successful reconnection
         reconnectAttempts = 0
         return // Success!
       }
-      
+
       // All attempts failed - reset counter for future retry sequences
       reconnectAttempts = 0
       throw RuntimeException("Failed to reconnect after $maxReconnectAttempts attempts", lastException)
@@ -710,14 +727,12 @@ public class MaestroDevice(
   }
 
   override fun close() {
-    isClosed = true
-    val current = connection
-    // onClose owns the iproxy forwarder; run it in finally so a failure closing maestro still tears
-    // the forwarder down instead of leaking it.
-    try {
-      current.maestro.close()
-    } finally {
-      runCatching { current.onClose?.invoke() }
+    // Same lock as reconnect so a close racing an in-progress reconnect tears down whichever
+    // connection reconnect ultimately installs, instead of capturing the old one and leaking the
+    // replacement's forwarder.
+    synchronized(reconnectLock) {
+      isClosed = true
+      closeConnection(connection)
     }
   }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
@@ -165,6 +165,10 @@ public sealed interface ArbigentAvailableDevice {
   ) : ArbigentAvailableDevice {
     override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Ios
 
+    // First 8 chars of the UDID, enough to disambiguate connected iPhones in a message without ever
+    // printing the full hardware UDID.
+    public val maskedUdid: String get() = hardwareUdid.take(8) + "…"
+
     override fun connectToDevice(): ArbigentDevice {
       val config = ArbigentIosRealDeviceSettings.current
       val host = "127.0.0.1"

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
@@ -179,6 +179,9 @@ public sealed interface ArbigentAvailableDevice {
         null
       }
 
+      // Hoisted so a warm-up failure can close the maestro session (and its XCTest driver) as well
+      // as the forwarder; both must be released exactly once on the failure path.
+      var maestro: Maestro? = null
       try {
         val tempFileHandler = TempFileHandler()
         // Our devicectl-backed controller fills maestro's stubbed real-device lifecycle methods.
@@ -216,7 +219,7 @@ public sealed interface ArbigentAvailableDevice {
           getInstalledApps = { xcRunnerCLIUtils.listApps(hardwareUdid) },
         )
 
-        val maestro = Maestro.ios(
+        maestro = Maestro.ios(
           IOSDriver(
             LocalIOSDevice(
               deviceId = hardwareUdid,
@@ -234,9 +237,11 @@ public sealed interface ArbigentAvailableDevice {
         )
       } catch (e: InterruptedException) {
         Thread.currentThread().interrupt()
+        maestro?.close()
         forwarder?.close()
         throw e
       } catch (e: Exception) {
+        maestro?.close()
         forwarder?.close()
         throw e
       }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
@@ -336,6 +336,11 @@ internal fun warmUpIosDevice(maestro: Maestro) {
       runBlocking { maestro.viewHierarchy() }
       responsive = true
       break
+    } catch (e: InterruptedException) {
+      // Cancellation must win: restore the interrupt flag and stop warming up rather than
+      // treating it as just another "not responsive yet" retry.
+      Thread.currentThread().interrupt()
+      throw e
     } catch (e: Exception) {
       arbigentInfoLog("iOS warm-up: device not responsive yet, retrying: ${e.message}")
       Thread.sleep(pollIntervalMs)

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
@@ -33,10 +33,19 @@ public sealed interface ArbigentAvailableDevice {
   public val deviceOs: ArbigentDeviceOs
   public val name: String
 
+  // Stable, full identity for INTERNAL use only (UI selection reconciliation, dropdown keying).
+  // It carries the full device identifier (hardware UDID / adb serial) and is never displayed, so
+  // the masking rules that apply to shown strings (see [IosReal.maskedUdid]) do not apply here.
+  // Names alone collide (two iPhones of the same model, a simulator and a phone), so keying by
+  // name would re-point a selection at the wrong device after a rediscovery.
+  public val stableKey: String
+
   // Do not use data class because dadb return true for equals
   public class Android(private val dadb: Dadb) : ArbigentAvailableDevice {
     override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Android
     override val name: String = dadb.toString()
+    // The adb serial (dadb.toString()) already uniquely identifies the device.
+    override val stableKey: String get() = "android:$name"
     override fun connectToDevice(): ArbigentDevice {
       // Maestro's AndroidDeviceConnection refactor (#3372) made AndroidDriver take an
       // AndroidDeviceConnection instead of a raw Dadb. byId() selects the same device by
@@ -73,6 +82,8 @@ public sealed interface ArbigentAvailableDevice {
   ) : ArbigentAvailableDevice {
     override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Ios
     override val name: String = device.name
+    // Simulator UDID uniquely identifies the device even when models share a name.
+    override val stableKey: String get() = "iossimulator:${device.udid}"
     override fun connectToDevice(): ArbigentDevice {
       val port = port
       val host = host
@@ -165,6 +176,10 @@ public sealed interface ArbigentAvailableDevice {
   ) : ArbigentAvailableDevice {
     override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Ios
 
+    // Full hardware UDID for internal identity only (never displayed — see the interface doc and
+    // [maskedUdid]); real iPhones share model names so name alone would collide.
+    override val stableKey: String get() = "iosreal:$hardwareUdid"
+
     // First 8 chars of the UDID: enough to point at a device in a message without ever printing the
     // full hardware UDID. When several candidates share this prefix, use [maskedUdidLabels] instead
     // so the shown prefix is extended until unique.
@@ -256,12 +271,13 @@ public sealed interface ArbigentAvailableDevice {
       /**
        * Labels each candidate with the shortest masked UDID prefix that is unique among
        * [candidates], so colliding 8-char prefixes are disambiguated by revealing a few more
-       * characters. The full UDID is never printed: the prefix is capped one character short of the
-       * shortest UDID, and if a collision somehow survives that cap a positional #index is appended
-       * instead of more UDID characters.
+       * characters. The revealed prefix is capped at [MAX_MASKED_UDID_PREFIX] characters (and never
+       * reaches the full UDID); if a collision survives that cap, a positional #index is appended
+       * instead of exposing more of the UDID.
        */
       public fun maskedUdidLabels(candidates: List<IosReal>): List<String> {
-        val maxPrefix = (candidates.minOfOrNull { it.hardwareUdid.length } ?: 1).minus(1).coerceAtLeast(1)
+        val shortest = candidates.minOfOrNull { it.hardwareUdid.length } ?: 1
+        val maxPrefix = minOf(MAX_MASKED_UDID_PREFIX, (shortest - 1).coerceAtLeast(1))
         fun collides(udid: String, length: Int): Boolean =
           candidates.count { it.hardwareUdid.take(length) == udid.take(length) } > 1
         return candidates.mapIndexed { index, candidate ->
@@ -272,12 +288,17 @@ public sealed interface ArbigentAvailableDevice {
           if (collides(udid, length)) "$prefix #${index + 1}" else prefix
         }
       }
+
+      // Cap on how many leading UDID characters a disambiguating label may reveal. Extending further
+      // would expose nearly the whole hardware UDID; past this, fall back to positional #index.
+      private const val MAX_MASKED_UDID_PREFIX = 12
     }
   }
 
   public class Web : ArbigentAvailableDevice {
     override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Web
     override val name: String = "Chrome"
+    override val stableKey: String get() = "web:$name"
     public override fun connectToDevice(): ArbigentDevice {
       return MaestroDevice(
         // Maestro.web() gained a third arg (custom Chrome binary path); null keeps the default.
@@ -290,6 +311,7 @@ public sealed interface ArbigentAvailableDevice {
   public class Fake : ArbigentAvailableDevice {
     override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Android
     override val name: String = "Fake"
+    override val stableKey: String get() = "fake:$name"
     public override fun connectToDevice(): ArbigentDevice {
       // This is not called
       throw UnsupportedOperationException("Fake device is not supported")

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
@@ -129,7 +129,7 @@ public sealed interface ArbigentAvailableDevice {
         )
       )
       try {
-        warmUp(maestro)
+        warmUpIosDevice(maestro)
         return MaestroDevice(
           maestro,
           availableDevice = this
@@ -143,41 +143,104 @@ public sealed interface ArbigentAvailableDevice {
         throw e
       }
     }
+  }
 
-    // A freshly booted iOS simulator is still doing post-boot work (e.g. Data
-    // Migration), and hitting it with the first scenario action tends to crash the
-    // XCTest runner. Warm it up first: poll the view hierarchy until the runner
-    // responds (this also starts the runner), then let it settle, so the first real
-    // interaction runs on a warm, stable device.
-    private fun warmUp(maestro: Maestro) {
-      val warmUpTimeoutMs = 60_000L
-      val settleMs = 10_000L
-      val pollIntervalMs = 2_000L
-      val start = System.currentTimeMillis()
-      var responsive = false
-      while (System.currentTimeMillis() - start < warmUpTimeoutMs) {
-        try {
-          runBlocking { maestro.viewHierarchy() }
-          responsive = true
-          break
-        } catch (e: Exception) {
-          arbigentInfoLog("iOS warm-up: device not responsive yet, retrying: ${e.message}")
-          Thread.sleep(pollIntervalMs)
-        }
+  /**
+   * Physical iPhone driven over XCTest, discovered via `xcrun devicectl`.
+   *
+   * Unlike a simulator, a real device needs three things maestro's consumable jars do not provide
+   * (see the PR-B research): a runner re-signed with the user's Apple team (built on demand by
+   * [IosRealDriverProducts]), `iproxy` port forwarding from host to device
+   * ([IosRealXCTestPortForwarder]), and a working app-lifecycle controller
+   * ([ArbigentDevicectlIOSDevice]). Everything else — the XCTest HTTP protocol, UI interaction —
+   * is identical to the simulator path once the runner port is reachable.
+   *
+   * @param coreDeviceIdentifier CoreDevice identifier used with `xcrun devicectl --device`.
+   * @param hardwareUdid hardware UDID used for xcodebuild's `-destination id=` and iproxy.
+   */
+  public class IosReal(
+    private val coreDeviceIdentifier: String,
+    private val hardwareUdid: String,
+    override val name: String,
+  ) : ArbigentAvailableDevice {
+    override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Ios
+
+    override fun connectToDevice(): ArbigentDevice {
+      val config = ArbigentIosRealDeviceSettings.current
+      val host = "127.0.0.1"
+      val port = ArbigentIosRealDeviceSettings.resolvedPort()
+      val teamId = IosCodeSigningTeamResolver.resolve(config)
+      val productsDir = IosRealDriverProducts(teamId = teamId, deviceUdid = hardwareUdid)
+        .resolveBuildProductsDir()
+
+      val forwarder = if (config.autoStartIproxy) {
+        IosRealXCTestPortForwarder(deviceUdid = hardwareUdid, port = port).also { it.start() }
+      } else {
+        null
       }
-      if (!responsive) {
-        arbigentInfoLog("iOS warm-up: device did not become responsive within ${warmUpTimeoutMs}ms; continuing anyway")
-        return
+
+      try {
+        val tempFileHandler = TempFileHandler()
+        // Our devicectl-backed controller fills maestro's stubbed real-device lifecycle methods.
+        val deviceController = ArbigentDevicectlIOSDevice(coreDeviceIdentifier)
+
+        val xcTestInstaller = LocalXCTestInstaller(
+          deviceId = hardwareUdid,
+          host = host,
+          deviceType = IOSDeviceType.REAL,
+          defaultPort = port,
+          reinstallDriver = true,
+          iOSDriverConfig = IOSDriverConfig(
+            prebuiltRunner = false,
+            // For REAL the installer reads the locally-built, user-signed products from this path
+            // (unlike SIMULATOR, which loads a bundled classpath driver).
+            sourceDirectory = productsDir.absolutePath,
+            context = Context.CLI,
+            snapshotKeyHonorModalViews = null,
+          ),
+          deviceController = deviceController,
+          tempFileHandler = tempFileHandler,
+          logsDir = xctestLogsDir(),
+        )
+
+        val xcTestDriverClient = XCTestDriverClient(
+          installer = xcTestInstaller,
+          client = XCTestClient(host, port),
+          reinstallDriver = true,
+        )
+        val xcRunnerCLIUtils = XCRunnerCLIUtils(tempFileHandler)
+
+        val xcTestDevice = XCTestIOSDevice(
+          deviceId = hardwareUdid,
+          client = xcTestDriverClient,
+          getInstalledApps = { xcRunnerCLIUtils.listApps(hardwareUdid) },
+        )
+
+        val maestro = Maestro.ios(
+          IOSDriver(
+            LocalIOSDevice(
+              deviceId = hardwareUdid,
+              xcTestDevice = xcTestDevice,
+              deviceController = deviceController,
+              insights = NoopInsights,
+            )
+          )
+        )
+        warmUpIosDevice(maestro)
+        return MaestroDevice(
+          maestro,
+          availableDevice = this,
+          onClose = { forwarder?.close() },
+        )
+      } catch (e: InterruptedException) {
+        Thread.currentThread().interrupt()
+        forwarder?.close()
+        throw e
+      } catch (e: Exception) {
+        forwarder?.close()
+        throw e
       }
-      // Let post-boot work settle before the first scenario interaction.
-      Thread.sleep(settleMs)
-      arbigentInfoLog("iOS warm-up done")
     }
-
-    // LocalXCTestInstaller writes XCTest runner logs here, replacing the removed
-    // enableXCTestOutputFileLogging flag.
-    private fun xctestLogsDir(): File =
-      File(ArbigentFiles.parentDir, "xctest-logs").apply { mkdirs() }
   }
 
   public class Web : ArbigentAvailableDevice {
@@ -203,3 +266,37 @@ public sealed interface ArbigentAvailableDevice {
 
   public fun connectToDevice(): ArbigentDevice
 }
+
+// A freshly booted iOS simulator (or a real device whose runner just launched) is still doing
+// post-launch work, and hitting it with the first scenario action tends to crash the XCTest
+// runner. Warm it up first: poll the view hierarchy until the runner responds (this also starts
+// the runner), then let it settle, so the first real interaction runs on a warm, stable device.
+internal fun warmUpIosDevice(maestro: Maestro) {
+  val warmUpTimeoutMs = 60_000L
+  val settleMs = 10_000L
+  val pollIntervalMs = 2_000L
+  val start = System.currentTimeMillis()
+  var responsive = false
+  while (System.currentTimeMillis() - start < warmUpTimeoutMs) {
+    try {
+      runBlocking { maestro.viewHierarchy() }
+      responsive = true
+      break
+    } catch (e: Exception) {
+      arbigentInfoLog("iOS warm-up: device not responsive yet, retrying: ${e.message}")
+      Thread.sleep(pollIntervalMs)
+    }
+  }
+  if (!responsive) {
+    arbigentInfoLog("iOS warm-up: device did not become responsive within ${warmUpTimeoutMs}ms; continuing anyway")
+    return
+  }
+  // Let post-launch work settle before the first scenario interaction.
+  Thread.sleep(settleMs)
+  arbigentInfoLog("iOS warm-up done")
+}
+
+// LocalXCTestInstaller writes XCTest runner logs here, replacing the removed
+// enableXCTestOutputFileLogging flag.
+internal fun xctestLogsDir(): File =
+  File(ArbigentFiles.parentDir, "xctest-logs").apply { mkdirs() }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
@@ -165,8 +165,9 @@ public sealed interface ArbigentAvailableDevice {
   ) : ArbigentAvailableDevice {
     override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Ios
 
-    // First 8 chars of the UDID, enough to disambiguate connected iPhones in a message without ever
-    // printing the full hardware UDID.
+    // First 8 chars of the UDID: enough to point at a device in a message without ever printing the
+    // full hardware UDID. When several candidates share this prefix, use [maskedUdidLabels] instead
+    // so the shown prefix is extended until unique.
     public val maskedUdid: String get() = hardwareUdid.take(8) + "…"
 
     override fun connectToDevice(): ArbigentDevice {
@@ -248,6 +249,28 @@ public sealed interface ArbigentAvailableDevice {
         maestro?.close()
         forwarder?.close()
         throw e
+      }
+    }
+
+    public companion object {
+      /**
+       * Labels each candidate with the shortest masked UDID prefix that is unique among
+       * [candidates], so colliding 8-char prefixes are disambiguated by revealing a few more
+       * characters. The full UDID is never printed: the prefix is capped one character short of the
+       * shortest UDID, and if a collision somehow survives that cap a positional #index is appended
+       * instead of more UDID characters.
+       */
+      public fun maskedUdidLabels(candidates: List<IosReal>): List<String> {
+        val maxPrefix = (candidates.minOfOrNull { it.hardwareUdid.length } ?: 1).minus(1).coerceAtLeast(1)
+        fun collides(udid: String, length: Int): Boolean =
+          candidates.count { it.hardwareUdid.take(length) == udid.take(length) } > 1
+        return candidates.mapIndexed { index, candidate ->
+          val udid = candidate.hardwareUdid
+          var length = 8.coerceAtMost(maxPrefix)
+          while (length < maxPrefix && collides(udid, length)) length++
+          val prefix = udid.take(length) + "…"
+          if (collides(udid, length)) "$prefix #${index + 1}" else prefix
+        }
       }
     }
   }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevicectlIOSDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevicectlIOSDevice.kt
@@ -4,6 +4,7 @@ import com.github.michaelbull.result.Result
 import com.github.michaelbull.result.runCatching
 import device.IOSDevice
 import ios.devicectl.DeviceControlIOSDevice
+import util.IOSLaunchArguments.toIOSLaunchArguments
 import java.io.File
 import java.io.InputStream
 import java.util.zip.ZipInputStream
@@ -34,14 +35,16 @@ public class ArbigentDevicectlIOSDevice(
       "xcrun", "devicectl", "device", "process", "launch",
       "--terminate-existing",
       "--device", coreDeviceIdentifier,
-      id,
     )
     // devicectl parses `-`-prefixed tokens as its own options wherever they appear (Swift
-    // ArgumentParser), so terminate option parsing with `--` before passing app launch arguments.
-    if (launchArguments.isNotEmpty()) {
-      command.add("--")
-      launchArguments.values.forEach { command.add(it.toString()) }
-    }
+    // ArgumentParser), so terminate option parsing with `--`. Per `devicectl device process
+    // launch --help` everything after `--` is positional (<bundle-identifier-or-path> then
+    // <command-line-arguments>...), so a malformed app id can't be read as a devicectl option.
+    // Convert the launch arguments with maestro's own toIOSLaunchArguments so key/value pairs
+    // (e.g. "-cartColor" "Orange") match the semantics used on simulators.
+    command.add("--")
+    command.add(id)
+    command.addAll(launchArguments.toIOSLaunchArguments())
     val result = executor.execute(command)
     check(result.isSuccess) {
       "Failed to launch $id on the connected device: ${result.stderr.ifBlank { result.stdout }}"
@@ -70,19 +73,24 @@ public class ArbigentDevicectlIOSDevice(
   }
 
   override fun clearAppState(id: String) {
-    // devicectl exposes no app-state clear; terminating is the closest safe behavior. Uninstall
-    // would be destructive without a reinstall path, so we log and skip rather than throw, keeping
-    // flows that call clearState from crashing on a real device.
-    arbigentInfoLog("iOS real device: clearAppState($id) is not supported via devicectl; skipping")
+    // devicectl exposes no app-state clear, and uninstall/reinstall would be destructive without a
+    // reliable reinstall path. Silently skipping made clearState() falsely report success and let
+    // scenarios run against stale data, so fail explicitly instead.
+    throw UnsupportedOperationException(
+      "clearAppState($id) is not supported on a physical iOS device via devicectl. Remove clearState " +
+        "from this scenario, or uninstall/reinstall the app between runs manually."
+    )
   }
 
   override fun openLink(link: String): Result<Unit, Throwable> = runCatching {
-    val result = executor.execute(
-      listOf("xcrun", "devicectl", "device", "process", "launch", "--device", coreDeviceIdentifier, "--payload-url", link)
+    // `devicectl device process launch` requires a <bundle-identifier-or-path> positional (see its
+    // --help); there is no devicectl verb that opens an arbitrary URL against the system handler, so
+    // --payload-url alone cannot launch anything. Fail loudly rather than run a command that always
+    // errors while pretending to be supported.
+    throw UnsupportedOperationException(
+      "openLink($link) is not supported on a physical iOS device via devicectl. Trigger the deep link " +
+        "from within the app under test instead."
     )
-    check(result.isSuccess) {
-      "Failed to open link on the connected device: ${result.stderr.ifBlank { result.stdout }}"
-    }
   }
 
   private fun unzip(stream: InputStream, targetDir: File) {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevicectlIOSDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevicectlIOSDevice.kt
@@ -1,0 +1,102 @@
+package io.github.takahirom.arbigent
+
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.runCatching
+import device.IOSDevice
+import ios.devicectl.DeviceControlIOSDevice
+import java.io.File
+import java.io.InputStream
+import java.util.zip.ZipInputStream
+
+/**
+ * App-lifecycle controller for a physical iPhone, backed by `xcrun devicectl`.
+ *
+ * maestro 2.7's [DeviceControlIOSDevice] leaves the app-lifecycle methods as
+ * `TODO("Not yet implemented")` (they throw [NotImplementedError]), so launching or installing the
+ * app-under-test on a real device would crash. arbigent's [ios.LocalIOSDevice] routes UI operations
+ * (tap, screenshot, hierarchy, ...) to the XCTest HTTP runner and only lifecycle operations to this
+ * controller, so we implement exactly those over devicectl and delegate everything else to maestro's
+ * class (its `uninstall` works; the remaining delegated methods are never reached through
+ * `LocalIOSDevice`).
+ *
+ * @param coreDeviceIdentifier the CoreDevice identifier (`--device` argument), i.e.
+ *   `DeviceCtlResponse.Device.identifier` — the same id maestro's controller uses.
+ */
+public class ArbigentDevicectlIOSDevice(
+  private val coreDeviceIdentifier: String,
+  private val executor: ArbigentCommandExecutor = DefaultArbigentCommandExecutor(),
+  private val delegate: IOSDevice = DeviceControlIOSDevice(coreDeviceIdentifier),
+) : IOSDevice by delegate {
+
+  override fun launch(id: String, launchArguments: Map<String, Any>) {
+    // --terminate-existing so re-running a scenario relaunches cleanly instead of attaching.
+    val command = mutableListOf(
+      "xcrun", "devicectl", "device", "process", "launch",
+      "--terminate-existing",
+      "--device", coreDeviceIdentifier,
+      id,
+    )
+    launchArguments.values.forEach { command.add(it.toString()) }
+    val result = executor.execute(command)
+    check(result.isSuccess) {
+      "Failed to launch $id on the connected device: ${result.stderr.ifBlank { result.stdout }}"
+    }
+  }
+
+  override fun install(stream: InputStream) {
+    // The stream is a zipped .app bundle. Unzip to a temp dir, locate the .app, install via devicectl.
+    val work = File.createTempFile("arbigent-ios-install", "").apply {
+      delete()
+      mkdirs()
+    }
+    try {
+      unzip(stream, work)
+      val app = work.walkTopDown().firstOrNull { it.isDirectory && it.extension == "app" }
+        ?: throw IllegalStateException("No .app bundle found in the provided install stream")
+      val result = executor.execute(
+        listOf("xcrun", "devicectl", "device", "install", "app", "--device", coreDeviceIdentifier, app.absolutePath)
+      )
+      check(result.isSuccess) {
+        "Failed to install ${app.name} on the connected device: ${result.stderr.ifBlank { result.stdout }}"
+      }
+    } finally {
+      work.deleteRecursively()
+    }
+  }
+
+  override fun clearAppState(id: String) {
+    // devicectl exposes no app-state clear; terminating is the closest safe behavior. Uninstall
+    // would be destructive without a reinstall path, so we log and skip rather than throw, keeping
+    // flows that call clearState from crashing on a real device.
+    arbigentInfoLog("iOS real device: clearAppState($id) is not supported via devicectl; skipping")
+  }
+
+  override fun openLink(link: String): Result<Unit, Throwable> = runCatching {
+    val result = executor.execute(
+      listOf("xcrun", "devicectl", "device", "process", "launch", "--device", coreDeviceIdentifier, "--payload-url", link)
+    )
+    check(result.isSuccess) {
+      "Failed to open link on the connected device: ${result.stderr.ifBlank { result.stdout }}"
+    }
+  }
+
+  private fun unzip(stream: InputStream, targetDir: File) {
+    ZipInputStream(stream).use { zip ->
+      var entry = zip.nextEntry
+      while (entry != null) {
+        val outFile = File(targetDir, entry.name)
+        // Guard against zip-slip.
+        check(outFile.canonicalPath.startsWith(targetDir.canonicalPath + File.separator)) {
+          "Zip entry escapes target directory: ${entry!!.name}"
+        }
+        if (entry.isDirectory) {
+          outFile.mkdirs()
+        } else {
+          outFile.parentFile?.mkdirs()
+          outFile.outputStream().use { zip.copyTo(it) }
+        }
+        entry = zip.nextEntry
+      }
+    }
+  }
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevicectlIOSDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevicectlIOSDevice.kt
@@ -36,7 +36,12 @@ public class ArbigentDevicectlIOSDevice(
       "--device", coreDeviceIdentifier,
       id,
     )
-    launchArguments.values.forEach { command.add(it.toString()) }
+    // devicectl parses `-`-prefixed tokens as its own options wherever they appear (Swift
+    // ArgumentParser), so terminate option parsing with `--` before passing app launch arguments.
+    if (launchArguments.isNotEmpty()) {
+      command.add("--")
+      launchArguments.values.forEach { command.add(it.toString()) }
+    }
     val result = executor.execute(command)
     check(result.isSuccess) {
       "Failed to launch $id on the connected device: ${result.stderr.ifBlank { result.stdout }}"

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
@@ -56,9 +56,17 @@ public fun fetchConnectedIosRealDevices(
   return try {
     val localDevice = util.LocalIOSDevice()
     var devices = localDevice.listDeviceViaDeviceCtl()
-    val hasConnected = devices.any { it.connectionProperties?.tunnelState.equals("connected", ignoreCase = true) }
-    if (!hasConnected && wakeTunnels) {
-      wakeIosRealDeviceTunnels(devices.mapNotNull { it.identifier }, executor)
+    fun isConnected(device: util.DeviceCtlResponse.Device) =
+      device.connectionProperties?.tunnelState.equals("connected", ignoreCase = true)
+    fun matchesFilter(device: util.DeviceCtlResponse.Device) =
+      deviceIdFilter == null || device.hardwareProperties?.udid == deviceIdFilter
+    // The device we actually need (the configured one, or any device when none was specified) must
+    // have a connected tunnel. Waking only when *nothing* is connected would strand a configured
+    // UDID that is disconnected while some other iPhone happens to be connected.
+    val satisfied = devices.any { isConnected(it) && matchesFilter(it) }
+    if (!satisfied && wakeTunnels) {
+      val toWake = devices.filter { matchesFilter(it) && !isConnected(it) }.mapNotNull { it.identifier }
+      wakeIosRealDeviceTunnels(toWake, executor)
       devices = localDevice.listDeviceViaDeviceCtl()
     }
     devices

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
@@ -13,17 +13,56 @@ public fun fetchAvailableDevicesByOs(deviceType: ArbigentDeviceOs): List<Arbigen
 
     ArbigentDeviceOs.Ios -> {
       // LocalSimulatorUtils is now a class taking a TempFileHandler instead of an object.
-      LocalSimulatorUtils(TempFileHandler()).list()
+      val simulators = LocalSimulatorUtils(TempFileHandler()).list()
         .devices
         .flatMap { runtime ->
           runtime.value
             .filter { it.isAvailable && it.state == "Booted" }
         }
         .map { ArbigentAvailableDevice.IOS(it) }
+      val realDevices = fetchConnectedIosRealDevices()
+      // Prefer a physical device only when the user has opted in by configuring an Apple team id
+      // (real devices need it to build a signed runner). Otherwise a booted simulator wins, keeping
+      // the common `--os=ios` dev flow unchanged. connectDevice() picks the first entry.
+      if (isRealIosDeviceOptedIn()) realDevices + simulators else simulators + realDevices
     }
 
     else -> {
       listOf(ArbigentAvailableDevice.Web())
     }
   }
+}
+
+/**
+ * Lists physical iPhones reachable over CoreDevice (`xcrun devicectl`), filtered to the ones with a
+ * connected tunnel — the same criterion maestro uses. Returns empty (never throws) when devicectl
+ * is unavailable or no device is connected, so simulator discovery keeps working without Xcode
+ * command-line tools set up for real devices.
+ */
+@ArbigentInternalApi
+public fun fetchConnectedIosRealDevices(): List<ArbigentAvailableDevice.IosReal> {
+  val deviceIdFilter = ArbigentIosRealDeviceSettings.resolvedDeviceId()
+  return try {
+    util.LocalIOSDevice().listDeviceViaDeviceCtl()
+      .filter { it.connectionProperties?.tunnelState.equals("connected", ignoreCase = true) }
+      .mapNotNull { device ->
+        val identifier = device.identifier ?: return@mapNotNull null
+        val udid = device.hardwareProperties?.udid ?: return@mapNotNull null
+        if (deviceIdFilter != null && udid != deviceIdFilter) return@mapNotNull null
+        ArbigentAvailableDevice.IosReal(
+          coreDeviceIdentifier = identifier,
+          hardwareUdid = udid,
+          name = device.deviceProperties?.name ?: udid,
+        )
+      }
+  } catch (e: Exception) {
+    arbigentInfoLog("iOS real device discovery skipped: ${e.message}")
+    emptyList()
+  }
+}
+
+private fun isRealIosDeviceOptedIn(env: (String) -> String? = System::getenv): Boolean {
+  val config = ArbigentIosRealDeviceSettings.current
+  if (!config.appleTeamId.isNullOrBlank()) return true
+  return !env(ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID).isNullOrBlank()
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
@@ -20,11 +20,14 @@ public fun fetchAvailableDevicesByOs(deviceType: ArbigentDeviceOs): List<Arbigen
             .filter { it.isAvailable && it.state == "Booted" }
         }
         .map { ArbigentAvailableDevice.IOS(it) }
-      val realDevices = fetchConnectedIosRealDevices()
-      // Prefer a physical device only when the user has opted in by configuring an Apple team id
-      // (real devices need it to build a signed runner). Otherwise a booted simulator wins, keeping
-      // the common `--os=ios` dev flow unchanged. connectDevice() picks the first entry.
-      if (isRealIosDeviceOptedIn()) realDevices + simulators else simulators + realDevices
+      val optedIn = isRealIosDeviceOptedIn()
+      // Wake the CoreDevice tunnel (read-only) when the user opted in, or when there is no booted
+      // simulator to fall back on so a lone connected iPhone still "just works".
+      val realDevices = fetchConnectedIosRealDevices(wakeTunnels = optedIn || simulators.isEmpty())
+      // Prefer a physical device only when the user has opted in (Apple team id or a specific
+      // real-device id). Otherwise a booted simulator wins, keeping the common `--os=ios` dev flow
+      // unchanged. connectDevice() picks the first entry.
+      if (optedIn) realDevices + simulators else simulators + realDevices
     }
 
     else -> {
@@ -38,12 +41,27 @@ public fun fetchAvailableDevicesByOs(deviceType: ArbigentDeviceOs): List<Arbigen
  * connected tunnel — the same criterion maestro uses. Returns empty (never throws) when devicectl
  * is unavailable or no device is connected, so simulator discovery keeps working without Xcode
  * command-line tools set up for real devices.
+ *
+ * CoreDevice only reports `tunnelState == connected` while a tunnel is actively held; a paired,
+ * USB-connected iPhone otherwise lists as `disconnected` even though it is perfectly usable. When
+ * the user has opted into real devices we first wake the tunnel with a read-only
+ * `devicectl device info` (see [wakeIosRealDeviceTunnels]) so discovery is not flaky.
  */
 @ArbigentInternalApi
-public fun fetchConnectedIosRealDevices(): List<ArbigentAvailableDevice.IosReal> {
+public fun fetchConnectedIosRealDevices(
+  wakeTunnels: Boolean = true,
+  executor: ArbigentCommandExecutor = DefaultArbigentCommandExecutor(),
+): List<ArbigentAvailableDevice.IosReal> {
   val deviceIdFilter = ArbigentIosRealDeviceSettings.resolvedDeviceId()
   return try {
-    util.LocalIOSDevice().listDeviceViaDeviceCtl()
+    val localDevice = util.LocalIOSDevice()
+    var devices = localDevice.listDeviceViaDeviceCtl()
+    val hasConnected = devices.any { it.connectionProperties?.tunnelState.equals("connected", ignoreCase = true) }
+    if (!hasConnected && wakeTunnels) {
+      wakeIosRealDeviceTunnels(devices.mapNotNull { it.identifier }, executor)
+      devices = localDevice.listDeviceViaDeviceCtl()
+    }
+    devices
       .filter { it.connectionProperties?.tunnelState.equals("connected", ignoreCase = true) }
       .mapNotNull { device ->
         val identifier = device.identifier ?: return@mapNotNull null
@@ -61,8 +79,23 @@ public fun fetchConnectedIosRealDevices(): List<ArbigentAvailableDevice.IosReal>
   }
 }
 
+// Reads device info to establish the CoreDevice tunnel (read-only; no device state changes), so the
+// subsequent `list devices` reports the device as connected. Failures are ignored — a device that
+// stays disconnected simply won't be surfaced.
+private fun wakeIosRealDeviceTunnels(identifiers: List<String>, executor: ArbigentCommandExecutor) {
+  identifiers.forEach { identifier ->
+    arbigentInfoLog("iOS real device: waking CoreDevice tunnel for a paired device")
+    executor.execute(
+      listOf("xcrun", "devicectl", "device", "info", "details", "--device", identifier),
+      timeoutMs = 20_000,
+    )
+  }
+}
+
 private fun isRealIosDeviceOptedIn(env: (String) -> String? = System::getenv): Boolean {
   val config = ArbigentIosRealDeviceSettings.current
   if (!config.appleTeamId.isNullOrBlank()) return true
-  return !env(ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID).isNullOrBlank()
+  if (!config.deviceId.isNullOrBlank()) return true
+  if (!env(ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID).isNullOrBlank()) return true
+  return !env(ArbigentIosRealDeviceSettings.ENV_DEVICE_ID).isNullOrBlank()
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
@@ -60,11 +60,17 @@ public fun fetchConnectedIosRealDevices(
       device.connectionProperties?.tunnelState.equals("connected", ignoreCase = true)
     fun matchesFilter(device: util.DeviceCtlResponse.Device) =
       deviceIdFilter == null || device.hardwareProperties?.udid == deviceIdFilter
-    // The device we actually need (the configured one, or any device when none was specified) must
-    // have a connected tunnel. Waking only when *nothing* is connected would strand a configured
-    // UDID that is disconnected while some other iPhone happens to be connected.
-    val satisfied = devices.any { isConnected(it) && matchesFilter(it) }
-    if (!satisfied && wakeTunnels) {
+    // When a specific device is configured we only need THAT device's tunnel up, so it is enough
+    // that it is connected — waking only when *nothing* is connected would strand a configured UDID
+    // that is disconnected while some other iPhone happens to be connected. When no device is
+    // configured (all-device discovery, e.g. the UI list), every paired-but-disconnected phone
+    // should be surfaced, so we wake all of them rather than stopping at the first connected one.
+    val needsWake = if (deviceIdFilter != null) {
+      devices.none { isConnected(it) && matchesFilter(it) }
+    } else {
+      devices.any { matchesFilter(it) && !isConnected(it) }
+    }
+    if (needsWake && wakeTunnels) {
       val toWake = devices.filter { matchesFilter(it) && !isConnected(it) }.mapNotNull { it.identifier }
       wakeIosRealDeviceTunnels(toWake, executor)
       devices = localDevice.listDeviceViaDeviceCtl()

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosCodeSigningTeamResolver.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosCodeSigningTeamResolver.kt
@@ -1,21 +1,31 @@
 package io.github.takahirom.arbigent
 
+import java.io.File
+
 /**
- * Resolves the Apple developer team id used to re-sign the XCTest runner for a physical device.
+ * Resolves the Apple developer team id used to re-sign the XCTest runner for a physical device
+ * (`DEVELOPMENT_TEAM`).
  *
  * Resolution order (per PR-B design):
  *   1. Explicit config/CLI option ([ArbigentIosRealDeviceConfiguration.appleTeamId]).
  *   2. Environment variable [ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID].
- *   3. Auto-detection via `security find-identity -v -p codesigning`, but ONLY when exactly one
- *      "Apple Development" identity is present. Zero or multiple → fail with an actionable message.
+ *   3. Auto-detection from the keychain, but ONLY when exactly one team owns the installed
+ *      "Apple Development" certificates. Zero or multiple → fail with an actionable message.
  *
- * Team ids are treated as sensitive: they are never logged in full (see [maskTeamId]).
+ * The team id is the certificate's Organizational Unit (OU), NOT the parenthetical in the common
+ * name "Apple Development: Name (XXXXXXXXXX)" — that parenthetical is the individual/user id and is
+ * rejected by xcodebuild as an unknown team. We therefore read the OU from the certificate subject.
+ *
+ * Team ids are treated as sensitive: never logged in full (see [maskTeamId]).
  */
 public object IosCodeSigningTeamResolver {
   private val TEAM_ID_REGEX = Regex("^[A-Z0-9]{10}$")
 
-  // "  1) ABC123... \"Apple Development: Jane Doe (TEAMID1234)\""
-  private val APPLE_DEVELOPMENT_LINE = Regex("""Apple Development:[^(]*\(([A-Z0-9]{10})\)""")
+  // Matches the OU in an openssl `-nameopt multiline` subject dump, e.g.
+  //   "organizationalUnitName    = 84ABCDE123"
+  private val OU_REGEX = Regex("""organizationalUnitName\s*=\s*([A-Z0-9]{10})""")
+  private val PEM_CERT_REGEX =
+    Regex("""-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----""", RegexOption.DOT_MATCHES_ALL)
 
   public fun resolve(
     config: ArbigentIosRealDeviceConfiguration = ArbigentIosRealDeviceSettings.current,
@@ -26,22 +36,36 @@ public object IosCodeSigningTeamResolver {
     env(ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID)?.trim()?.takeIf { it.isNotBlank() }
       ?.let { return validate(it, "environment ${ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID}") }
 
-    val result = executor.execute(listOf("security", "find-identity", "-v", "-p", "codesigning"))
-    val teamId = autoDetect(result.stdout)
+    val teamId = autoDetectFromKeychain(executor)
     arbigentInfoLog("iOS real device: auto-detected Apple team id ${maskTeamId(teamId)} from codesigning identities")
-    return teamId
+    return validate(teamId, "keychain auto-detection")
   }
 
-  /** Extracts a single "Apple Development" team id from `security find-identity` output. */
-  public fun autoDetect(findIdentityOutput: String): String {
-    val teamIds = APPLE_DEVELOPMENT_LINE.findAll(findIdentityOutput)
-      .map { it.groupValues[1] }
-      .toSet()
+  private fun autoDetectFromKeychain(executor: ArbigentCommandExecutor): String {
+    val pem = executor.execute(
+      listOf("security", "find-certificate", "-a", "-c", "Apple Development", "-p")
+    )
+    val subjects = PEM_CERT_REGEX.findAll(pem.stdout).mapNotNull { match ->
+      val tmp = File.createTempFile("arbigent-appledev-cert", ".pem").apply { writeText(match.value) }
+      try {
+        executor.execute(
+          listOf("openssl", "x509", "-in", tmp.absolutePath, "-noout", "-subject", "-nameopt", "multiline")
+        ).takeIf { it.isSuccess }?.stdout
+      } finally {
+        tmp.delete()
+      }
+    }.toList()
+    return teamIdFromSubjects(subjects)
+  }
+
+  /** Extracts the single team id (certificate OU) from openssl subject dumps. */
+  public fun teamIdFromSubjects(subjects: List<String>): String {
+    val teamIds = subjects.flatMap { subject -> OU_REGEX.findAll(subject).map { it.groupValues[1] } }.toSet()
     return when {
       teamIds.isEmpty() -> throw IllegalStateException(
-        "No 'Apple Development' code-signing identity found. Set the Apple team id via the " +
-          "ios-xctest-apple-team-id option or the ${ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID} " +
-          "environment variable, and ensure a signing certificate is installed in your keychain."
+        "No 'Apple Development' code-signing team found in your keychain. Set the Apple team id via " +
+          "the ios-xctest-apple-team-id option or the ${ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID} " +
+          "environment variable, and ensure a signing certificate is installed."
       )
       teamIds.size > 1 -> throw IllegalStateException(
         "Multiple Apple developer teams found in your keychain; cannot auto-detect. Choose one by " +
@@ -60,7 +84,7 @@ public object IosCodeSigningTeamResolver {
   }
 
   /**
-   * Masks a team id for logging, keeping only the first two characters (e.g. "TN********"). Team
+   * Masks a team id for logging, keeping only the first two characters (e.g. "84********"). Team
    * ids are never logged in full.
    */
   public fun maskTeamId(teamId: String): String =

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosCodeSigningTeamResolver.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosCodeSigningTeamResolver.kt
@@ -1,0 +1,68 @@
+package io.github.takahirom.arbigent
+
+/**
+ * Resolves the Apple developer team id used to re-sign the XCTest runner for a physical device.
+ *
+ * Resolution order (per PR-B design):
+ *   1. Explicit config/CLI option ([ArbigentIosRealDeviceConfiguration.appleTeamId]).
+ *   2. Environment variable [ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID].
+ *   3. Auto-detection via `security find-identity -v -p codesigning`, but ONLY when exactly one
+ *      "Apple Development" identity is present. Zero or multiple → fail with an actionable message.
+ *
+ * Team ids are treated as sensitive: they are never logged in full (see [maskTeamId]).
+ */
+public object IosCodeSigningTeamResolver {
+  private val TEAM_ID_REGEX = Regex("^[A-Z0-9]{10}$")
+
+  // "  1) ABC123... \"Apple Development: Jane Doe (TEAMID1234)\""
+  private val APPLE_DEVELOPMENT_LINE = Regex("""Apple Development:[^(]*\(([A-Z0-9]{10})\)""")
+
+  public fun resolve(
+    config: ArbigentIosRealDeviceConfiguration = ArbigentIosRealDeviceSettings.current,
+    env: (String) -> String? = System::getenv,
+    executor: ArbigentCommandExecutor = DefaultArbigentCommandExecutor(),
+  ): String {
+    config.appleTeamId?.trim()?.takeIf { it.isNotBlank() }?.let { return validate(it, "CLI option/settings") }
+    env(ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID)?.trim()?.takeIf { it.isNotBlank() }
+      ?.let { return validate(it, "environment ${ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID}") }
+
+    val result = executor.execute(listOf("security", "find-identity", "-v", "-p", "codesigning"))
+    val teamId = autoDetect(result.stdout)
+    arbigentInfoLog("iOS real device: auto-detected Apple team id ${maskTeamId(teamId)} from codesigning identities")
+    return teamId
+  }
+
+  /** Extracts a single "Apple Development" team id from `security find-identity` output. */
+  public fun autoDetect(findIdentityOutput: String): String {
+    val teamIds = APPLE_DEVELOPMENT_LINE.findAll(findIdentityOutput)
+      .map { it.groupValues[1] }
+      .toSet()
+    return when {
+      teamIds.isEmpty() -> throw IllegalStateException(
+        "No 'Apple Development' code-signing identity found. Set the Apple team id via the " +
+          "ios-xctest-apple-team-id option or the ${ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID} " +
+          "environment variable, and ensure a signing certificate is installed in your keychain."
+      )
+      teamIds.size > 1 -> throw IllegalStateException(
+        "Multiple Apple developer teams found in your keychain; cannot auto-detect. Choose one by " +
+          "setting the ios-xctest-apple-team-id option or the " +
+          "${ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID} environment variable."
+      )
+      else -> teamIds.first()
+    }
+  }
+
+  private fun validate(teamId: String, source: String): String {
+    require(TEAM_ID_REGEX.matches(teamId)) {
+      "Invalid Apple team id from $source: expected 10 uppercase alphanumeric characters."
+    }
+    return teamId
+  }
+
+  /**
+   * Masks a team id for logging, keeping only the first two characters (e.g. "TN********"). Team
+   * ids are never logged in full.
+   */
+  public fun maskTeamId(teamId: String): String =
+    if (teamId.length <= 2) "****" else teamId.take(2) + "*".repeat(teamId.length - 2)
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDeviceConfiguration.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDeviceConfiguration.kt
@@ -1,0 +1,49 @@
+package io.github.takahirom.arbigent
+
+/**
+ * Runtime configuration for the iOS real-device (physical iPhone) XCTest backend.
+ *
+ * These knobs only apply to physical devices discovered via `xcrun devicectl`; simulators are
+ * unaffected. Values flow from the CLI/settings into [ArbigentIosRealDeviceSettings.current] before
+ * device discovery, and each field falls back to an environment variable and finally a sensible
+ * default (see [ArbigentIosRealDeviceSettings]).
+ */
+public class ArbigentIosRealDeviceConfiguration(
+  /**
+   * Apple developer team id used to re-sign the XCTest runner for the device
+   * (`DEVELOPMENT_TEAM`). When null, resolution falls back to the environment and then to
+   * auto-detection (see [resolveAppleTeamId]).
+   */
+  public val appleTeamId: String? = null,
+  /** Hardware UDID selecting a specific connected device; null means "the only connected one". */
+  public val deviceId: String? = null,
+  /** Host/device loopback port the XCTest runner binds and iproxy forwards. */
+  public val port: Int? = null,
+  /** When true, arbigent spawns and manages `iproxy` to bridge the device loopback to the host. */
+  public val autoStartIproxy: Boolean = true,
+)
+
+/**
+ * Process-wide holder for [ArbigentIosRealDeviceConfiguration], mirroring [ArbigentFiles]. The CLI
+ * populates [current] from options/settings; discovery and connection read it. Environment-variable
+ * fallbacks live here so both the holder default and callers agree on precedence.
+ */
+public object ArbigentIosRealDeviceSettings {
+  public const val ENV_APPLE_TEAM_ID: String = "ARBIGENT_IOS_XCTEST_APPLE_TEAM_ID"
+  public const val ENV_DEVICE_ID: String = "ARBIGENT_IOS_REAL_DEVICE_ID"
+  public const val ENV_PORT: String = "ARBIGENT_IOS_REAL_DEVICE_PORT"
+
+  // The maestro XCTest runner's default loopback port (XCTestHTTPServer defaults to 22087 when the
+  // PORT env is unset). Keeping this as the host/iproxy port keeps both ends in sync.
+  public const val DEFAULT_PORT: Int = 22087
+
+  public var current: ArbigentIosRealDeviceConfiguration = ArbigentIosRealDeviceConfiguration()
+
+  /** Resolved device UDID filter: explicit config, then env, else null (auto-select single device). */
+  public fun resolvedDeviceId(env: (String) -> String? = System::getenv): String? =
+    current.deviceId?.takeIf { it.isNotBlank() } ?: env(ENV_DEVICE_ID)?.takeIf { it.isNotBlank() }
+
+  /** Resolved runner port: explicit config, then env, else [DEFAULT_PORT]. */
+  public fun resolvedPort(env: (String) -> String? = System::getenv): Int =
+    current.port ?: env(ENV_PORT)?.trim()?.toIntOrNull() ?: DEFAULT_PORT
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDeviceConfiguration.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDeviceConfiguration.kt
@@ -43,7 +43,24 @@ public object ArbigentIosRealDeviceSettings {
   public fun resolvedDeviceId(env: (String) -> String? = System::getenv): String? =
     current.deviceId?.takeIf { it.isNotBlank() } ?: env(ENV_DEVICE_ID)?.takeIf { it.isNotBlank() }
 
-  /** Resolved runner port: explicit config, then env, else [DEFAULT_PORT]. */
-  public fun resolvedPort(env: (String) -> String? = System::getenv): Int =
-    current.port ?: env(ENV_PORT)?.trim()?.toIntOrNull() ?: DEFAULT_PORT
+  /**
+   * Resolved runner port: explicit config, then env, else [DEFAULT_PORT]. A configured or env value
+   * outside `1..65535` — or non-numeric env text — fails loudly rather than silently falling back to
+   * the default, which would mask a misconfiguration.
+   */
+  public fun resolvedPort(env: (String) -> String? = System::getenv): Int {
+    current.port?.let { return requireValidPort(it) { "configured iOS real-device port" } }
+    val raw = env(ENV_PORT)?.trim()
+    if (!raw.isNullOrEmpty()) {
+      val parsed = raw.toIntOrNull()
+        ?: throw IllegalArgumentException("$ENV_PORT must be an integer in 1..65535 but was \"$raw\"")
+      return requireValidPort(parsed) { ENV_PORT }
+    }
+    return DEFAULT_PORT
+  }
+
+  private inline fun requireValidPort(port: Int, name: () -> String): Int {
+    require(port in 1..65535) { "${name()} must be in 1..65535 but was $port" }
+    return port
+  }
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDriverProducts.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDriverProducts.kt
@@ -84,8 +84,11 @@ public class IosRealDriverProducts(
         timeoutMs = xcodebuildTimeoutMs(),
       )
       if (!result.isSuccess) {
+        // xcodebuild echoes the full invocation (including DEVELOPMENT_TEAM=<teamId>) into its
+        // output; redact the team id before persisting so it never lands in cleartext on disk.
+        val masked = IosCodeSigningTeamResolver.maskTeamId(teamId)
         val log = File(cacheDir, "xcodebuild-output.log").apply {
-          writeText(result.stdout + "\n" + result.stderr)
+          writeText((result.stdout + "\n" + result.stderr).replace(teamId, masked))
         }
         throw IllegalStateException(
           "Failed to build the iOS XCTest runner for the connected device. " +

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDriverProducts.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDriverProducts.kt
@@ -71,8 +71,32 @@ public class IosRealDriverProducts(
     val hasXctestRun = productsDir.walkTopDown().any { it.extension == "xctestrun" }
     if (!hasXctestRun) return false
     val props = Properties().apply { marker.inputStream().use { load(it) } }
-    return props.getProperty("maestroVersion") == maestroVersion &&
-      props.getProperty("teamHash") == teamHash()
+    // Every input that changes the signed products must be part of the reuse decision: schema (so a
+    // format change forces a rebuild), maestro version, team, target device, Xcode/toolchain and the
+    // exact runner source. The device is also in the cache path, but validating it here guards against
+    // a hand-edited marker or path collision.
+    if (props.getProperty("schemaVersion") != CACHE_SCHEMA_VERSION) return false
+    if (props.getProperty("maestroVersion") != maestroVersion) return false
+    if (props.getProperty("teamHash") != teamHash()) return false
+    if (props.getProperty("deviceHash") != deviceHash()) return false
+    if (props.getProperty("xcodeVersion") != xcodeVersion()) return false
+    if (props.getProperty("runnerSourceChecksum") != runnerSourceChecksum()) return false
+    // Free (7-day) provisioning profiles expire; a cached-but-expired runner would fail to install.
+    // Rebuild if the embedded profile is expired or does not cover the target device.
+    if (!isProvisioningProfileUsable(productsDir)) {
+      arbigentInfoLog("iOS real device: cached runner's provisioning profile is expired or missing this device; rebuilding")
+      return false
+    }
+    return true
+  }
+
+  /** Decodes the built runner's embedded.mobileprovision and checks expiry + device eligibility. */
+  private fun isProvisioningProfileUsable(productsDir: File): Boolean {
+    val profile = productsDir.walkTopDown().firstOrNull { it.name == "embedded.mobileprovision" }
+      ?: return false
+    val decoded = executor.execute(listOf("security", "cms", "-D", "-i", profile.absolutePath))
+    if (!decoded.isSuccess || decoded.stdout.isBlank()) return false
+    return MobileProvisionInspector.isUsable(decoded.stdout, deviceUdid, java.time.Instant.now())
   }
 
   private fun build(cacheDir: File, productsDir: File) {
@@ -157,29 +181,45 @@ public class IosRealDriverProducts(
 
   private fun writeMarker(cacheDir: File) {
     val props = Properties()
+    props["schemaVersion"] = CACHE_SCHEMA_VERSION
     props["maestroVersion"] = maestroVersion
     props["teamHash"] = teamHash()
+    props["deviceHash"] = deviceHash()
+    props["xcodeVersion"] = xcodeVersion()
+    props["runnerSourceChecksum"] = runnerSourceChecksum()
     File(cacheDir, MARKER_FILE).outputStream().use { props.store(it, "arbigent iOS real-device runner") }
   }
 
-  /** Copies the bundled driver/ios resource tree to [target], handling jar and file layouts. */
-  private fun copyDriverSource(target: Path) {
+  /**
+   * Resolves the bundled driver/ios resource tree and runs [block] against its root, handling both
+   * jar and exploded-directory layouts. When the resource lives in a jar whose FileSystem we had to
+   * open ourselves, we close it afterwards; a FileSystem the JVM already owns (e.g. the app jar) is
+   * left open so we don't break other consumers.
+   */
+  private fun <T> withDriverSourceRoot(block: (Path) -> T): T {
     val url = javaClass.classLoader.getResource(DRIVER_SOURCE_RESOURCE)
       ?: throw IllegalStateException(
         "Bundled iOS driver source not found on classpath at $DRIVER_SOURCE_RESOURCE. " +
           "This build was produced without the iOS real-device runner source."
       )
     val uri = url.toURI()
-    val sourceRoot: Path = if (uri.scheme == "jar") {
-      val fs = try {
-        FileSystems.getFileSystem(uri)
-      } catch (e: FileSystemNotFoundException) {
-        FileSystems.newFileSystem(uri, emptyMap<String, Any>())
-      }
-      fs.getPath("/$DRIVER_SOURCE_RESOURCE")
-    } else {
-      Paths.get(uri)
+    if (uri.scheme != "jar") return block(Paths.get(uri))
+    var createdFs = false
+    val fs = try {
+      FileSystems.getFileSystem(uri)
+    } catch (e: FileSystemNotFoundException) {
+      createdFs = true
+      FileSystems.newFileSystem(uri, emptyMap<String, Any>())
     }
+    return try {
+      block(fs.getPath("/$DRIVER_SOURCE_RESOURCE"))
+    } finally {
+      if (createdFs) fs.close()
+    }
+  }
+
+  /** Copies the bundled driver/ios resource tree to [target], handling jar and file layouts. */
+  private fun copyDriverSource(target: Path): Unit = withDriverSourceRoot { sourceRoot ->
     Files.walk(sourceRoot).use { paths ->
       paths.filter { Files.isRegularFile(it) }.forEach { path ->
         val relative = sourceRoot.relativize(path).toString()
@@ -190,12 +230,35 @@ public class IosRealDriverProducts(
     }
   }
 
+  // Fingerprint of the packaged runner source (relative paths + contents), so a runner cached from a
+  // different or tampered source tree is rebuilt even though the maestro version matches.
+  private fun runnerSourceChecksum(): String = withDriverSourceRoot { sourceRoot ->
+    val digest = MessageDigest.getInstance("SHA-256")
+    Files.walk(sourceRoot).use { paths ->
+      paths.filter { Files.isRegularFile(it) }.sorted().forEach { path ->
+        digest.update(sourceRoot.relativize(path).toString().toByteArray())
+        digest.update(Files.readAllBytes(path))
+      }
+    }
+    digest.digest().take(8).joinToString("") { "%02x".format(it) }
+  }
+
+  private fun xcodeVersion(): String =
+    executor.execute(listOf("xcodebuild", "-version")).stdout.trim().replace("\n", " ").ifBlank { "unknown" }
+
+  // Scope the cache path by team AND device so a runner signed/provisioned for one iPhone is never
+  // reused for another; other build inputs (Xcode, source, schema) are validated via the marker.
   private fun cacheDir(): File =
-    File(arbigentHomeDir(), "ios-real-driver/$maestroVersion/${teamHash()}")
+    File(arbigentHomeDir(), "ios-real-driver/$maestroVersion/${teamHash()}/${deviceHash()}")
 
   // Hash the team id so it never appears in cleartext in filesystem paths.
-  private fun teamHash(): String {
-    val digest = MessageDigest.getInstance("SHA-256").digest(teamId.toByteArray())
+  private fun teamHash(): String = shortHash(teamId)
+
+  // Hash the device udid too, so real UDIDs never appear in cleartext on disk.
+  private fun deviceHash(): String = shortHash(deviceUdid)
+
+  private fun shortHash(value: String): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(value.toByteArray())
     return digest.take(8).joinToString("") { "%02x".format(it) }
   }
 
@@ -217,6 +280,9 @@ public class IosRealDriverProducts(
     public const val DRIVER_SOURCE_RESOURCE: String = "ios-real-driver/runner"
     private const val MARKER_FILE = "arbigent-driver.properties"
 
+    // Bump when the marker format or the set of validated inputs changes, so old caches are ignored.
+    private const val CACHE_SCHEMA_VERSION = "2"
+
     // In-process guard around the cross-process FileLock (a channel can't be locked twice in one JVM).
     private val buildLock = Any()
 
@@ -229,3 +295,33 @@ public class IosRealDriverProducts(
 /** `~/.arbigent`, the on-disk home for cached artifacts shared across arbigent runs. */
 internal fun arbigentHomeDir(): File =
   File(System.getProperty("user.home"), ".arbigent").apply { mkdirs() }
+
+/**
+ * Reads the two fields that decide whether a cached, signed runner is still usable from a decoded
+ * `embedded.mobileprovision` plist (as produced by `security cms -D -i`). Kept string-based and pure
+ * so it is unit-testable without a real profile.
+ */
+internal object MobileProvisionInspector {
+  private val expirationRegex = Regex("""<key>ExpirationDate</key>\s*<date>([^<]+)</date>""")
+  private val provisionedDevicesRegex =
+    Regex("""<key>ProvisionedDevices</key>\s*<array>(.*?)</array>""", RegexOption.DOT_MATCHES_ALL)
+  private val stringRegex = Regex("""<string>([^<]+)</string>""")
+
+  fun expirationDate(plistXml: String): java.time.Instant? =
+    expirationRegex.find(plistXml)?.groupValues?.get(1)?.let {
+      runCatching { java.time.Instant.parse(it.trim()) }.getOrNull()
+    }
+
+  /** The provisioned device UDIDs, or null when the profile lists none (wildcard/enterprise). */
+  fun provisionedDevices(plistXml: String): List<String>? {
+    val block = provisionedDevicesRegex.find(plistXml)?.groupValues?.get(1) ?: return null
+    return stringRegex.findAll(block).map { it.groupValues[1].trim() }.toList()
+  }
+
+  fun isUsable(plistXml: String, deviceUdid: String, now: java.time.Instant): Boolean {
+    val expiry = expirationDate(plistXml) ?: return false
+    if (!expiry.isAfter(now)) return false
+    val devices = provisionedDevices(plistXml) ?: return true
+    return devices.any { it.equals(deviceUdid, ignoreCase = true) }
+  }
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDriverProducts.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDriverProducts.kt
@@ -38,8 +38,31 @@ public class IosRealDriverProducts(
       arbigentInfoLog("iOS real device: reusing cached runner at ${productsDir.absolutePath}")
       return productsDir
     }
-    build(cacheDir, productsDir)
-    return productsDir
+    // The cache dir is shared across arbigent processes (e.g. UI + CLI); serialize the
+    // check-then-build so two runs cannot wipe each other's in-progress build. See [withBuildLock].
+    return withBuildLock(cacheDir) {
+      // Another run may have finished the build while we waited for the lock.
+      if (isUpToDate(cacheDir, productsDir)) {
+        arbigentInfoLog("iOS real device: reusing cached runner at ${productsDir.absolutePath}")
+      } else {
+        build(cacheDir, productsDir)
+      }
+      productsDir
+    }
+  }
+
+  // Serialize the shared-cache build both across threads (synchronized on [buildLock]) and across
+  // processes (an exclusive FileLock on a `.lock` file kept in the cache PARENT, so it survives the
+  // cache dir being replaced). synchronized is required around the FileLock too: a second thread in
+  // the same JVM locking the same channel would hit OverlappingFileLockException.
+  private fun <T> withBuildLock(cacheDir: File, block: () -> T): T {
+    val lockParent = cacheDir.parentFile.apply { mkdirs() }
+    val lockFile = File(lockParent, "${cacheDir.name}.build.lock")
+    return synchronized(buildLock) {
+      java.io.RandomAccessFile(lockFile, "rw").use { raf ->
+        raf.channel.lock().use { block() }
+      }
+    }
   }
 
   private fun isUpToDate(cacheDir: File, productsDir: File): Boolean {
@@ -57,9 +80,13 @@ public class IosRealDriverProducts(
       "iOS real device: building signed XCTest runner (team ${IosCodeSigningTeamResolver.maskTeamId(teamId)}); " +
         "first build can take several minutes"
     )
-    // Rebuild from a clean cache dir to avoid stale products from an older maestro/team.
-    cacheDir.deleteRecursively()
-    cacheDir.mkdirs()
+    // Build into a process-unique sibling dir and only swap it into place once complete, so a
+    // partially-built or failed build never leaves a corrupt runner at the shared cache path.
+    val buildDir = Files.createTempDirectory(
+      cacheDir.parentFile.apply { mkdirs() }.toPath(),
+      "${cacheDir.name}.building",
+    ).toFile()
+    val buildProductsDir = File(buildDir, "Build/Products")
 
     val sourceDir = Files.createTempDirectory("arbigent-ios-driver-src")
     try {
@@ -73,16 +100,17 @@ public class IosRealDriverProducts(
       // build description is sometimes computed before the profile lands on disk ("Build input
       // file cannot be found: …/<uuid>.mobileprovision"). The profile exists by the time the run
       // fails, so a single clean rebuild picks it up. Retry once on that transient race.
-      var result = runXcodebuild(project, cacheDir)
+      var result = runXcodebuild(project, buildDir)
       if (!result.isSuccess && isTransientProvisioningFailure(result)) {
         arbigentInfoLog("iOS real device: transient provisioning race on first build; retrying once")
-        result = runXcodebuild(project, cacheDir)
+        result = runXcodebuild(project, buildDir)
       }
       if (!result.isSuccess) {
         // xcodebuild echoes the full invocation (including DEVELOPMENT_TEAM=<teamId>) into its
         // output; redact the team id before persisting so it never lands in cleartext on disk.
         val masked = IosCodeSigningTeamResolver.maskTeamId(teamId)
-        val log = File(cacheDir, "xcodebuild-output.log").apply {
+        cacheDir.parentFile.mkdirs()
+        val log = File(cacheDir.parentFile, "${cacheDir.name}-xcodebuild-output.log").apply {
           writeText((result.stdout + "\n" + result.stderr).replace(teamId, masked))
         }
         throw IllegalStateException(
@@ -91,17 +119,26 @@ public class IosRealDriverProducts(
             "provision this device. Build log: ${log.absolutePath}"
         )
       }
-      check(productsDir.isDirectory && productsDir.walkTopDown().any { it.extension == "xctestrun" }) {
-        "xcodebuild reported success but no .xctestrun was produced under ${productsDir.absolutePath}"
+      check(buildProductsDir.isDirectory && buildProductsDir.walkTopDown().any { it.extension == "xctestrun" }) {
+        "xcodebuild reported success but no .xctestrun was produced under ${buildProductsDir.absolutePath}"
       }
-      writeMarker(cacheDir)
+      writeMarker(buildDir)
+      // Swap the freshly built dir into place. We hold the build lock, so no other run is building;
+      // replace any stale cache dir and move atomically where the filesystem supports it.
+      cacheDir.deleteRecursively()
+      try {
+        Files.move(buildDir.toPath(), cacheDir.toPath(), StandardCopyOption.ATOMIC_MOVE)
+      } catch (e: java.nio.file.AtomicMoveNotSupportedException) {
+        Files.move(buildDir.toPath(), cacheDir.toPath())
+      }
       arbigentInfoLog("iOS real device: runner built at ${productsDir.absolutePath}")
     } finally {
       sourceDir.toFile().deleteRecursively()
+      buildDir.deleteRecursively()
     }
   }
 
-  private fun runXcodebuild(project: java.nio.file.Path, cacheDir: File): ArbigentCommandResult =
+  private fun runXcodebuild(project: java.nio.file.Path, derivedDataPath: File): ArbigentCommandResult =
     executor.execute(
       listOf(
         "xcodebuild",
@@ -111,7 +148,7 @@ public class IosRealDriverProducts(
         "-scheme", "maestro-driver-ios",
         "-destination", "platform=iOS,id=$deviceUdid",
         "-allowProvisioningUpdates",
-        "-derivedDataPath", cacheDir.absolutePath,
+        "-derivedDataPath", derivedDataPath.absolutePath,
         "DEVELOPMENT_TEAM=$teamId",
         "CODE_SIGN_IDENTITY=Apple Development",
       ),
@@ -179,6 +216,9 @@ public class IosRealDriverProducts(
   public companion object {
     public const val DRIVER_SOURCE_RESOURCE: String = "ios-real-driver/runner"
     private const val MARKER_FILE = "arbigent-driver.properties"
+
+    // In-process guard around the cross-process FileLock (a channel can't be locked twice in one JVM).
+    private val buildLock = Any()
 
     // First builds (clean + provisioning) routinely exceed maestro's 120s default; give xcodebuild
     // more room while still honoring an explicit MAESTRO_XCODEBUILD_WAIT_TIME override.

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDriverProducts.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDriverProducts.kt
@@ -14,8 +14,8 @@ import java.util.Properties
  * Builds and caches the XCTest runner for a physical iPhone, re-signed with the user's Apple team.
  *
  * The runner Xcode project + Swift sources ship as a classpath resource under
- * [DRIVER_SOURCE_RESOURCE] (extracted from the pinned maestro-cli jar at build time). We mirror
- * maestro-cli's `DriverBuilder`: copy the source to a temp dir and run
+ * [DRIVER_SOURCE_RESOURCE] (extracted from the pinned Maestro source archive at build time). We
+ * mirror maestro-cli's `DriverBuilder`: copy the source to a temp dir and run
  * `xcodebuild clean build-for-testing` with `DEVELOPMENT_TEAM` and `CODE_SIGN_IDENTITY`. Products
  * land in `<cache>/Build/Products`, which is what [xcuitest.installer.LocalXCTestInstaller] consumes
  * as `sourceDirectory` for `IOSDeviceType.REAL`.
@@ -68,21 +68,16 @@ public class IosRealDriverProducts(
       check(Files.exists(project)) {
         "Bundled iOS driver source is missing maestro-driver-ios.xcodeproj at $project"
       }
-      val result = executor.execute(
-        listOf(
-          "xcodebuild",
-          "clean",
-          "build-for-testing",
-          "-project", project.toString(),
-          "-scheme", "maestro-driver-ios",
-          "-destination", "platform=iOS,id=$deviceUdid",
-          "-allowProvisioningUpdates",
-          "-derivedDataPath", cacheDir.absolutePath,
-          "DEVELOPMENT_TEAM=$teamId",
-          "CODE_SIGN_IDENTITY=Apple Development",
-        ),
-        timeoutMs = xcodebuildTimeoutMs(),
-      )
+
+      // `-allowProvisioningUpdates` creates a fresh provisioning profile on first run, but the
+      // build description is sometimes computed before the profile lands on disk ("Build input
+      // file cannot be found: …/<uuid>.mobileprovision"). The profile exists by the time the run
+      // fails, so a single clean rebuild picks it up. Retry once on that transient race.
+      var result = runXcodebuild(project, cacheDir)
+      if (!result.isSuccess && isTransientProvisioningFailure(result)) {
+        arbigentInfoLog("iOS real device: transient provisioning race on first build; retrying once")
+        result = runXcodebuild(project, cacheDir)
+      }
       if (!result.isSuccess) {
         // xcodebuild echoes the full invocation (including DEVELOPMENT_TEAM=<teamId>) into its
         // output; redact the team id before persisting so it never lands in cleartext on disk.
@@ -105,6 +100,23 @@ public class IosRealDriverProducts(
       sourceDir.toFile().deleteRecursively()
     }
   }
+
+  private fun runXcodebuild(project: java.nio.file.Path, cacheDir: File): ArbigentCommandResult =
+    executor.execute(
+      listOf(
+        "xcodebuild",
+        "clean",
+        "build-for-testing",
+        "-project", project.toString(),
+        "-scheme", "maestro-driver-ios",
+        "-destination", "platform=iOS,id=$deviceUdid",
+        "-allowProvisioningUpdates",
+        "-derivedDataPath", cacheDir.absolutePath,
+        "DEVELOPMENT_TEAM=$teamId",
+        "CODE_SIGN_IDENTITY=Apple Development",
+      ),
+      timeoutMs = xcodebuildTimeoutMs(),
+    )
 
   private fun writeMarker(cacheDir: File) {
     val props = Properties()
@@ -150,6 +162,14 @@ public class IosRealDriverProducts(
     return digest.take(8).joinToString("") { "%02x".format(it) }
   }
 
+  // First-run `-allowProvisioningUpdates` races: a just-created provisioning profile the build
+  // description referenced before it was written to disk. Re-running finds the now-present profile.
+  private fun isTransientProvisioningFailure(result: ArbigentCommandResult): Boolean {
+    val text = result.stdout + result.stderr
+    return text.contains(".mobileprovision") &&
+      (text.contains("Build input file cannot be found") || text.contains("No profiles for"))
+  }
+
   private fun xcodebuildTimeoutMs(): Long {
     val seconds = System.getenv("MAESTRO_XCODEBUILD_WAIT_TIME")?.trim()?.toLongOrNull()
       ?: DEFAULT_XCODEBUILD_WAIT_SECONDS
@@ -157,7 +177,7 @@ public class IosRealDriverProducts(
   }
 
   public companion object {
-    public const val DRIVER_SOURCE_RESOURCE: String = "ios-real-driver/driver/ios"
+    public const val DRIVER_SOURCE_RESOURCE: String = "ios-real-driver/runner"
     private const val MARKER_FILE = "arbigent-driver.properties"
 
     // First builds (clean + provisioning) routinely exceed maestro's 120s default; give xcodebuild

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDriverProducts.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDriverProducts.kt
@@ -1,0 +1,168 @@
+package io.github.takahirom.arbigent
+
+import java.io.File
+import java.nio.file.FileSystemNotFoundException
+import java.nio.file.FileSystems
+import java.nio.file.Files
+import java.nio.file.Path
+import java.nio.file.Paths
+import java.nio.file.StandardCopyOption
+import java.security.MessageDigest
+import java.util.Properties
+
+/**
+ * Builds and caches the XCTest runner for a physical iPhone, re-signed with the user's Apple team.
+ *
+ * The runner Xcode project + Swift sources ship as a classpath resource under
+ * [DRIVER_SOURCE_RESOURCE] (extracted from the pinned maestro-cli jar at build time). We mirror
+ * maestro-cli's `DriverBuilder`: copy the source to a temp dir and run
+ * `xcodebuild clean build-for-testing` with `DEVELOPMENT_TEAM` and `CODE_SIGN_IDENTITY`. Products
+ * land in `<cache>/Build/Products`, which is what [xcuitest.installer.LocalXCTestInstaller] consumes
+ * as `sourceDirectory` for `IOSDeviceType.REAL`.
+ *
+ * Products are cached under `~/.arbigent/ios-real-driver/<maestroVersion>/<teamHash>/` and reused
+ * when a marker file matches the current maestro version and team; a missing `.xctestrun` or a
+ * version/team mismatch triggers a rebuild.
+ */
+public class IosRealDriverProducts(
+  private val teamId: String,
+  private val deviceUdid: String,
+  private val executor: ArbigentCommandExecutor = DefaultArbigentCommandExecutor(),
+  private val maestroVersion: String = BuildConfig.MAESTRO_VERSION,
+) {
+  /** Returns the `Build/Products` directory, building the signed runner first if necessary. */
+  public fun resolveBuildProductsDir(): File {
+    val cacheDir = cacheDir()
+    val productsDir = File(cacheDir, "Build/Products")
+    if (isUpToDate(cacheDir, productsDir)) {
+      arbigentInfoLog("iOS real device: reusing cached runner at ${productsDir.absolutePath}")
+      return productsDir
+    }
+    build(cacheDir, productsDir)
+    return productsDir
+  }
+
+  private fun isUpToDate(cacheDir: File, productsDir: File): Boolean {
+    val marker = File(cacheDir, MARKER_FILE)
+    if (!marker.exists() || !productsDir.isDirectory) return false
+    val hasXctestRun = productsDir.walkTopDown().any { it.extension == "xctestrun" }
+    if (!hasXctestRun) return false
+    val props = Properties().apply { marker.inputStream().use { load(it) } }
+    return props.getProperty("maestroVersion") == maestroVersion &&
+      props.getProperty("teamHash") == teamHash()
+  }
+
+  private fun build(cacheDir: File, productsDir: File) {
+    arbigentInfoLog(
+      "iOS real device: building signed XCTest runner (team ${IosCodeSigningTeamResolver.maskTeamId(teamId)}); " +
+        "first build can take several minutes"
+    )
+    // Rebuild from a clean cache dir to avoid stale products from an older maestro/team.
+    cacheDir.deleteRecursively()
+    cacheDir.mkdirs()
+
+    val sourceDir = Files.createTempDirectory("arbigent-ios-driver-src")
+    try {
+      copyDriverSource(sourceDir)
+      val project = sourceDir.resolve("maestro-driver-ios.xcodeproj")
+      check(Files.exists(project)) {
+        "Bundled iOS driver source is missing maestro-driver-ios.xcodeproj at $project"
+      }
+      val result = executor.execute(
+        listOf(
+          "xcodebuild",
+          "clean",
+          "build-for-testing",
+          "-project", project.toString(),
+          "-scheme", "maestro-driver-ios",
+          "-destination", "platform=iOS,id=$deviceUdid",
+          "-allowProvisioningUpdates",
+          "-derivedDataPath", cacheDir.absolutePath,
+          "DEVELOPMENT_TEAM=$teamId",
+          "CODE_SIGN_IDENTITY=Apple Development",
+        ),
+        timeoutMs = xcodebuildTimeoutMs(),
+      )
+      if (!result.isSuccess) {
+        val log = File(cacheDir, "xcodebuild-output.log").apply {
+          writeText(result.stdout + "\n" + result.stderr)
+        }
+        throw IllegalStateException(
+          "Failed to build the iOS XCTest runner for the connected device. " +
+            "Check signing (team ${IosCodeSigningTeamResolver.maskTeamId(teamId)}) and that Xcode can " +
+            "provision this device. Build log: ${log.absolutePath}"
+        )
+      }
+      check(productsDir.isDirectory && productsDir.walkTopDown().any { it.extension == "xctestrun" }) {
+        "xcodebuild reported success but no .xctestrun was produced under ${productsDir.absolutePath}"
+      }
+      writeMarker(cacheDir)
+      arbigentInfoLog("iOS real device: runner built at ${productsDir.absolutePath}")
+    } finally {
+      sourceDir.toFile().deleteRecursively()
+    }
+  }
+
+  private fun writeMarker(cacheDir: File) {
+    val props = Properties()
+    props["maestroVersion"] = maestroVersion
+    props["teamHash"] = teamHash()
+    File(cacheDir, MARKER_FILE).outputStream().use { props.store(it, "arbigent iOS real-device runner") }
+  }
+
+  /** Copies the bundled driver/ios resource tree to [target], handling jar and file layouts. */
+  private fun copyDriverSource(target: Path) {
+    val url = javaClass.classLoader.getResource(DRIVER_SOURCE_RESOURCE)
+      ?: throw IllegalStateException(
+        "Bundled iOS driver source not found on classpath at $DRIVER_SOURCE_RESOURCE. " +
+          "This build was produced without the iOS real-device runner source."
+      )
+    val uri = url.toURI()
+    val sourceRoot: Path = if (uri.scheme == "jar") {
+      val fs = try {
+        FileSystems.getFileSystem(uri)
+      } catch (e: FileSystemNotFoundException) {
+        FileSystems.newFileSystem(uri, emptyMap<String, Any>())
+      }
+      fs.getPath("/$DRIVER_SOURCE_RESOURCE")
+    } else {
+      Paths.get(uri)
+    }
+    Files.walk(sourceRoot).use { paths ->
+      paths.filter { Files.isRegularFile(it) }.forEach { path ->
+        val relative = sourceRoot.relativize(path).toString()
+        val dest = target.resolve(relative)
+        Files.createDirectories(dest.parent)
+        Files.copy(path, dest, StandardCopyOption.REPLACE_EXISTING)
+      }
+    }
+  }
+
+  private fun cacheDir(): File =
+    File(arbigentHomeDir(), "ios-real-driver/$maestroVersion/${teamHash()}")
+
+  // Hash the team id so it never appears in cleartext in filesystem paths.
+  private fun teamHash(): String {
+    val digest = MessageDigest.getInstance("SHA-256").digest(teamId.toByteArray())
+    return digest.take(8).joinToString("") { "%02x".format(it) }
+  }
+
+  private fun xcodebuildTimeoutMs(): Long {
+    val seconds = System.getenv("MAESTRO_XCODEBUILD_WAIT_TIME")?.trim()?.toLongOrNull()
+      ?: DEFAULT_XCODEBUILD_WAIT_SECONDS
+    return seconds * 1_000
+  }
+
+  public companion object {
+    public const val DRIVER_SOURCE_RESOURCE: String = "ios-real-driver/driver/ios"
+    private const val MARKER_FILE = "arbigent-driver.properties"
+
+    // First builds (clean + provisioning) routinely exceed maestro's 120s default; give xcodebuild
+    // more room while still honoring an explicit MAESTRO_XCODEBUILD_WAIT_TIME override.
+    private const val DEFAULT_XCODEBUILD_WAIT_SECONDS = 600L
+  }
+}
+
+/** `~/.arbigent`, the on-disk home for cached artifacts shared across arbigent runs. */
+internal fun arbigentHomeDir(): File =
+  File(System.getProperty("user.home"), ".arbigent").apply { mkdirs() }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDriverProducts.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDriverProducts.kt
@@ -34,14 +34,12 @@ public class IosRealDriverProducts(
   public fun resolveBuildProductsDir(): File {
     val cacheDir = cacheDir()
     val productsDir = File(cacheDir, "Build/Products")
-    if (isUpToDate(cacheDir, productsDir)) {
-      arbigentInfoLog("iOS real device: reusing cached runner at ${productsDir.absolutePath}")
-      return productsDir
-    }
-    // The cache dir is shared across arbigent processes (e.g. UI + CLI); serialize the
-    // check-then-build so two runs cannot wipe each other's in-progress build. See [withBuildLock].
+    // Validate the cache and (if needed) build entirely under the build lock. A cache-hit
+    // validation done outside the lock could return a products dir that a concurrent run is
+    // mid-way through deleting and rebuilding, and its runner-source checksum could open the
+    // bundled-source jar FileSystem while another thread closes it. Holding the lock across the
+    // whole check-then-build serializes both against other runs (process) and threads (JVM).
     return withBuildLock(cacheDir) {
-      // Another run may have finished the build while we waited for the lock.
       if (isUpToDate(cacheDir, productsDir)) {
         arbigentInfoLog("iOS real device: reusing cached runner at ${productsDir.absolutePath}")
       } else {
@@ -206,10 +204,18 @@ public class IosRealDriverProducts(
     if (uri.scheme != "jar") return block(Paths.get(uri))
     var createdFs = false
     val fs = try {
+      // The JVM already owns this jar FileSystem (e.g. the app jar); borrow it and leave it open.
       FileSystems.getFileSystem(uri)
     } catch (e: FileSystemNotFoundException) {
-      createdFs = true
-      FileSystems.newFileSystem(uri, emptyMap<String, Any>())
+      try {
+        createdFs = true
+        FileSystems.newFileSystem(uri, emptyMap<String, Any>())
+      } catch (e: java.nio.file.FileSystemAlreadyExistsException) {
+        // Another caller created it between our lookup and creation; borrow it without closing so
+        // we don't yank the FileSystem out from under that caller mid-walk.
+        createdFs = false
+        FileSystems.getFileSystem(uri)
+      }
     }
     return try {
       block(fs.getPath("/$DRIVER_SOURCE_RESOURCE"))

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDriverProducts.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDriverProducts.kt
@@ -45,6 +45,10 @@ public class IosRealDriverProducts(
       } else {
         build(cacheDir, productsDir)
       }
+      // Accepted tradeoff: the returned dir is validated/built under the lock but not lifetime-
+      // protected once the lock is released — a *different process* could later replace this cache
+      // (same device+team) while a caller still holds the path. Concurrent multi-process runs
+      // against the same device+team are out of scope, so we do not pin or copy the products here.
       productsDir
     }
   }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealXCTestPortForwarder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealXCTestPortForwarder.kt
@@ -1,0 +1,103 @@
+package io.github.takahirom.arbigent
+
+import java.io.File
+import java.util.concurrent.TimeUnit
+
+/**
+ * Bridges the host to the XCTest runner's HTTP server on a physical device.
+ *
+ * The maestro runner binds `127.0.0.1:<port>` on the DEVICE's loopback, and maestro ships no
+ * forwarding code, so on a USB-connected iPhone the host's `127.0.0.1:<port>` never reaches it.
+ * This forwarder spawns and supervises `iproxy` (libimobiledevice) to publish the device port on
+ * the same host port, and ties its lifecycle to the arbigent session: it is killed on [close], via
+ * a JVM shutdown hook, and it proactively reaps orphaned `iproxy` processes left holding the port by
+ * a previously crashed run.
+ */
+public class IosRealXCTestPortForwarder(
+  private val deviceUdid: String,
+  private val port: Int,
+  private val executor: ArbigentCommandExecutor = DefaultArbigentCommandExecutor(),
+) : AutoCloseable {
+  private var process: Process? = null
+  private var shutdownHook: Thread? = null
+
+  public fun start() {
+    ensureIproxyInstalled()
+    reapOrphans()
+
+    val logFile = File(ArbigentFiles.parentDir, "iproxy-$port.log").apply { parentFile?.mkdirs() }
+    val builder = ProcessBuilder(
+      "iproxy", "--udid", deviceUdid, "$port:$port"
+    )
+      .redirectErrorStream(true)
+      .redirectOutput(ProcessBuilder.Redirect.appendTo(logFile))
+    val started = try {
+      builder.start()
+    } catch (e: java.io.IOException) {
+      throw IllegalStateException(iproxyMissingMessage(), e)
+    }
+    process = started
+    val hook = Thread { started.destroyForcibly() }
+    Runtime.getRuntime().addShutdownHook(hook)
+    shutdownHook = hook
+
+    // iproxy exits immediately if the port is taken or the device is gone; give it a moment and
+    // confirm it is still alive before we rely on the tunnel.
+    if (started.waitFor(1_000, TimeUnit.MILLISECONDS)) {
+      val log = logFile.takeIf { it.exists() }?.readText().orEmpty()
+      throw IllegalStateException(
+        "iproxy exited immediately (port $port). It may be in use or the device may be " +
+          "disconnected. Log: ${logFile.absolutePath}\n$log"
+      )
+    }
+    arbigentInfoLog("iOS real device: iproxy forwarding host 127.0.0.1:$port to device $port")
+  }
+
+  override fun close() {
+    process?.destroyForcibly()
+    process = null
+    shutdownHook?.let {
+      runCatching { Runtime.getRuntime().removeShutdownHook(it) }
+    }
+    shutdownHook = null
+  }
+
+  private fun ensureIproxyInstalled() {
+    val which = executor.execute(listOf("which", "iproxy"))
+    if (!which.isSuccess) throw IllegalStateException(iproxyMissingMessage())
+  }
+
+  /** Kills only `iproxy` processes still listening on [port] from a previous crashed run. */
+  private fun reapOrphans() {
+    val pids = orphanIproxyPids(
+      lsofOutput = executor.execute(
+        listOf("lsof", "-nP", "-iTCP:$port", "-sTCP:LISTEN", "-t")
+      ).stdout,
+      commandNameOf = { pid ->
+        executor.execute(listOf("ps", "-p", pid, "-o", "comm=")).stdout.trim()
+      },
+    )
+    pids.forEach { pid ->
+      arbigentInfoLog("iOS real device: reaping orphaned iproxy (pid $pid) holding port $port")
+      executor.execute(listOf("kill", "-9", pid))
+    }
+  }
+
+  private fun iproxyMissingMessage(): String =
+    "iproxy is not installed. Real iOS devices need libimobiledevice to forward the XCTest port. " +
+      "Install it with: brew install libimobiledevice"
+
+  public companion object {
+    /**
+     * Filters [lsofOutput] (newline-separated PIDs) to those whose process command name is
+     * `iproxy`, so we never kill an unrelated process that happens to hold the port.
+     */
+    public fun orphanIproxyPids(lsofOutput: String, commandNameOf: (String) -> String): List<String> =
+      lsofOutput.lineSequence()
+        .map { it.trim() }
+        .filter { it.isNotEmpty() && it.all(Char::isDigit) }
+        .distinct()
+        .filter { commandNameOf(it).contains("iproxy") }
+        .toList()
+  }
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealXCTestPortForwarder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealXCTestPortForwarder.kt
@@ -1,6 +1,9 @@
 package io.github.takahirom.arbigent
 
 import java.io.File
+import java.io.RandomAccessFile
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 import java.util.concurrent.TimeUnit
 
 /**
@@ -23,9 +26,25 @@ public class IosRealXCTestPortForwarder(
 ) : AutoCloseable {
   private var process: Process? = null
   private var shutdownHook: Thread? = null
+  // The record this instance published, so close() only deletes the shared pidfile while it still
+  // names us (never a record a newer instance rewrote in our place).
+  @Volatile private var ownershipRecord: IproxyOwnershipRecord? = null
 
   private val ownershipRecordFile: File
     get() = File(File(System.getProperty("user.home"), ".arbigent/iproxy-locks"), "port-$port.pid")
+
+  // Sibling lock file guarding every read/write/delete of the shared per-port pidfile, so
+  // concurrent arbigent runs racing the same port can't clobber or half-observe each other's
+  // record. The lock file itself is never a payload, so creating it is harmless.
+  private val ownershipLockFile: File
+    get() = File(ownershipRecordFile.parentFile, "port-$port.pid.lock")
+
+  private fun <T> withOwnershipLock(block: () -> T): T {
+    val lock = ownershipLockFile.apply { parentFile?.mkdirs() }
+    return RandomAccessFile(lock, "rw").use { raf ->
+      raf.channel.lock().use { block() }
+    }
+  }
 
   public fun start() {
     ensureIproxyInstalled()
@@ -73,7 +92,20 @@ public class IosRealXCTestPortForwarder(
       runCatching { Runtime.getRuntime().removeShutdownHook(it) }
     }
     shutdownHook = null
-    runCatching { ownershipRecordFile.delete() }
+    deleteOwnershipRecordIfOurs()
+    ownershipRecord = null
+  }
+
+  // Delete the shared pidfile only if it still names the record we wrote. If start() failed before
+  // publishing (ownershipRecord null) or a newer instance already rewrote it, we leave it intact so
+  // a live forwarder never appears unowned.
+  private fun deleteOwnershipRecordIfOurs() {
+    val ours = ownershipRecord ?: return
+    withOwnershipLock {
+      if (readOwnershipRecord() == ours) {
+        runCatching { ownershipRecordFile.delete() }
+      }
+    }
   }
 
   private fun ensureIproxyInstalled() {
@@ -95,21 +127,30 @@ public class IosRealXCTestPortForwarder(
         executor.execute(listOf("ps", "-p", pid, "-o", "comm=")).stdout.trim()
       },
     )
-    val decision = reapDecision(
-      port = port,
-      listeningIproxyPids = listening,
-      record = readOwnershipRecord(),
-      isOwnerAlive = ::isProcessAlive,
-      iproxyStartOf = { pid -> processStartMillis(pid) },
-    )
-    when (decision) {
-      is ReapDecision.Fail -> throw IllegalStateException("iOS real device: ${decision.reason}")
-      is ReapDecision.Reap -> {
-        decision.pids.forEach { pid ->
-          arbigentInfoLog("iOS real device: reaping orphaned iproxy (pid $pid) from a crashed run holding port $port")
-          executor.execute(listOf("kill", "-9", pid))
+    // Read the record, decide, and clear it all under the lock so a concurrent instance can't
+    // publish a fresh record between our decision and our delete (which would clobber it).
+    withOwnershipLock {
+      val record = readOwnershipRecord()
+      val decision = reapDecision(
+        port = port,
+        listeningIproxyPids = listening,
+        record = record,
+        isOwnerAlive = ::isProcessAlive,
+        iproxyStartOf = { pid -> processStartMillis(pid) },
+      )
+      when (decision) {
+        is ReapDecision.Fail -> throw IllegalStateException("iOS real device: ${decision.reason}")
+        is ReapDecision.Reap -> {
+          decision.pids.forEach { pid ->
+            arbigentInfoLog("iOS real device: reaping orphaned iproxy (pid $pid) from a crashed run holding port $port")
+            executor.execute(listOf("kill", "-9", pid))
+          }
+          // Only clear the record we just validated as belonging to a dead owner; if another
+          // instance rewrote it meanwhile it no longer matches and we leave it alone.
+          if (decision.pids.isNotEmpty() && readOwnershipRecord() == record) {
+            runCatching { ownershipRecordFile.delete() }
+          }
         }
-        if (decision.pids.isNotEmpty()) runCatching { ownershipRecordFile.delete() }
       }
     }
   }
@@ -122,7 +163,22 @@ public class IosRealXCTestPortForwarder(
       ownerPid = self.pid(),
       ownerStart = self.info().startInstant().map { it.toEpochMilli() }.orElse(0L),
     )
-    ownershipRecordFile.apply { parentFile?.mkdirs() }.writeText(record.serialize())
+    // Publish atomically under the lock: write a sibling temp then rename into place, so a reader
+    // never sees a half-written record and a concurrent writer can't interleave with ours.
+    withOwnershipLock {
+      val dir = ownershipRecordFile.parentFile.apply { mkdirs() }
+      val tmp = File.createTempFile("port-$port", ".pid", dir)
+      try {
+        tmp.writeText(record.serialize())
+        Files.move(
+          tmp.toPath(), ownershipRecordFile.toPath(),
+          StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE,
+        )
+      } finally {
+        tmp.delete()
+      }
+    }
+    ownershipRecord = record
   }
 
   private fun readOwnershipRecord(): IproxyOwnershipRecord? =

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealXCTestPortForwarder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealXCTestPortForwarder.kt
@@ -10,8 +10,11 @@ import java.util.concurrent.TimeUnit
  * forwarding code, so on a USB-connected iPhone the host's `127.0.0.1:<port>` never reaches it.
  * This forwarder spawns and supervises `iproxy` (libimobiledevice) to publish the device port on
  * the same host port, and ties its lifecycle to the arbigent session: it is killed on [close], via
- * a JVM shutdown hook, and it proactively reaps orphaned `iproxy` processes left holding the port by
- * a previously crashed run.
+ * a JVM shutdown hook, and it reaps `iproxy` processes that a *previous* arbigent run left holding
+ * the port after crashing. Reaping is limited to processes we can prove we own (a pidfile records
+ * both the iproxy and the owning arbigent, with start times to defeat PID reuse); an iproxy owned
+ * by a still-running arbigent, or one arbigent never started, is never killed — the port is
+ * reported as busy instead.
  */
 public class IosRealXCTestPortForwarder(
   private val deviceUdid: String,
@@ -20,6 +23,9 @@ public class IosRealXCTestPortForwarder(
 ) : AutoCloseable {
   private var process: Process? = null
   private var shutdownHook: Thread? = null
+
+  private val ownershipRecordFile: File
+    get() = File(File(System.getProperty("user.home"), ".arbigent/iproxy-locks"), "port-$port.pid")
 
   public fun start() {
     ensureIproxyInstalled()
@@ -37,18 +43,25 @@ public class IosRealXCTestPortForwarder(
       throw IllegalStateException(iproxyMissingMessage(), e)
     }
     process = started
+    // Register the shutdown hook and record ownership only after confirming iproxy stayed up; on any
+    // failure below, close() removes the hook and record so we never leak a hook or a stale pidfile.
     val hook = Thread { started.destroyForcibly() }
     Runtime.getRuntime().addShutdownHook(hook)
     shutdownHook = hook
-
-    // iproxy exits immediately if the port is taken or the device is gone; give it a moment and
-    // confirm it is still alive before we rely on the tunnel.
-    if (started.waitFor(1_000, TimeUnit.MILLISECONDS)) {
-      val log = logFile.takeIf { it.exists() }?.readText().orEmpty()
-      throw IllegalStateException(
-        "iproxy exited immediately (port $port). It may be in use or the device may be " +
-          "disconnected. Log: ${logFile.absolutePath}\n$log"
-      )
+    try {
+      // iproxy exits immediately if the port is taken or the device is gone; give it a moment and
+      // confirm it is still alive before we rely on the tunnel.
+      if (started.waitFor(1_000, TimeUnit.MILLISECONDS)) {
+        val log = logFile.takeIf { it.exists() }?.readText().orEmpty()
+        throw IllegalStateException(
+          "iproxy exited immediately (port $port). It may be in use or the device may be " +
+            "disconnected. Log: ${logFile.absolutePath}\n$log"
+        )
+      }
+      writeOwnershipRecord(started.pid())
+    } catch (t: Throwable) {
+      close()
+      throw t
     }
     arbigentInfoLog("iOS real device: iproxy forwarding host 127.0.0.1:$port to device $port")
   }
@@ -60,6 +73,7 @@ public class IosRealXCTestPortForwarder(
       runCatching { Runtime.getRuntime().removeShutdownHook(it) }
     }
     shutdownHook = null
+    runCatching { ownershipRecordFile.delete() }
   }
 
   private fun ensureIproxyInstalled() {
@@ -67,9 +81,13 @@ public class IosRealXCTestPortForwarder(
     if (!which.isSuccess) throw IllegalStateException(iproxyMissingMessage())
   }
 
-  /** Kills only `iproxy` processes still listening on [port] from a previous crashed run. */
+  /**
+   * Reaps only `iproxy` processes that a crashed arbigent run left holding [port]. An iproxy owned
+   * by a live arbigent, or one no arbigent pidfile claims, is treated as busy and reported rather
+   * than killed.
+   */
   private fun reapOrphans() {
-    val pids = orphanIproxyPids(
+    val listening = orphanIproxyPids(
       lsofOutput = executor.execute(
         listOf("lsof", "-nP", "-iTCP:$port", "-sTCP:LISTEN", "-t")
       ).stdout,
@@ -77,15 +95,68 @@ public class IosRealXCTestPortForwarder(
         executor.execute(listOf("ps", "-p", pid, "-o", "comm=")).stdout.trim()
       },
     )
-    pids.forEach { pid ->
-      arbigentInfoLog("iOS real device: reaping orphaned iproxy (pid $pid) holding port $port")
-      executor.execute(listOf("kill", "-9", pid))
+    val decision = reapDecision(
+      port = port,
+      listeningIproxyPids = listening,
+      record = readOwnershipRecord(),
+      isOwnerAlive = ::isProcessAlive,
+      iproxyStartOf = { pid -> processStartMillis(pid) },
+    )
+    when (decision) {
+      is ReapDecision.Fail -> throw IllegalStateException("iOS real device: ${decision.reason}")
+      is ReapDecision.Reap -> {
+        decision.pids.forEach { pid ->
+          arbigentInfoLog("iOS real device: reaping orphaned iproxy (pid $pid) from a crashed run holding port $port")
+          executor.execute(listOf("kill", "-9", pid))
+        }
+        if (decision.pids.isNotEmpty()) runCatching { ownershipRecordFile.delete() }
+      }
     }
   }
+
+  private fun writeOwnershipRecord(iproxyPid: Long) {
+    val self = ProcessHandle.current()
+    val record = IproxyOwnershipRecord(
+      iproxyPid = iproxyPid,
+      iproxyStart = processStartMillis(iproxyPid.toString()) ?: 0L,
+      ownerPid = self.pid(),
+      ownerStart = self.info().startInstant().map { it.toEpochMilli() }.orElse(0L),
+    )
+    ownershipRecordFile.apply { parentFile?.mkdirs() }.writeText(record.serialize())
+  }
+
+  private fun readOwnershipRecord(): IproxyOwnershipRecord? =
+    ownershipRecordFile.takeIf { it.exists() }?.let { IproxyOwnershipRecord.parse(it.readText()) }
 
   private fun iproxyMissingMessage(): String =
     "iproxy is not installed. Real iOS devices need libimobiledevice to forward the XCTest port. " +
       "Install it with: brew install libimobiledevice"
+
+  /** Ownership pidfile contents: the spawned iproxy and the arbigent that owns it, with start times. */
+  public data class IproxyOwnershipRecord(
+    val iproxyPid: Long,
+    val iproxyStart: Long,
+    val ownerPid: Long,
+    val ownerStart: Long,
+  ) {
+    public fun serialize(): String = "$iproxyPid:$iproxyStart:$ownerPid:$ownerStart"
+
+    public companion object {
+      public fun parse(text: String): IproxyOwnershipRecord? {
+        val parts = text.trim().split(":")
+        if (parts.size != 4) return null
+        val nums = parts.map { it.toLongOrNull() ?: return null }
+        return IproxyOwnershipRecord(nums[0], nums[1], nums[2], nums[3])
+      }
+    }
+  }
+
+  public sealed interface ReapDecision {
+    /** [pids] are orphaned iproxy processes safe to kill (may be empty). */
+    public data class Reap(val pids: List<String>) : ReapDecision
+    /** The port is legitimately busy; [reason] explains why nothing was killed. */
+    public data class Fail(val reason: String) : ReapDecision
+  }
 
   public companion object {
     /**
@@ -99,5 +170,49 @@ public class IosRealXCTestPortForwarder(
         .distinct()
         .filter { commandNameOf(it).contains("iproxy") }
         .toList()
+
+    /**
+     * Decides which listening `iproxy` processes may be reaped. Only a process the ownership
+     * [record] claims (matching pid and start time) AND whose owning arbigent is dead is an orphan;
+     * an unrecorded iproxy, or one owned by a live arbigent, makes the port busy.
+     */
+    public fun reapDecision(
+      port: Int,
+      listeningIproxyPids: List<String>,
+      record: IproxyOwnershipRecord?,
+      isOwnerAlive: (pid: Long, startMillis: Long) -> Boolean,
+      iproxyStartOf: (pid: String) -> Long?,
+    ): ReapDecision {
+      if (listeningIproxyPids.isEmpty()) return ReapDecision.Reap(emptyList())
+      for (pid in listeningIproxyPids) {
+        val ownedByRecord = record != null &&
+          record.iproxyPid.toString() == pid &&
+          iproxyStartOf(pid) == record.iproxyStart
+        if (!ownedByRecord) {
+          return ReapDecision.Fail(
+            "port $port is held by an iproxy (pid $pid) arbigent did not start. Stop it (kill $pid) " +
+              "or configure a different port."
+          )
+        }
+        if (isOwnerAlive(record!!.ownerPid, record.ownerStart)) {
+          return ReapDecision.Fail(
+            "port $port is in use by another running arbigent (pid ${record.ownerPid}). Finish that " +
+              "run or configure a different port."
+          )
+        }
+      }
+      return ReapDecision.Reap(listeningIproxyPids)
+    }
+
+    private fun processStartMillis(pid: String): Long? =
+      pid.toLongOrNull()?.let { p ->
+        ProcessHandle.of(p).flatMap { it.info().startInstant() }.map { it.toEpochMilli() }.orElse(null)
+      }
+
+    /** Alive AND (start time matches, or is unavailable), so a reused PID is not mistaken for the owner. */
+    private fun isProcessAlive(pid: Long, startMillis: Long): Boolean =
+      ProcessHandle.of(pid).map { handle ->
+        handle.isAlive && handle.info().startInstant().map { it.toEpochMilli() == startMillis }.orElse(true)
+      }.orElse(false)
   }
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealXCTestPortForwarder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealXCTestPortForwarder.kt
@@ -4,6 +4,7 @@ import java.io.File
 import java.io.RandomAccessFile
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 
 /**
@@ -39,12 +40,17 @@ public class IosRealXCTestPortForwarder(
   private val ownershipLockFile: File
     get() = File(ownershipRecordFile.parentFile, "port-$port.pid.lock")
 
-  private fun <T> withOwnershipLock(block: () -> T): T {
-    val lock = ownershipLockFile.apply { parentFile?.mkdirs() }
-    return RandomAccessFile(lock, "rw").use { raf ->
-      raf.channel.lock().use { block() }
+  private fun <T> withOwnershipLock(block: () -> T): T =
+    // Serialize same-JVM callers on a shared per-port monitor BEFORE touching the OS file lock:
+    // a FileChannel lock is held by the whole JVM, so two threads (or two instances) in this
+    // process locking the same file would throw OverlappingFileLockException. The monitor makes
+    // same-JVM access sequential; the file lock still guards against other processes.
+    synchronized(portMonitor(port)) {
+      val lock = ownershipLockFile.apply { parentFile?.mkdirs() }
+      RandomAccessFile(lock, "rw").use { raf ->
+        raf.channel.lock().use { block() }
+      }
     }
-  }
 
   public fun start() {
     ensureIproxyInstalled()
@@ -100,8 +106,12 @@ public class IosRealXCTestPortForwarder(
   // publishing (ownershipRecord null) or a newer instance already rewrote it, we leave it intact so
   // a live forwarder never appears unowned.
   private fun deleteOwnershipRecordIfOurs() {
-    val ours = ownershipRecord ?: return
+    // Read our published record under the same per-port lock that writeOwnershipRecord assigns it
+    // under, so a close() racing an in-progress start() is serialized against the publish: either it
+    // sees the record and deletes the matching pidfile, or it runs before the publish (when no file
+    // exists yet) — it can never see a null record while the pidfile is already on disk.
     withOwnershipLock {
+      val ours = ownershipRecord ?: return@withOwnershipLock
       if (readOwnershipRecord() == ours) {
         runCatching { ownershipRecordFile.delete() }
       }
@@ -164,7 +174,10 @@ public class IosRealXCTestPortForwarder(
       ownerStart = self.info().startInstant().map { it.toEpochMilli() }.orElse(0L),
     )
     // Publish atomically under the lock: write a sibling temp then rename into place, so a reader
-    // never sees a half-written record and a concurrent writer can't interleave with ours.
+    // never sees a half-written record and a concurrent writer can't interleave with ours. Assign
+    // the in-memory ownershipRecord under the SAME lock as (and only after) the file publish, so a
+    // close() serialized on the same per-port monitor never observes a null record while the
+    // pidfile already exists — which would leave the pidfile orphaned.
     withOwnershipLock {
       val dir = ownershipRecordFile.parentFile.apply { mkdirs() }
       val tmp = File.createTempFile("port-$port", ".pid", dir)
@@ -174,11 +187,11 @@ public class IosRealXCTestPortForwarder(
           tmp.toPath(), ownershipRecordFile.toPath(),
           StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE,
         )
+        ownershipRecord = record
       } finally {
         tmp.delete()
       }
     }
-    ownershipRecord = record
   }
 
   private fun readOwnershipRecord(): IproxyOwnershipRecord? =
@@ -215,6 +228,13 @@ public class IosRealXCTestPortForwarder(
   }
 
   public companion object {
+    // One monitor per port, shared across all forwarder instances in this JVM, so same-JVM callers
+    // serialize before acquiring the per-port OS file lock (which is JVM-wide and would otherwise
+    // throw OverlappingFileLockException). See [withOwnershipLock].
+    private val portMonitors = ConcurrentHashMap<Int, Any>()
+
+    private fun portMonitor(port: Int): Any = portMonitors.computeIfAbsent(port) { Any() }
+
     /**
      * Filters [lsofOutput] (newline-separated PIDs) to those whose process command name is
      * `iproxy`, so we never kill an unrelated process that happens to hold the port.

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
@@ -1,5 +1,6 @@
 package io.github.takahirom.arbigent
 
+import com.github.michaelbull.result.get
 import device.IOSDevice
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -152,6 +153,113 @@ class IosRealDeviceTest {
     assertEquals(listOf("555"), pids)
   }
 
+  private fun record(iproxyPid: Long, iproxyStart: Long, ownerPid: Long = 900, ownerStart: Long = 111) =
+    IosRealXCTestPortForwarder.IproxyOwnershipRecord(iproxyPid, iproxyStart, ownerPid, ownerStart)
+
+  @Test
+  fun reapDecision_reapsWhenOwnerArbigentIsDead() {
+    val decision = IosRealXCTestPortForwarder.reapDecision(
+      port = 22087,
+      listeningIproxyPids = listOf("111"),
+      record = record(iproxyPid = 111, iproxyStart = 5000),
+      isOwnerAlive = { _, _ -> false },
+      iproxyStartOf = { 5000 },
+    )
+    assertEquals(IosRealXCTestPortForwarder.ReapDecision.Reap(listOf("111")), decision)
+  }
+
+  @Test
+  fun reapDecision_failsWhenOwnerArbigentStillAlive() {
+    val decision = IosRealXCTestPortForwarder.reapDecision(
+      port = 22087,
+      listeningIproxyPids = listOf("111"),
+      record = record(iproxyPid = 111, iproxyStart = 5000, ownerPid = 42),
+      isOwnerAlive = { pid, _ -> pid == 42L },
+      iproxyStartOf = { 5000 },
+    )
+    assertTrue(decision is IosRealXCTestPortForwarder.ReapDecision.Fail)
+    assertTrue(decision.reason.contains("another running arbigent"))
+  }
+
+  @Test
+  fun reapDecision_failsForUnownedIproxy() {
+    val decision = IosRealXCTestPortForwarder.reapDecision(
+      port = 22087,
+      listeningIproxyPids = listOf("111"),
+      record = null,
+      isOwnerAlive = { _, _ -> false },
+      iproxyStartOf = { 5000 },
+    )
+    assertTrue(decision is IosRealXCTestPortForwarder.ReapDecision.Fail)
+    assertTrue(decision.reason.contains("did not start"))
+  }
+
+  @Test
+  fun reapDecision_failsWhenRecordedIproxyStartMismatches() {
+    // PID reuse: the pid matches the record but the process started at a different time.
+    val decision = IosRealXCTestPortForwarder.reapDecision(
+      port = 22087,
+      listeningIproxyPids = listOf("111"),
+      record = record(iproxyPid = 111, iproxyStart = 5000),
+      isOwnerAlive = { _, _ -> false },
+      iproxyStartOf = { 9999 },
+    )
+    assertTrue(decision is IosRealXCTestPortForwarder.ReapDecision.Fail)
+  }
+
+  @Test
+  fun reapDecision_reapsNothingWhenPortFree() {
+    val decision = IosRealXCTestPortForwarder.reapDecision(
+      port = 22087,
+      listeningIproxyPids = emptyList(),
+      record = null,
+      isOwnerAlive = { _, _ -> true },
+      iproxyStartOf = { null },
+    )
+    assertEquals(IosRealXCTestPortForwarder.ReapDecision.Reap(emptyList()), decision)
+  }
+
+  // --- provisioning profile validity ----------------------------------------------------
+
+  private fun profileXml(expiration: String, devices: List<String>?): String {
+    val deviceBlock = devices?.joinToString("\n") { "\t\t<string>$it</string>" }?.let {
+      "\t<key>ProvisionedDevices</key>\n\t<array>\n$it\n\t</array>\n"
+    }.orEmpty()
+    return """
+      <?xml version="1.0" encoding="UTF-8"?>
+      <plist version="1.0">
+      <dict>
+      $deviceBlock	<key>ExpirationDate</key>
+      	<date>$expiration</date>
+      </dict>
+      </plist>
+    """.trimIndent()
+  }
+
+  @Test
+  fun mobileProvision_validAndDeviceCovered_isUsable() {
+    val xml = profileXml("2999-01-01T00:00:00Z", listOf("DEVICE-A", "DEVICE-B"))
+    assertTrue(MobileProvisionInspector.isUsable(xml, "DEVICE-B", java.time.Instant.parse("2026-07-22T00:00:00Z")))
+  }
+
+  @Test
+  fun mobileProvision_expired_isNotUsable() {
+    val xml = profileXml("2020-01-01T00:00:00Z", listOf("DEVICE-A"))
+    assertTrue(!MobileProvisionInspector.isUsable(xml, "DEVICE-A", java.time.Instant.parse("2026-07-22T00:00:00Z")))
+  }
+
+  @Test
+  fun mobileProvision_deviceNotCovered_isNotUsable() {
+    val xml = profileXml("2999-01-01T00:00:00Z", listOf("DEVICE-A"))
+    assertTrue(!MobileProvisionInspector.isUsable(xml, "DEVICE-Z", java.time.Instant.parse("2026-07-22T00:00:00Z")))
+  }
+
+  @Test
+  fun mobileProvision_noDeviceList_isUsableWhenUnexpired() {
+    val xml = profileXml("2999-01-01T00:00:00Z", devices = null)
+    assertTrue(MobileProvisionInspector.isUsable(xml, "ANY-DEVICE", java.time.Instant.parse("2026-07-22T00:00:00Z")))
+  }
+
   // --- devicectl controller --------------------------------------------------------------
 
   @Test
@@ -167,31 +275,52 @@ class IosRealDeviceTest {
     assertEquals(
       listOf(
         "xcrun", "devicectl", "device", "process", "launch",
-        "--terminate-existing", "--device", "CORE-ID-1", "com.apple.Preferences",
+        "--terminate-existing", "--device", "CORE-ID-1", "--", "com.apple.Preferences",
       ),
       cmd,
     )
   }
 
   @Test
-  fun launch_separatesLaunchArgumentsWithDoubleDash() {
+  fun launch_placesDoubleDashBeforeBundleIdAndKeepsArgumentKeys() {
     val executor = FakeExecutor()
     val controller = ArbigentDevicectlIOSDevice(
       coreDeviceIdentifier = "CORE-ID-1",
       executor = executor,
       delegate = NoopIOSDevice(),
     )
-    // A `-`-prefixed arg must not be consumed by devicectl as one of its own options.
+    // `--` before the bundle id keeps a malformed app id from being parsed as a devicectl option,
+    // and launch arguments must keep their keys (maestro's toIOSLaunchArguments prefixes bare keys
+    // with `-`), not collapse to values only.
     controller.launch("com.example", linkedMapOf("-cartColor" to "Orange", "count" to 3))
     val cmd = executor.commands.single()
     assertEquals(
       listOf(
         "xcrun", "devicectl", "device", "process", "launch",
-        "--terminate-existing", "--device", "CORE-ID-1", "com.example",
-        "--", "Orange", "3",
+        "--terminate-existing", "--device", "CORE-ID-1",
+        "--", "com.example", "-cartColor", "Orange", "-count", "3",
       ),
       cmd,
     )
+  }
+
+  @Test
+  fun clearAppState_failsAsUnsupportedRatherThanFakingSuccess() {
+    val executor = FakeExecutor()
+    val controller = ArbigentDevicectlIOSDevice("CORE-ID-1", executor, NoopIOSDevice())
+    assertFailsWith<UnsupportedOperationException> { controller.clearAppState("com.example") }
+    assertTrue(executor.commands.isEmpty(), "clearAppState must not run any devicectl command")
+  }
+
+  @Test
+  fun openLink_failsAsUnsupportedRatherThanRunningABrokenCommand() {
+    val executor = FakeExecutor()
+    val controller = ArbigentDevicectlIOSDevice("CORE-ID-1", executor, NoopIOSDevice())
+    // openLink is unsupported on a real device, so it must report failure (a null success value)
+    // without ever shelling out to a devicectl command that could not work.
+    val result = controller.openLink("https://example.com")
+    assertEquals(null, result.get())
+    assertTrue(executor.commands.isEmpty(), "openLink must not run any devicectl command")
   }
 
   @Test

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
@@ -252,6 +252,22 @@ class IosRealDeviceTest {
     assertEquals(2, labels.toSet().size, "labels must be distinct")
   }
 
+  @Test
+  fun maskedUdidLabels_capsRevealedPrefixAtTwelveCharsThenUsesIndex() {
+    // UDIDs sharing more than the 12-char cap (identical for the first 13 chars): disambiguation
+    // must NOT reveal a 13th UDID character; it falls back to a positional #index instead.
+    val labels = ArbigentAvailableDevice.IosReal.maskedUdidLabels(
+      listOf(iosReal("SHARED0000000AAAAAAA"), iosReal("SHARED0000000BBBBBBB"))
+    )
+    labels.forEach { label ->
+      assertTrue(
+        label.substringBefore("…").length <= 12,
+        "must not reveal more than 12 UDID characters: $label",
+      )
+    }
+    assertEquals(2, labels.toSet().size, "labels must be distinct")
+  }
+
   // --- provisioning profile validity ----------------------------------------------------
 
   private fun profileXml(expiration: String, devices: List<String>?): String {

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
@@ -219,6 +219,39 @@ class IosRealDeviceTest {
     assertEquals(IosRealXCTestPortForwarder.ReapDecision.Reap(emptyList()), decision)
   }
 
+  // --- masked UDID disambiguation --------------------------------------------------------
+
+  private fun iosReal(udid: String) =
+    ArbigentAvailableDevice.IosReal(coreDeviceIdentifier = "core-$udid", hardwareUdid = udid, name = "iPhone")
+
+  @Test
+  fun maskedUdidLabels_extendsPrefixUntilUnique() {
+    val labels = ArbigentAvailableDevice.IosReal.maskedUdidLabels(
+      listOf(iosReal("AAAAAAAA1111zzzz"), iosReal("AAAAAAAA2222zzzz"))
+    )
+    // 8-char prefixes collide (AAAAAAAA), so the shown prefix extends until the differing character.
+    assertEquals(listOf("AAAAAAAA1…", "AAAAAAAA2…"), labels)
+  }
+
+  @Test
+  fun maskedUdidLabels_keepsEightCharsWhenPrefixesDiffer() {
+    val labels = ArbigentAvailableDevice.IosReal.maskedUdidLabels(
+      listOf(iosReal("ABCDEFGH0000"), iosReal("ZYXWVUTS0000"))
+    )
+    assertEquals(listOf("ABCDEFGH…", "ZYXWVUTS…"), labels)
+  }
+
+  @Test
+  fun maskedUdidLabels_neverPrintsFullUdidOnLastCharCollision() {
+    // Two UDIDs identical except the final character: the prefix is capped one short of full length
+    // so the last char is never revealed, and a positional #index disambiguates instead.
+    val labels = ArbigentAvailableDevice.IosReal.maskedUdidLabels(
+      listOf(iosReal("SAMESAME9"), iosReal("SAMESAME8"))
+    )
+    assertTrue(labels.none { it.contains("SAMESAME9") || it.contains("SAMESAME8") })
+    assertEquals(2, labels.toSet().size, "labels must be distinct")
+  }
+
   // --- provisioning profile validity ----------------------------------------------------
 
   private fun profileXml(expiration: String, devices: List<String>?): String {

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
@@ -23,41 +23,47 @@ class IosRealDeviceTest {
 
   // --- Team resolution -------------------------------------------------------------------
 
+  // openssl `-nameopt multiline` subject dump. The team id is the OU, NOT the CN parenthetical
+  // (which is the individual/user id — xcodebuild rejects it as an unknown team).
+  private fun subject(teamOu: String, userId: String) = """
+    subject=
+        countryName               = US
+        organizationName          = Jane Doe
+        organizationalUnitName    = $teamOu
+        commonName                = Apple Development: Jane Doe ($userId)
+  """.trimIndent()
+
   @Test
-  fun autoDetect_singleAppleDevelopmentIdentity_returnsTeamId() {
-    val output = """
-      Policy: Code Signing
-        Matching identities
-        1) A1B2C3D4 "Apple Development: Jane Doe (ABCDE12345)"
-           1 valid identities found
-    """.trimIndent()
-    assertEquals("ABCDE12345", IosCodeSigningTeamResolver.autoDetect(output))
+  fun teamIdFromSubjects_returnsOuNotCommonNameParenthetical() {
+    // OU (team) differs from the CN parenthetical (user id); we must return the OU.
+    assertEquals("84ABCDE123", IosCodeSigningTeamResolver.teamIdFromSubjects(listOf(subject("84ABCDE123", "TNWZJXLBJF"))))
   }
 
   @Test
-  fun autoDetect_noIdentity_throwsActionableError() {
+  fun teamIdFromSubjects_noTeam_throwsActionableError() {
     val e = assertFailsWith<IllegalStateException> {
-      IosCodeSigningTeamResolver.autoDetect("  0 valid identities found")
+      IosCodeSigningTeamResolver.teamIdFromSubjects(emptyList())
     }
     assertTrue(e.message!!.contains(ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID))
   }
 
   @Test
-  fun autoDetect_multipleTeams_throws() {
-    val output = """
-      1) AAAA "Apple Development: A (TEAM111111)"
-      2) BBBB "Apple Development: B (TEAM222222)"
-    """.trimIndent()
-    assertFailsWith<IllegalStateException> { IosCodeSigningTeamResolver.autoDetect(output) }
+  fun teamIdFromSubjects_multipleTeams_throws() {
+    assertFailsWith<IllegalStateException> {
+      IosCodeSigningTeamResolver.teamIdFromSubjects(
+        listOf(subject("84ABCDE123", "U000000001"), subject("99ZZZZZ000", "U000000002"))
+      )
+    }
   }
 
   @Test
-  fun autoDetect_sameTeamTwice_isSingle() {
-    val output = """
-      1) AAAA "Apple Development: A (TEAM111111)"
-      2) BBBB "Apple Development: A2 (TEAM111111)"
-    """.trimIndent()
-    assertEquals("TEAM111111", IosCodeSigningTeamResolver.autoDetect(output))
+  fun teamIdFromSubjects_sameTeamTwice_isSingle() {
+    assertEquals(
+      "84ABCDE123",
+      IosCodeSigningTeamResolver.teamIdFromSubjects(
+        listOf(subject("84ABCDE123", "U000000001"), subject("84ABCDE123", "U000000002"))
+      ),
+    )
   }
 
   @Test

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
@@ -204,6 +204,25 @@ class IosRealDeviceTest {
     assertTrue(e.message!!.contains("no such device"))
   }
 
+  @Test
+  fun install_rejectsZipSlipEntry() {
+    val executor = FakeExecutor()
+    val controller = ArbigentDevicectlIOSDevice("CORE-ID-1", executor, NoopIOSDevice())
+    // An archive entry that resolves outside the extraction dir must be rejected, not written.
+    val malicious = java.io.ByteArrayOutputStream().also { bytes ->
+      java.util.zip.ZipOutputStream(bytes).use { zip ->
+        zip.putNextEntry(java.util.zip.ZipEntry("../arbigent-zip-slip-escape.txt"))
+        zip.write("pwned".toByteArray())
+        zip.closeEntry()
+      }
+    }.toByteArray()
+    val e = assertFailsWith<IllegalStateException> {
+      controller.install(java.io.ByteArrayInputStream(malicious))
+    }
+    assertTrue(e.message!!.contains("escapes target directory"))
+    assertTrue(executor.commands.isEmpty(), "install must not run devicectl for a rejected archive")
+  }
+
   /** Minimal IOSDevice delegate so the controller can be built without maestro's stub. */
   private class NoopIOSDevice : IOSDevice {
     override val deviceId: String get() = "noop"

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
@@ -174,6 +174,27 @@ class IosRealDeviceTest {
   }
 
   @Test
+  fun launch_separatesLaunchArgumentsWithDoubleDash() {
+    val executor = FakeExecutor()
+    val controller = ArbigentDevicectlIOSDevice(
+      coreDeviceIdentifier = "CORE-ID-1",
+      executor = executor,
+      delegate = NoopIOSDevice(),
+    )
+    // A `-`-prefixed arg must not be consumed by devicectl as one of its own options.
+    controller.launch("com.example", linkedMapOf("-cartColor" to "Orange", "count" to 3))
+    val cmd = executor.commands.single()
+    assertEquals(
+      listOf(
+        "xcrun", "devicectl", "device", "process", "launch",
+        "--terminate-existing", "--device", "CORE-ID-1", "com.example",
+        "--", "Orange", "3",
+      ),
+      cmd,
+    )
+  }
+
+  @Test
   fun launch_failsWithMessageOnNonZeroExit() {
     val executor = FakeExecutor(
       responses = mapOf("xcrun devicectl" to ArbigentCommandResult(1, "", "no such device")),

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
@@ -1,0 +1,211 @@
+package io.github.takahirom.arbigent
+
+import device.IOSDevice
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class IosRealDeviceTest {
+
+  /** Records commands and returns canned results keyed by the first two args. */
+  private class FakeExecutor(
+    private val responses: Map<String, ArbigentCommandResult> = emptyMap(),
+    private val default: ArbigentCommandResult = ArbigentCommandResult(0, "", ""),
+  ) : ArbigentCommandExecutor {
+    val commands = mutableListOf<List<String>>()
+    override fun execute(command: List<String>, timeoutMs: Long): ArbigentCommandResult {
+      commands += command
+      val key = command.take(2).joinToString(" ")
+      return responses[key] ?: default
+    }
+  }
+
+  // --- Team resolution -------------------------------------------------------------------
+
+  @Test
+  fun autoDetect_singleAppleDevelopmentIdentity_returnsTeamId() {
+    val output = """
+      Policy: Code Signing
+        Matching identities
+        1) A1B2C3D4 "Apple Development: Jane Doe (ABCDE12345)"
+           1 valid identities found
+    """.trimIndent()
+    assertEquals("ABCDE12345", IosCodeSigningTeamResolver.autoDetect(output))
+  }
+
+  @Test
+  fun autoDetect_noIdentity_throwsActionableError() {
+    val e = assertFailsWith<IllegalStateException> {
+      IosCodeSigningTeamResolver.autoDetect("  0 valid identities found")
+    }
+    assertTrue(e.message!!.contains(ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID))
+  }
+
+  @Test
+  fun autoDetect_multipleTeams_throws() {
+    val output = """
+      1) AAAA "Apple Development: A (TEAM111111)"
+      2) BBBB "Apple Development: B (TEAM222222)"
+    """.trimIndent()
+    assertFailsWith<IllegalStateException> { IosCodeSigningTeamResolver.autoDetect(output) }
+  }
+
+  @Test
+  fun autoDetect_sameTeamTwice_isSingle() {
+    val output = """
+      1) AAAA "Apple Development: A (TEAM111111)"
+      2) BBBB "Apple Development: A2 (TEAM111111)"
+    """.trimIndent()
+    assertEquals("TEAM111111", IosCodeSigningTeamResolver.autoDetect(output))
+  }
+
+  @Test
+  fun resolve_prefersExplicitConfigOverEnvAndAutoDetect() {
+    val executor = FakeExecutor()
+    val teamId = IosCodeSigningTeamResolver.resolve(
+      config = ArbigentIosRealDeviceConfiguration(appleTeamId = "CFGCFG7890"),
+      env = { "ENVENV1234" },
+      executor = executor,
+    )
+    assertEquals("CFGCFG7890", teamId)
+    assertTrue(executor.commands.isEmpty(), "auto-detect should not run when config is set")
+  }
+
+  @Test
+  fun resolve_fallsBackToEnvBeforeAutoDetect() {
+    val executor = FakeExecutor()
+    val teamId = IosCodeSigningTeamResolver.resolve(
+      config = ArbigentIosRealDeviceConfiguration(appleTeamId = null),
+      env = { name -> if (name == ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID) "ENVENV1234" else null },
+      executor = executor,
+    )
+    assertEquals("ENVENV1234", teamId)
+    assertTrue(executor.commands.isEmpty())
+  }
+
+  @Test
+  fun resolve_rejectsMalformedTeamId() {
+    assertFailsWith<IllegalArgumentException> {
+      IosCodeSigningTeamResolver.resolve(
+        config = ArbigentIosRealDeviceConfiguration(appleTeamId = "too-short"),
+        env = { null },
+        executor = FakeExecutor(),
+      )
+    }
+  }
+
+  @Test
+  fun maskTeamId_keepsOnlyFirstTwoChars() {
+    assertEquals("AB********", IosCodeSigningTeamResolver.maskTeamId("ABCDE12345"))
+    assertTrue(!IosCodeSigningTeamResolver.maskTeamId("ABCDE12345").contains("CDE"))
+  }
+
+  // --- Port / device id resolution -------------------------------------------------------
+
+  @Test
+  fun resolvedPort_defaultsToRunnerPort() {
+    ArbigentIosRealDeviceSettings.current = ArbigentIosRealDeviceConfiguration()
+    assertEquals(ArbigentIosRealDeviceSettings.DEFAULT_PORT, ArbigentIosRealDeviceSettings.resolvedPort { null })
+  }
+
+  @Test
+  fun resolvedPort_configWinsOverEnv() {
+    ArbigentIosRealDeviceSettings.current = ArbigentIosRealDeviceConfiguration(port = 30000)
+    assertEquals(30000, ArbigentIosRealDeviceSettings.resolvedPort { "40000" })
+  }
+
+  @Test
+  fun resolvedDeviceId_fallsBackToEnv() {
+    ArbigentIosRealDeviceSettings.current = ArbigentIosRealDeviceConfiguration(deviceId = null)
+    assertEquals(
+      "UDID-FROM-ENV",
+      ArbigentIosRealDeviceSettings.resolvedDeviceId { name ->
+        if (name == ArbigentIosRealDeviceSettings.ENV_DEVICE_ID) "UDID-FROM-ENV" else null
+      },
+    )
+  }
+
+  // --- iproxy orphan reaping -------------------------------------------------------------
+
+  @Test
+  fun orphanIproxyPids_keepsOnlyIproxyProcesses() {
+    val pids = IosRealXCTestPortForwarder.orphanIproxyPids(
+      lsofOutput = "111\n222\n\n333\n",
+      commandNameOf = { pid -> if (pid == "222") "python" else "iproxy" },
+    )
+    assertEquals(listOf("111", "333"), pids)
+  }
+
+  @Test
+  fun orphanIproxyPids_ignoresNonNumericLines() {
+    val pids = IosRealXCTestPortForwarder.orphanIproxyPids(
+      lsofOutput = "COMMAND\n555\n",
+      commandNameOf = { "iproxy" },
+    )
+    assertEquals(listOf("555"), pids)
+  }
+
+  // --- devicectl controller --------------------------------------------------------------
+
+  @Test
+  fun launch_terminatesExistingAndTargetsCoreDevice() {
+    val executor = FakeExecutor()
+    val controller = ArbigentDevicectlIOSDevice(
+      coreDeviceIdentifier = "CORE-ID-1",
+      executor = executor,
+      delegate = NoopIOSDevice(),
+    )
+    controller.launch("com.apple.Preferences", emptyMap())
+    val cmd = executor.commands.single()
+    assertEquals(
+      listOf(
+        "xcrun", "devicectl", "device", "process", "launch",
+        "--terminate-existing", "--device", "CORE-ID-1", "com.apple.Preferences",
+      ),
+      cmd,
+    )
+  }
+
+  @Test
+  fun launch_failsWithMessageOnNonZeroExit() {
+    val executor = FakeExecutor(
+      responses = mapOf("xcrun devicectl" to ArbigentCommandResult(1, "", "no such device")),
+    )
+    val controller = ArbigentDevicectlIOSDevice("CORE-ID-1", executor, NoopIOSDevice())
+    val e = assertFailsWith<IllegalStateException> { controller.launch("com.example", emptyMap()) }
+    assertTrue(e.message!!.contains("no such device"))
+  }
+
+  /** Minimal IOSDevice delegate so the controller can be built without maestro's stub. */
+  private class NoopIOSDevice : IOSDevice {
+    override val deviceId: String get() = "noop"
+    override fun open() {}
+    override fun deviceInfo() = throw UnsupportedOperationException()
+    override fun viewHierarchy(excludeKeyboardElements: Boolean) = throw UnsupportedOperationException()
+    override fun tap(x: Int, y: Int) {}
+    override fun longPress(x: Int, y: Int, durationMs: Long) {}
+    override fun scroll(xStart: Double, yStart: Double, xEnd: Double, yEnd: Double, duration: Double) {}
+    override fun input(text: String) {}
+    override fun install(stream: java.io.InputStream) {}
+    override fun uninstall(id: String) {}
+    override fun clearAppState(id: String) {}
+    override fun clearKeychain() = com.github.michaelbull.result.Ok(Unit)
+    override fun launch(id: String, launchArguments: Map<String, Any>) {}
+    override fun stop(id: String) {}
+    override fun isKeyboardVisible() = false
+    override fun openLink(link: String) = com.github.michaelbull.result.Ok(Unit)
+    override fun takeScreenshot(out: okio.Sink, compressed: Boolean) {}
+    override fun startScreenRecording(out: okio.Sink) = throw UnsupportedOperationException()
+    override fun setLocation(latitude: Double, longitude: Double) = com.github.michaelbull.result.Ok(Unit)
+    override fun setOrientation(orientation: String) {}
+    override fun isShutdown() = false
+    override fun isScreenStatic() = false
+    override fun setPermissions(id: String, permissions: Map<String, String>) {}
+    override fun pressKey(name: String) {}
+    override fun pressButton(name: String) {}
+    override fun eraseText(charactersToErase: Int) {}
+    override fun addMedia(path: String) {}
+    override fun close() {}
+  }
+}

--- a/gradle/maestro.gradle.kts
+++ b/gradle/maestro.gradle.kts
@@ -231,3 +231,50 @@ val maestroJars: FileCollection = files(
 
 // Consumed by modules via rootProject.extra: dependencies { api(rootMaestroJars()) }.
 extra["maestroJars"] = maestroJars
+
+// Pinned Maestro version, exposed so modules can key caches (e.g. the built iOS real-device
+// runner) on the exact runner source they ship.
+extra["maestroVersion"] = maestroVersion
+
+// --- iOS real-device driver source ------------------------------------------------------
+//
+// Building the XCTest runner for a physical iPhone requires re-signing it with the user's
+// Apple team (maestro's mobile-dev signature is useless off their machines). maestro does
+// this in its `maestro-cli` module (DriverBuilder), which arbigent does not depend on, but
+// the runner's Xcode project + Swift sources ship as the `driver/ios/**` resource inside
+// `maestro/lib/maestro-cli-<version>.jar` within the same pinned zip. We extract that source
+// so arbigent-core can package it and run its own `xcodebuild build-for-testing` at runtime.
+val maestroCliJarEntry = "maestro/lib/maestro-cli-$maestroVersion.jar"
+val maestroCliJarDir: File = maestroCacheDir.resolve("cli-jar")
+val maestroDriverSourceDir: File = maestroCacheDir.resolve("ios-driver-source")
+
+val extractMaestroCliJar = tasks.register<Copy>("extractMaestroCliJar") {
+  description = "Extract the maestro-cli jar (carrier of the iOS driver source) from the pinned zip."
+  group = "maestro"
+  dependsOn(downloadMaestroZip)
+  from(zipTree(maestroZipFile)) {
+    include(maestroCliJarEntry)
+    eachFile { path = name } // flatten maestro/lib/<jar> -> <jar>
+  }
+  includeEmptyDirs = false
+  into(maestroCliJarDir)
+}
+
+val extractMaestroIosDriverSource = tasks.register<Copy>("extractMaestroIosDriverSource") {
+  description = "Extract the iOS XCTest runner source (driver/ios) used to build a signed real-device runner."
+  group = "maestro"
+  dependsOn(extractMaestroCliJar)
+  from(zipTree(maestroCliJarDir.resolve("maestro-cli-$maestroVersion.jar"))) {
+    include("driver/ios/**")
+  }
+  includeEmptyDirs = false
+  into(maestroDriverSourceDir)
+}
+
+// Packaged into arbigent-core resources under ios-real-driver/driver/ios/**; the runtime
+// runner builder copies it out and runs xcodebuild against maestro-driver-ios.xcodeproj.
+val maestroIosDriverSource: FileCollection = fileTree(maestroDriverSourceDir) {
+  include("driver/ios/**")
+  builtBy(extractMaestroIosDriverSource)
+}
+extra["maestroIosDriverSource"] = maestroIosDriverSource

--- a/gradle/maestro.gradle.kts
+++ b/gradle/maestro.gradle.kts
@@ -239,42 +239,62 @@ extra["maestroVersion"] = maestroVersion
 // --- iOS real-device driver source ------------------------------------------------------
 //
 // Building the XCTest runner for a physical iPhone requires re-signing it with the user's
-// Apple team (maestro's mobile-dev signature is useless off their machines). maestro does
-// this in its `maestro-cli` module (DriverBuilder), which arbigent does not depend on, but
-// the runner's Xcode project + Swift sources ship as the `driver/ios/**` resource inside
-// `maestro/lib/maestro-cli-<version>.jar` within the same pinned zip. We extract that source
-// so arbigent-core can package it and run its own `xcodebuild build-for-testing` at runtime.
-val maestroCliJarEntry = "maestro/lib/maestro-cli-$maestroVersion.jar"
-val maestroCliJarDir: File = maestroCacheDir.resolve("cli-jar")
+// Apple team (maestro's mobile-dev signature is useless off their machines). maestro does this
+// in its `maestro-cli` module (DriverBuilder), which arbigent does not depend on. We therefore
+// build the runner ourselves, from the COMPLETE runner Xcode project in the pinned source
+// archive (`maestro-ios-xctest-runner/`). Note: the `driver/ios` copy bundled inside
+// maestro-cli-<version>.jar is incomplete — it omits the MaestroDriverLib sub-project its own
+// xcodeproj references — so the source archive, not that jar resource, is the source of truth.
+val maestroSourceSha256 = "6ff65eba63ec4910df59ddb1007044f964753c3b4a66464447c6676594809c0b"
+val maestroSourceUrl =
+  "https://github.com/mobile-dev-inc/Maestro/archive/refs/tags/cli-$maestroVersion.tar.gz"
+val maestroSourceTar: File = maestroCacheDir.resolve("maestro-source.tar.gz")
 val maestroDriverSourceDir: File = maestroCacheDir.resolve("ios-driver-source")
+// Path prefix inside the GitHub source tarball (repo name + tag) that wraps every entry.
+val maestroSourceRootPrefix = "Maestro-cli-$maestroVersion"
 
-val extractMaestroCliJar = tasks.register<Copy>("extractMaestroCliJar") {
-  description = "Extract the maestro-cli jar (carrier of the iOS driver source) from the pinned zip."
+val downloadMaestroSource = tasks.register("downloadMaestroSource") {
+  description = "Download the pinned Maestro source archive (carrier of the iOS runner Xcode project)."
   group = "maestro"
-  dependsOn(downloadMaestroZip)
-  from(zipTree(maestroZipFile)) {
-    include(maestroCliJarEntry)
-    eachFile { path = name } // flatten maestro/lib/<jar> -> <jar>
+  outputs.file(maestroSourceTar)
+  outputs.upToDateWhen { maestroSourceTar.exists() && sha256(maestroSourceTar) == maestroSourceSha256 }
+  doLast {
+    maestroCacheDir.mkdirs()
+    if (maestroSourceTar.exists() && sha256(maestroSourceTar) == maestroSourceSha256) return@doLast
+    logger.lifecycle("Downloading Maestro source $maestroVersion from $maestroSourceUrl")
+    val tmp = File.createTempFile("maestro-source", ".tar.gz", maestroCacheDir)
+    try {
+      uri(maestroSourceUrl).toURL().openStream().use { input ->
+        tmp.outputStream().use { output -> input.copyTo(output) }
+      }
+      val actual = sha256(tmp)
+      check(actual == maestroSourceSha256) {
+        "Maestro source checksum mismatch for $maestroSourceUrl: expected $maestroSourceSha256 but got $actual"
+      }
+      tmp.copyTo(maestroSourceTar, overwrite = true)
+    } finally {
+      tmp.delete()
+    }
   }
-  includeEmptyDirs = false
-  into(maestroCliJarDir)
 }
 
 val extractMaestroIosDriverSource = tasks.register<Copy>("extractMaestroIosDriverSource") {
-  description = "Extract the iOS XCTest runner source (driver/ios) used to build a signed real-device runner."
+  description = "Extract the complete iOS XCTest runner Xcode project used to build a signed real-device runner."
   group = "maestro"
-  dependsOn(extractMaestroCliJar)
-  from(zipTree(maestroCliJarDir.resolve("maestro-cli-$maestroVersion.jar"))) {
-    include("driver/ios/**")
+  dependsOn(downloadMaestroSource)
+  from(tarTree(resources.gzip(maestroSourceTar))) {
+    include("$maestroSourceRootPrefix/maestro-ios-xctest-runner/**")
+    // Strip the "<root>/maestro-ios-xctest-runner/" prefix so maestro-driver-ios.xcodeproj sits
+    // at the top of the extracted tree.
+    eachFile { relativePath = RelativePath(true, *relativePath.segments.drop(2).toTypedArray()) }
   }
   includeEmptyDirs = false
   into(maestroDriverSourceDir)
 }
 
-// Packaged into arbigent-core resources under ios-real-driver/driver/ios/**; the runtime
-// runner builder copies it out and runs xcodebuild against maestro-driver-ios.xcodeproj.
+// Packaged into arbigent-core resources under ios-real-driver/runner/**; the runtime runner
+// builder copies it out and runs xcodebuild against maestro-driver-ios.xcodeproj.
 val maestroIosDriverSource: FileCollection = fileTree(maestroDriverSourceDir) {
-  include("driver/ios/**")
   builtBy(extractMaestroIosDriverSource)
 }
 extra["maestroIosDriverSource"] = maestroIosDriverSource

--- a/gradle/maestro.gradle.kts
+++ b/gradle/maestro.gradle.kts
@@ -95,14 +95,53 @@ fun publishFileAtomically(source: File, target: File) {
   }
 }
 
+// Re-hashing a multi-hundred-MB download on every build's up-to-date check is wasteful (it made
+// even Android/Web-only builds pay for the iOS source tarball). Instead hash once — in doLast,
+// which only runs when the task isn't up-to-date — and stamp a marker recording the verified
+// file's expected sha, length and mtime. The cheap up-to-date check compares that fingerprint
+// rather than reading the whole file.
+//
+// The fingerprint (sha+length+mtime) is only a fast-path hint: content swapped in place while
+// preserving length and mtime would slip past it. So the actual bytes are re-hashed at
+// consumption (verifyArchiveIntegrity, called from the extract tasks) before they are ever
+// trusted, which costs one hash only when an extract task is out of date — never on the common
+// incremental path where extraction is already up-to-date.
+fun verifiedMarkerFile(target: File): File = File(target.parentFile, "${target.name}.sha256.ok")
+
+fun verifiedFingerprint(target: File, expectedSha: String): String =
+  "$expectedSha:${target.length()}:${target.lastModified()}"
+
+fun stampVerified(target: File, expectedSha: String) {
+  verifiedMarkerFile(target).writeText(verifiedFingerprint(target, expectedSha))
+}
+
+fun isVerifiedUpToDate(target: File, expectedSha: String): Boolean {
+  if (!target.exists()) return false
+  val marker = verifiedMarkerFile(target)
+  return marker.exists() && marker.readText().trim() == verifiedFingerprint(target, expectedSha)
+}
+
+// Re-hash a cached archive before extracting from it, so content swapped in place (same
+// length/mtime, defeating the marker fast-path) is caught rather than silently extracted.
+fun verifyArchiveIntegrity(target: File, expectedSha: String) {
+  val actual = sha256(target)
+  check(actual == expectedSha) {
+    "Maestro cache artifact ${target.name} failed its integrity check: expected $expectedSha but got " +
+      "$actual. Delete $maestroCacheDir and re-run to re-download."
+  }
+}
+
 val downloadMaestroZip = tasks.register("downloadMaestroZip") {
   description = "Download the pinned Maestro release artifact and verify its sha256 checksum."
   group = "maestro"
   outputs.file(maestroZipFile)
-  outputs.upToDateWhen { maestroZipFile.exists() && sha256(maestroZipFile) == maestroZipSha256 }
+  outputs.upToDateWhen { isVerifiedUpToDate(maestroZipFile, maestroZipSha256) }
   doLast {
     withMaestroCacheLock {
-      if (maestroZipFile.exists() && sha256(maestroZipFile) == maestroZipSha256) return@withMaestroCacheLock
+      if (maestroZipFile.exists() && sha256(maestroZipFile) == maestroZipSha256) {
+        stampVerified(maestroZipFile, maestroZipSha256)
+        return@withMaestroCacheLock
+      }
       logger.lifecycle("Downloading Maestro $maestroVersion from $maestroZipUrl")
       val tmp = File.createTempFile("maestro", ".zip", maestroCacheDir)
       try {
@@ -114,6 +153,7 @@ val downloadMaestroZip = tasks.register("downloadMaestroZip") {
           "Maestro zip checksum mismatch for $maestroZipUrl: expected $maestroZipSha256 but got $actual"
         }
         publishFileAtomically(tmp, maestroZipFile)
+        stampVerified(maestroZipFile, maestroZipSha256)
       } finally {
         tmp.delete()
       }
@@ -136,6 +176,7 @@ val extractMaestroJars = tasks.register<Copy>("extractMaestroJars") {
   description = "Extract the maestro-* jars arbigent depends on from the pinned release artifact."
   group = "maestro"
   dependsOn(downloadMaestroZip)
+  doFirst { verifyArchiveIntegrity(maestroZipFile, maestroZipSha256) }
   from(zipTree(maestroZipFile)) {
     include(maestroJarEntries)
     eachFile { path = name } // flatten maestro/lib/<jar> -> <jar>
@@ -257,23 +298,28 @@ val downloadMaestroSource = tasks.register("downloadMaestroSource") {
   description = "Download the pinned Maestro source archive (carrier of the iOS runner Xcode project)."
   group = "maestro"
   outputs.file(maestroSourceTar)
-  outputs.upToDateWhen { maestroSourceTar.exists() && sha256(maestroSourceTar) == maestroSourceSha256 }
+  outputs.upToDateWhen { isVerifiedUpToDate(maestroSourceTar, maestroSourceSha256) }
   doLast {
-    maestroCacheDir.mkdirs()
-    if (maestroSourceTar.exists() && sha256(maestroSourceTar) == maestroSourceSha256) return@doLast
-    logger.lifecycle("Downloading Maestro source $maestroVersion from $maestroSourceUrl")
-    val tmp = File.createTempFile("maestro-source", ".tar.gz", maestroCacheDir)
-    try {
-      uri(maestroSourceUrl).toURL().openStream().use { input ->
-        tmp.outputStream().use { output -> input.copyTo(output) }
+    withMaestroCacheLock {
+      if (maestroSourceTar.exists() && sha256(maestroSourceTar) == maestroSourceSha256) {
+        stampVerified(maestroSourceTar, maestroSourceSha256)
+        return@withMaestroCacheLock
       }
-      val actual = sha256(tmp)
-      check(actual == maestroSourceSha256) {
-        "Maestro source checksum mismatch for $maestroSourceUrl: expected $maestroSourceSha256 but got $actual"
+      logger.lifecycle("Downloading Maestro source $maestroVersion from $maestroSourceUrl")
+      val tmp = File.createTempFile("maestro-source", ".tar.gz", maestroCacheDir)
+      try {
+        uri(maestroSourceUrl).toURL().openStream().use { input ->
+          tmp.outputStream().use { output -> input.copyTo(output) }
+        }
+        val actual = sha256(tmp)
+        check(actual == maestroSourceSha256) {
+          "Maestro source checksum mismatch for $maestroSourceUrl: expected $maestroSourceSha256 but got $actual"
+        }
+        publishFileAtomically(tmp, maestroSourceTar)
+        stampVerified(maestroSourceTar, maestroSourceSha256)
+      } finally {
+        tmp.delete()
       }
-      tmp.copyTo(maestroSourceTar, overwrite = true)
-    } finally {
-      tmp.delete()
     }
   }
 }
@@ -282,6 +328,7 @@ val extractMaestroIosDriverSource = tasks.register<Copy>("extractMaestroIosDrive
   description = "Extract the complete iOS XCTest runner Xcode project used to build a signed real-device runner."
   group = "maestro"
   dependsOn(downloadMaestroSource)
+  doFirst { verifyArchiveIntegrity(maestroSourceTar, maestroSourceSha256) }
   from(tarTree(resources.gzip(maestroSourceTar))) {
     include("$maestroSourceRootPrefix/maestro-ios-xctest-runner/**")
     // Strip the "<root>/maestro-ios-xctest-runner/" prefix so maestro-driver-ios.xcodeproj sits


### PR DESCRIPTION
## Why
Maestro 2.7's jars already contain most of the iOS real-device machinery (`IOSDeviceType.REAL`, devicectl-based install, the XCTest HTTP protocol), but three pieces are missing for arbigent to drive a physical iPhone: port forwarding to the on-device runner, a working app-lifecycle controller (maestro's `DeviceControlIOSDevice` launch/install are `TODO` stubs), and building/signing the XCTest runner with the user's Apple team. This PR adds those, stacked on #398.

## What
- **Discovery**: physical iPhones via `xcrun devicectl list devices` (with a read-only tunnel wake, since CoreDevice reports `tunnelState=disconnected` until something opens the tunnel), surfaced alongside simulators under `--os=ios`
- **Signed runner**: built from the pinned Maestro source archive with `xcodebuild build-for-testing -allowProvisioningUpdates`, team resolved from `--ios-xctest-apple-team-id` / env / auto-detect (only when exactly one Apple Development identity exists; resolved from the certificate OU), products cached per team under the user home; one retry on transient provisioning races. Team ids are masked in logs and redacted from persisted xcodebuild output
- **Port forward**: `iproxy` child process tied to the session (shutdown hook + close), with orphan reaping that only kills processes actually named `iproxy` holding the port
- **App lifecycle**: devicectl-backed controller (`device process launch --terminate-existing`, `device install app`) filling maestro's stubs
- **CLI**: `--ios-real-device-id`, `--ios-real-device-port`, `--ios-xctest-apple-team-id`

## Verification
- Unit tests for team resolution, port-forwarder orphan reaping, and devicectl launch (`:arbigent-core:test` green)
- iOS **simulator** regression: both `e2e-test-ios.yaml` scenarios green (simulator path unaffected)
- **Real device** smoke on iPhone SE (3rd gen, iOS 26.5): AI agent launched Settings, navigated to General, goal achieved — full pipeline (discovery → signed runner → iproxy → XCTest → screenshots → AI loop) verified end-to-end

## Notes for users
- Requires Xcode with the device's iOS platform installed, `iproxy` (`brew install libimobiledevice`), a paired+unlocked device, and any Apple Development identity (free account works; profile renews weekly)
- The device must stay unlocked while tests run (lock screen is the top cause of XCTest timeouts)