### PR TITLE
List physical iPhones in the UI and document iOS real-device support

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,9 @@ Options:
   --ai-type=(openai|gemini|azureopenai)  Type of AI to use
   --ai-api-logging                       Enable AI API debug logging
   --os=(android|ios|web)                 Target operating system
+  --ios-xctest-apple-team-id=<text>      Apple team id for signing the XCTest runner on a physical iPhone
+  --ios-real-device-id=<text>            Hardware UDID selecting a specific physical iPhone
+  --ios-real-device-port=<text>          Host/device port for the XCTest runner (default 22087)
   --project-file=<text>                  Path to the project YAML file
   --log-level=(debug|info|warn|error)    Log level
   --log-file=<text>                      Log file path
@@ -401,6 +404,52 @@ Options:
   --shard=<value>                        Shard specification (e.g., 1/5)
   -h, --help                             Show this message and exit
 ```
+
+#### iOS real devices
+
+Arbigent can drive a physical iPhone (not just a simulator) over Apple's CoreDevice/XCTest stack. Discovery, runner signing, and port forwarding are handled for you; a single connected iPhone with `--os=ios` just works.
+
+**Prerequisites**
+
+- **Xcode** installed, plus the iOS platform matching your device's iOS version. If a build fails with `iOS X.Y is not installed`, install it with `xcodebuild -downloadPlatform iOS`.
+- **`iproxy`** from [libimobiledevice](https://libimobiledevice.org) on your `PATH` (`brew install libimobiledevice`). Arbigent starts and manages it to bridge the XCTest runner port from the device to the host.
+- The device must be **paired, trusted, and unlocked**. Keep it unlocked for the whole run — a locked screen is the most common cause of timeouts.
+- **A code-signing identity.** Any Apple Development identity works, including a **free Apple ID** account. Free accounts issue 7-day provisioning profiles, so you must rebuild/re-sign roughly weekly; a paid Apple Developer account avoids this. Arbigent auto-detects the team when you have exactly one identity; pass `--ios-xctest-apple-team-id` when you have several.
+
+**Quickstart**
+
+With one iPhone connected, paired, and unlocked:
+
+```bash
+arbigent run --os=ios
+```
+
+For multiple connected devices, or when auto-detection can't pick a single signing team, pass the relevant options (placeholder values shown — use your own):
+
+```bash
+arbigent run --os=ios \
+  --ios-xctest-apple-team-id=ABCDE12345 \
+  --ios-real-device-id=00008110-XXXXXXXXXXXXXXXX
+```
+
+These options can also live in `.arbigent/settings.local.yml` like any other option (globally or under `run:`), so you don't repeat them:
+
+```yaml
+run:
+  os: ios
+  ios-xctest-apple-team-id: ABCDE12345
+  ios-real-device-id: 00008110-XXXXXXXXXXXXXXXX
+  ios-real-device-port: "22087"
+```
+
+The team id is treated as sensitive and is masked in `--help` output and redacted from persisted logs.
+
+**Troubleshooting**
+
+- **Timeouts / no response:** the device screen is locked. Wake and unlock it, and keep it unlocked during the run.
+- **`Timed out while enabling automation mode`:** transient; retry with the device awake and unlocked.
+- **A macOS keychain prompt on the first build** (codesign wanting to sign): allow it (choose "Always Allow" to avoid repeat prompts) so the runner can be signed.
+- **`iOS X.Y is not installed`:** install the matching platform with `xcodebuild -downloadPlatform iOS`.
 
 #### Other commands
 

--- a/arbigent-cli/src/main/kotlin/GuideCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GuideCommand.kt
@@ -276,6 +276,14 @@ Done when: you know the scenario ids and tags you need for the next `run` comman
   Never commit keys; use the `settings.local.yml` file (gitignore it).
 - A connected device matching `--os` (`android` (default) / `ios` / `web`). The first
   available device is used. Not needed for `--dry-run`.
+  - `--os=ios` uses a booted simulator, or a physical iPhone when one is connected.
+    Runner signing and USB port forwarding are handled for you (needs Xcode, the iOS
+    platform matching the device, and `iproxy` on PATH). Keep the iPhone paired,
+    trusted, and unlocked for the whole run. Real-device options: `--ios-xctest-apple-team-id`
+    (signing team; auto-detected when you have exactly one identity),
+    `--ios-real-device-id` (hardware UDID; required when several iPhones are connected),
+    `--ios-real-device-port` (default 22087). All can live in `.arbigent/settings.local.yml`.
+    See the README "iOS real devices" section for details.
 
 ## Selecting scenarios
 
@@ -356,6 +364,8 @@ you suspect the wrong scenarios were selected.
   `.arbigent/settings.local.yml`.
 - "No available device found" — start an emulator/simulator or connect a device
   matching `--os` before running.
+- iOS real-device run times out — the iPhone screen is almost always locked; unlock it and
+  keep it unlocked. For other setup causes see `arbigent guide running-scenarios`.
 - Goal not achieved within steps — raise `maxStep`, split the scenario using
   `dependency`, or make the `goal` more specific with explicit guardrails.
 - Wrong starting state — add `initializationMethods` (`CleanupData`, `LaunchApp`,

--- a/arbigent-cli/src/main/kotlin/RunCommand.kt
+++ b/arbigent-cli/src/main/kotlin/RunCommand.kt
@@ -56,16 +56,17 @@ class ArbigentRunCommand : CliktCommand(name = "run") {
     .choice("android", "ios", "web")
     .default("android")
 
-  private val iosAppleTeamId by defaultOption(
+  // internal (not private) so tests can assert these resolve from .arbigent settings yaml.
+  internal val iosAppleTeamId by defaultOption(
     "--ios-xctest-apple-team-id",
     help = "Apple developer team id used to sign the XCTest runner for a physical iPhone (--os=ios). " +
       "Falls back to ${ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID}, then single-identity auto-detect."
   )
-  private val iosRealDeviceId by defaultOption(
+  internal val iosRealDeviceId by defaultOption(
     "--ios-real-device-id",
     help = "Hardware UDID selecting a specific physical iPhone (--os=ios)."
   )
-  private val iosRealDevicePort by defaultOption(
+  internal val iosRealDevicePort by defaultOption(
     "--ios-real-device-port",
     help = "Host/device port for the XCTest runner on a physical iPhone (default 22087)."
   )

--- a/arbigent-cli/src/test/kotlin/CliTest.kt
+++ b/arbigent-cli/src/test/kotlin/CliTest.kt
@@ -12,6 +12,7 @@ import java.io.File
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContains
+import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 
 class CliTest {
@@ -158,6 +159,74 @@ scenarios:
     // Should succeed using settings file value
     assertContains(globalTest.output, "Selected scenarios for execution")
     
+    settingsFile.delete()
+  }
+
+  @Test
+  fun `ios real-device options resolve from settings yaml global keys`() {
+    // Placeholder team id / UDID only — never real values.
+    val settingsFile = File("build/test-.arbigent/settings-ios.yml")
+    settingsFile.parentFile.mkdirs()
+    settingsFile.writeText(
+      """
+      project-file: ${yaml.absolutePath}
+      ios-xctest-apple-team-id: ABCDE12345
+      ios-real-device-id: 00008110-XXXXXXXXXXXXXXXX
+      ios-real-device-port: "22090"
+      """.trimIndent()
+    )
+
+    val runCommand = ArbigentRunCommand().subcommands(ArbigentRunTaskCommand())
+    val command = ArbigentCli().apply {
+      context {
+        valueSource = ChainedValueSource(
+          listOf(
+            YamlValueSource.from(settingsFile.absolutePath, getKey = ValueSource.getKey(joinSubcommands = ".")),
+            YamlValueSource.from(settingsFile.absolutePath, getKey = { _, option -> option.names.first().removePrefix("--") })
+          )
+        )
+      }
+    }.subcommands(runCommand)
+
+    // --dry-run resolves every option but never connects a device, so this stays hermetic.
+    val test = command.test("run --dry-run --os=ios", envvars = mapOf("OPENAI_API_KEY" to "key"))
+    assertContains(test.output, "Selected scenarios for execution")
+
+    assertEquals("ABCDE12345", runCommand.iosAppleTeamId)
+    assertEquals("00008110-XXXXXXXXXXXXXXXX", runCommand.iosRealDeviceId)
+    assertEquals("22090", runCommand.iosRealDevicePort)
+
+    settingsFile.delete()
+  }
+
+  @Test
+  fun `ios real-device options resolve from command-specific run keys`() {
+    val settingsFile = File("build/test-.arbigent/settings-ios-run.yml")
+    settingsFile.parentFile.mkdirs()
+    settingsFile.writeText(
+      """
+      project-file: ${yaml.absolutePath}
+      run:
+        ios-real-device-port: "22091"
+      """.trimIndent()
+    )
+
+    val runCommand = ArbigentRunCommand().subcommands(ArbigentRunTaskCommand())
+    val command = ArbigentCli().apply {
+      context {
+        valueSource = ChainedValueSource(
+          listOf(
+            YamlValueSource.from(settingsFile.absolutePath, getKey = ValueSource.getKey(joinSubcommands = ".")),
+            YamlValueSource.from(settingsFile.absolutePath, getKey = { _, option -> option.names.first().removePrefix("--") })
+          )
+        )
+      }
+    }.subcommands(runCommand)
+
+    val test = command.test("run --dry-run --os=ios", envvars = mapOf("OPENAI_API_KEY" to "key"))
+    assertContains(test.output, "Selected scenarios for execution")
+    assertEquals("22091", runCommand.iosRealDevicePort)
+
     settingsFile.delete()
   }
 

--- a/arbigent-cli/src/test/kotlin/CliTest.kt
+++ b/arbigent-cli/src/test/kotlin/CliTest.kt
@@ -176,27 +176,29 @@ scenarios:
       """.trimIndent()
     )
 
-    val runCommand = ArbigentRunCommand().subcommands(ArbigentRunTaskCommand())
-    val command = ArbigentCli().apply {
-      context {
-        valueSource = ChainedValueSource(
-          listOf(
-            YamlValueSource.from(settingsFile.absolutePath, getKey = ValueSource.getKey(joinSubcommands = ".")),
-            YamlValueSource.from(settingsFile.absolutePath, getKey = { _, option -> option.names.first().removePrefix("--") })
+    try {
+      val runCommand = ArbigentRunCommand().subcommands(ArbigentRunTaskCommand())
+      val command = ArbigentCli().apply {
+        context {
+          valueSource = ChainedValueSource(
+            listOf(
+              YamlValueSource.from(settingsFile.absolutePath, getKey = ValueSource.getKey(joinSubcommands = ".")),
+              YamlValueSource.from(settingsFile.absolutePath, getKey = { _, option -> option.names.first().removePrefix("--") })
+            )
           )
-        )
-      }
-    }.subcommands(runCommand)
+        }
+      }.subcommands(runCommand)
 
-    // --dry-run resolves every option but never connects a device, so this stays hermetic.
-    val test = command.test("run --dry-run --os=ios", envvars = mapOf("OPENAI_API_KEY" to "key"))
-    assertContains(test.output, "Selected scenarios for execution")
+      // --dry-run resolves every option but never connects a device, so this stays hermetic.
+      val test = command.test("run --dry-run --os=ios", envvars = mapOf("OPENAI_API_KEY" to "key"))
+      assertContains(test.output, "Selected scenarios for execution")
 
-    assertEquals("ABCDE12345", runCommand.iosAppleTeamId)
-    assertEquals("00008110-XXXXXXXXXXXXXXXX", runCommand.iosRealDeviceId)
-    assertEquals("22090", runCommand.iosRealDevicePort)
-
-    settingsFile.delete()
+      assertEquals("ABCDE12345", runCommand.iosAppleTeamId)
+      assertEquals("00008110-XXXXXXXXXXXXXXXX", runCommand.iosRealDeviceId)
+      assertEquals("22090", runCommand.iosRealDevicePort)
+    } finally {
+      settingsFile.delete()
+    }
   }
 
   @Test
@@ -211,23 +213,25 @@ scenarios:
       """.trimIndent()
     )
 
-    val runCommand = ArbigentRunCommand().subcommands(ArbigentRunTaskCommand())
-    val command = ArbigentCli().apply {
-      context {
-        valueSource = ChainedValueSource(
-          listOf(
-            YamlValueSource.from(settingsFile.absolutePath, getKey = ValueSource.getKey(joinSubcommands = ".")),
-            YamlValueSource.from(settingsFile.absolutePath, getKey = { _, option -> option.names.first().removePrefix("--") })
+    try {
+      val runCommand = ArbigentRunCommand().subcommands(ArbigentRunTaskCommand())
+      val command = ArbigentCli().apply {
+        context {
+          valueSource = ChainedValueSource(
+            listOf(
+              YamlValueSource.from(settingsFile.absolutePath, getKey = ValueSource.getKey(joinSubcommands = ".")),
+              YamlValueSource.from(settingsFile.absolutePath, getKey = { _, option -> option.names.first().removePrefix("--") })
+            )
           )
-        )
-      }
-    }.subcommands(runCommand)
+        }
+      }.subcommands(runCommand)
 
-    val test = command.test("run --dry-run --os=ios", envvars = mapOf("OPENAI_API_KEY" to "key"))
-    assertContains(test.output, "Selected scenarios for execution")
-    assertEquals("22091", runCommand.iosRealDevicePort)
-
-    settingsFile.delete()
+      val test = command.test("run --dry-run --os=ios", envvars = mapOf("OPENAI_API_KEY" to "key"))
+      assertContains(test.output, "Selected scenarios for execution")
+      assertEquals("22091", runCommand.iosRealDevicePort)
+    } finally {
+      settingsFile.delete()
+    }
   }
 
   @Test

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
@@ -5,29 +5,34 @@ import maestro.utils.TempFileHandler
 import util.LocalSimulatorUtils
 
 @ArbigentInternalApi
-public fun fetchAvailableDevicesByOs(deviceType: ArbigentDeviceOs): List<ArbigentAvailableDevice> {
+public fun fetchAvailableDevicesByOs(
+  deviceType: ArbigentDeviceOs,
+  // The CLI auto-selects the first device, so iOS discovery hides physical iPhones behind an
+  // opt-in (see below). The UI lets the user pick explicitly, so it passes true to list every
+  // connected iOS device (booted simulators and paired iPhones) at once.
+  includeAllIosDevices: Boolean = false,
+): List<ArbigentAvailableDevice> {
   return when (deviceType) {
     ArbigentDeviceOs.Android -> {
       Dadb.list().map { ArbigentAvailableDevice.Android(it) }
     }
 
     ArbigentDeviceOs.Ios -> {
-      // LocalSimulatorUtils is now a class taking a TempFileHandler instead of an object.
-      val simulators = LocalSimulatorUtils(TempFileHandler()).list()
-        .devices
-        .flatMap { runtime ->
-          runtime.value
-            .filter { it.isAvailable && it.state == "Booted" }
-        }
-        .map { ArbigentAvailableDevice.IOS(it) }
-      val optedIn = isRealIosDeviceOptedIn()
-      // Wake the CoreDevice tunnel (read-only) when the user opted in, or when there is no booted
-      // simulator to fall back on so a lone connected iPhone still "just works".
-      val realDevices = fetchConnectedIosRealDevices(wakeTunnels = optedIn || simulators.isEmpty())
-      // Prefer a physical device only when the user has opted in (Apple team id or a specific
-      // real-device id). Otherwise a booted simulator wins, keeping the common `--os=ios` dev flow
-      // unchanged. connectDevice() picks the first entry.
-      if (optedIn) realDevices + simulators else simulators + realDevices
+      val simulators = fetchBootedIosSimulators()
+      if (includeAllIosDevices) {
+        // Interactive selection: surface both kinds. Always wake tunnels so a paired iPhone shows
+        // up even when a simulator is also booted.
+        fetchConnectedIosRealDevices(wakeTunnels = true) + simulators
+      } else {
+        val optedIn = isRealIosDeviceOptedIn()
+        // Wake the CoreDevice tunnel (read-only) when the user opted in, or when there is no booted
+        // simulator to fall back on so a lone connected iPhone still "just works".
+        val realDevices = fetchConnectedIosRealDevices(wakeTunnels = optedIn || simulators.isEmpty())
+        // Prefer a physical device only when the user has opted in (Apple team id or a specific
+        // real-device id). Otherwise a booted simulator wins, keeping the common `--os=ios` dev flow
+        // unchanged. connectDevice() picks the first entry.
+        if (optedIn) realDevices + simulators else simulators + realDevices
+      }
     }
 
     else -> {
@@ -35,6 +40,16 @@ public fun fetchAvailableDevicesByOs(deviceType: ArbigentDeviceOs): List<Arbigen
     }
   }
 }
+
+// LocalSimulatorUtils is now a class taking a TempFileHandler instead of an object.
+private fun fetchBootedIosSimulators(): List<ArbigentAvailableDevice.IOS> =
+  LocalSimulatorUtils(TempFileHandler()).list()
+    .devices
+    .flatMap { runtime ->
+      runtime.value
+        .filter { it.isAvailable && it.state == "Booted" }
+    }
+    .map { ArbigentAvailableDevice.IOS(it) }
 
 /**
  * Lists physical iPhones reachable over CoreDevice (`xcrun devicectl`), filtered to the ones with a

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
@@ -41,15 +41,18 @@ public fun fetchAvailableDevicesByOs(
   }
 }
 
-// LocalSimulatorUtils is now a class taking a TempFileHandler instead of an object.
+// LocalSimulatorUtils is now a class taking a TempFileHandler instead of an object. TempFileHandler
+// is Closeable and we own this instance, so scope it with use {} to clean up any temp files.
 private fun fetchBootedIosSimulators(): List<ArbigentAvailableDevice.IOS> =
-  LocalSimulatorUtils(TempFileHandler()).list()
-    .devices
-    .flatMap { runtime ->
-      runtime.value
-        .filter { it.isAvailable && it.state == "Booted" }
-    }
-    .map { ArbigentAvailableDevice.IOS(it) }
+  TempFileHandler().use { tempFileHandler ->
+    LocalSimulatorUtils(tempFileHandler).list()
+      .devices
+      .flatMap { runtime ->
+        runtime.value
+          .filter { it.isAvailable && it.state == "Booted" }
+      }
+      .map { ArbigentAvailableDevice.IOS(it) }
+  }
 
 /**
  * Lists physical iPhones reachable over CoreDevice (`xcrun devicectl`), filtered to the ones with a

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/App.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/App.kt
@@ -25,14 +25,21 @@ import org.jetbrains.jewel.ui.component.*
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import org.jetbrains.jewel.ui.painter.hints.Size
 
-// Label for a device in the picker. Names alone can collide (a simulator and a phone, or two phones,
-// with the same model name), so when a name is shared we append the device kind and, for a physical
-// iPhone, its masked UDID to disambiguate. Selection itself is keyed by the device object, not this.
+// Label for a device in the picker. Names alone can collide (a simulator and a phone, two phones,
+// two simulators, or two Android devices with the same model name), so when a name is shared we
+// append a disambiguating hint: a physical iPhone shows its masked UDID; anything else shows its OS
+// plus an ordinal among the same-named devices, so two simulators (or two Android devices) never
+// render identically without leaking a raw identifier. Selection itself is keyed by the device
+// object, not this label.
 private fun deviceItemLabel(device: ArbigentAvailableDevice, all: List<ArbigentAvailableDevice>): String {
-  if (all.count { it.name == device.name } <= 1) return device.name
+  val sameName = all.filter { it.name == device.name }
+  if (sameName.size <= 1) return device.name
   val hint = when (device) {
     is ArbigentAvailableDevice.IosReal -> "iOS device ${device.maskedUdid}"
-    else -> device.deviceOs.name
+    else -> {
+      val ordinal = sameName.indexOfFirst { it.stableKey == device.stableKey } + 1
+      "${device.deviceOs.name} #$ordinal"
+    }
   }
   return "${device.name} ($hint)"
 }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/App.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/App.kt
@@ -12,6 +12,7 @@ import androidx.compose.ui.input.pointer.pointerHoverIcon
 import androidx.compose.ui.input.pointer.PointerIcon
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
+import io.github.takahirom.arbigent.ArbigentAvailableDevice
 import io.github.takahirom.arbigent.ArbigentDeviceOs
 import io.github.takahirom.arbigent.arbigentDebugLog
 import io.github.takahirom.arbigent.ui.ArbigentAppStateHolder.DeviceConnectionState
@@ -23,6 +24,18 @@ import org.jetbrains.jewel.ui.Orientation
 import org.jetbrains.jewel.ui.component.*
 import org.jetbrains.jewel.ui.icons.AllIconsKeys
 import org.jetbrains.jewel.ui.painter.hints.Size
+
+// Label for a device in the picker. Names alone can collide (a simulator and a phone, or two phones,
+// with the same model name), so when a name is shared we append the device kind and, for a physical
+// iPhone, its masked UDID to disambiguate. Selection itself is keyed by the device object, not this.
+private fun deviceItemLabel(device: ArbigentAvailableDevice, all: List<ArbigentAvailableDevice>): String {
+  if (all.count { it.name == device.name } <= 1) return device.name
+  val hint = when (device) {
+    is ArbigentAvailableDevice.IosReal -> "iOS device ${device.maskedUdid}"
+    else -> device.deviceOs.name
+  }
+  return "${device.name} ($hint)"
+}
 
 @Composable
 fun App(
@@ -296,8 +309,9 @@ fun ScenarioControls(appStateHolder: ArbigentAppStateHolder) {
             text = item.name,
             isSelected = isSelected,
             onClick = {
+              // The holder's OS collector re-fetches on this change; no explicit fetch needed (which
+              // would only launch a second, redundant discovery).
               devicesStateHolder.selectedDeviceOs.value = item
-              devicesStateHolder.fetchDevices()
               devicesStateHolder.onSelectedDeviceChanged(null)
             },
           )
@@ -306,21 +320,23 @@ fun ScenarioControls(appStateHolder: ArbigentAppStateHolder) {
     }
 
     val selectedDevice by devicesStateHolder.selectedDevice.collectAsState()
-    val items = devicesStateHolder.devices.collectAsState().value.map { it.name }
+    val deviceList = devicesStateHolder.devices.collectAsState().value
     arbigentDebugLog("selectedDevice: $selectedDevice")
     ComboBox(
       modifier = Modifier.width(170.dp).padding(end = 2.dp),
-      labelText = selectedDevice?.name ?: "Select device",
+      labelText = selectedDevice?.let { deviceItemLabel(it, deviceList) } ?: "Select device",
       maxPopupHeight = 150.dp,
     ) {
       Column {
-        items.forEach { itemText ->
-          val isSelected = itemText == selectedDevice?.name
+        // Iterate device objects (not display names) so a simulator and a phone, or two phones, that
+        // share a name each select the exact device the user clicked rather than the first name match.
+        deviceList.forEach { device ->
+          val isSelected = device == selectedDevice
           ComboBoxItem(
-            text = itemText,
+            text = deviceItemLabel(device, deviceList),
             isSelected = isSelected,
             onClick = {
-              devicesStateHolder.onSelectedDeviceChanged(devicesStateHolder.devices.value.firstOrNull { it.name == itemText })
+              devicesStateHolder.onSelectedDeviceChanged(device)
               devicesStateHolder.selectedDevice.value?.let {
                 appStateHolder.onClickConnect(devicesStateHolder)
               }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -629,6 +629,7 @@ class ArbigentAppStateHolder(
     job?.cancel()
     projectStateFlow.value?.cancel()
     allScenarioStateHoldersStateFlow.value.forEach { it.cancel() }
+    devicesStateHolder.close()
     deviceConnectionState.value = DeviceConnectionState.NotConnected
     ArbigentGlobalStatus.onDisconnect {
       deviceCache.values.forEach { it.close() }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -22,7 +22,9 @@ class ArbigentAppStateHolder(
     }
   },
   val availableDeviceListFactory: (ArbigentDeviceOs) -> List<ArbigentAvailableDevice> = { os ->
-    fetchAvailableDevicesByOs(os)
+    // The UI selects a device explicitly, so list every connected iOS device (simulators and
+    // paired iPhones) rather than the CLI's auto-select subset.
+    fetchAvailableDevicesByOs(os, includeAllIosDevices = true)
   }
 ) {
   private val _fixedScenariosFlow = MutableStateFlow<List<FixedScenario>>(emptyList())

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/DevicesStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/DevicesStateHolder.kt
@@ -7,6 +7,7 @@ import io.github.takahirom.arbigent.ArbigentDeviceOs
 import io.github.takahirom.arbigent.arbigentDebugLog
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -75,5 +76,11 @@ class DevicesStateHolder(val arbigentAvailableDeviceListFactory: (ArbigentDevice
   private fun reconcileSelection(newDevices: List<ArbigentAvailableDevice>) {
     val previous = _selectedDevice.value ?: return
     _selectedDevice.value = newDevices.firstOrNull { it.stableKey == previous.stableKey }
+  }
+
+  // Cancel the holder-owned scope so the OS collector and any in-flight discovery don't outlive the
+  // owning app state holder. Called from ArbigentAppStateHolder.close().
+  fun close() {
+    scope.cancel()
   }
 }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/DevicesStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/DevicesStateHolder.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -31,9 +30,12 @@ class DevicesStateHolder(val arbigentAvailableDeviceListFactory: (ArbigentDevice
   // collectors or let a slow discovery overwrite a newer result out of order.
   private val scope = CoroutineScope(ArbigentCoroutinesDispatcher.dispatcher + SupervisorJob())
   private var fetchJob: Job? = null
-  // Serializes the cancel-then-replace of fetchJob: the OS-change collector and the UI refresh
-  // handler can both call fetchDevices() from different threads, and an unguarded swap could leave
-  // an older discovery running (and later clobbering a newer result).
+  // Monotonic id of the latest fetch. A job publishes only if it still matches this when it finishes,
+  // which makes the "am I still the newest?" check and the state writes atomic under fetchLock.
+  private var fetchGeneration = 0
+  // Serializes the cancel-then-replace of fetchJob (and the generation bump/publish): the OS-change
+  // collector and the UI refresh handler can both call fetchDevices() from different threads, and an
+  // unguarded swap could leave an older discovery running and later clobbering a newer result.
   private val fetchLock = Any()
 
   init {
@@ -47,22 +49,27 @@ class DevicesStateHolder(val arbigentAvailableDeviceListFactory: (ArbigentDevice
 
   fun fetchDevices() {
     synchronized(fetchLock) {
-      // Accepted tradeoff: cancel() only requests cancellation, so a just-cancelled predecessor may
-      // still be unwinding its (read-only) discovery when the replacement starts, briefly running
-      // two discoveries. That is harmless — discovery mutates no device state, and the ensureActive()
-      // guard below means only the latest job ever publishes its result.
+      // cancel() only requests cancellation, so a just-cancelled predecessor may still be unwinding
+      // its (read-only, state-free) discovery when the replacement starts, briefly running two
+      // discoveries — harmless. What is NOT harmless is a stale job publishing after a newer one: a
+      // job that already passed a cancellation check can still be preempted before its writes, so a
+      // bare ensureActive() leaves a check-then-act window. Instead each job captures the generation
+      // it was launched under and, holding fetchLock, publishes only if it is still the latest — so
+      // the newest fetch always wins regardless of completion order.
       fetchJob?.cancel()
+      val generation = ++fetchGeneration
       fetchJob = scope.launch {
         val os = selectedDeviceOs.value
         // Device discovery (e.g. devicectl) blocks, so run it off the caller under runInterruptible
-        // so cancelling the job actually interrupts the blocking call, and drop the result if a
-        // newer fetch cancelled us while it ran.
+        // so cancelling the job actually interrupts the blocking call.
         val result = withContext(ArbigentCoroutinesDispatcher.dispatcher) {
           runInterruptible { arbigentAvailableDeviceListFactory(os) }
         }
-        ensureActive()
-        devices.value = result
-        reconcileSelection(result)
+        synchronized(fetchLock) {
+          if (generation != fetchGeneration) return@launch
+          devices.value = result
+          reconcileSelection(result)
+        }
       }
     }
   }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/DevicesStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/DevicesStateHolder.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 
 
@@ -29,6 +30,10 @@ class DevicesStateHolder(val arbigentAvailableDeviceListFactory: (ArbigentDevice
   // collectors or let a slow discovery overwrite a newer result out of order.
   private val scope = CoroutineScope(ArbigentCoroutinesDispatcher.dispatcher + SupervisorJob())
   private var fetchJob: Job? = null
+  // Serializes the cancel-then-replace of fetchJob: the OS-change collector and the UI refresh
+  // handler can both call fetchDevices() from different threads, and an unguarded swap could leave
+  // an older discovery running (and later clobbering a newer result).
+  private val fetchLock = Any()
 
   init {
     selectedDeviceOs.onEach { fetchDevices() }.launchIn(scope)
@@ -40,16 +45,36 @@ class DevicesStateHolder(val arbigentAvailableDeviceListFactory: (ArbigentDevice
   }
 
   fun fetchDevices() {
-    fetchJob?.cancel()
-    fetchJob = scope.launch {
-      val os = selectedDeviceOs.value
-      // Device discovery (e.g. devicectl) blocks, so run it off the caller and drop the result if a
-      // newer fetch cancelled us while it ran.
-      val result = withContext(ArbigentCoroutinesDispatcher.dispatcher) {
-        arbigentAvailableDeviceListFactory(os)
+    synchronized(fetchLock) {
+      fetchJob?.cancel()
+      fetchJob = scope.launch {
+        val os = selectedDeviceOs.value
+        // Device discovery (e.g. devicectl) blocks, so run it off the caller under runInterruptible
+        // so cancelling the job actually interrupts the blocking call, and drop the result if a
+        // newer fetch cancelled us while it ran.
+        val result = withContext(ArbigentCoroutinesDispatcher.dispatcher) {
+          runInterruptible { arbigentAvailableDeviceListFactory(os) }
+        }
+        ensureActive()
+        devices.value = result
+        reconcileSelection(result)
       }
-      ensureActive()
-      devices.value = result
     }
+  }
+
+  // Rediscovery produces fresh device objects that are never reference-equal to the previously
+  // selected one (these device classes deliberately don't override equals), so re-point the
+  // selection at the matching entry in the new list by a stable identity, or clear it if the
+  // device is gone. Without this the UI keeps a stale object selected that no list entry matches.
+  private fun reconcileSelection(newDevices: List<ArbigentAvailableDevice>) {
+    val previous = _selectedDevice.value ?: return
+    _selectedDevice.value = newDevices.firstOrNull { deviceIdentity(it) == deviceIdentity(previous) }
+  }
+
+  private fun deviceIdentity(device: ArbigentAvailableDevice): String = when (device) {
+    // Real iPhones share model names, so key on the masked UDID (never the raw one) plus name.
+    is ArbigentAvailableDevice.IosReal -> "iosreal:${device.maskedUdid}:${device.name}"
+    // Android name is the adb serial; simulator/web names are stable per device.
+    else -> "${device.deviceOs.name}:${device.name}"
   }
 }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/DevicesStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/DevicesStateHolder.kt
@@ -6,12 +6,16 @@ import io.github.takahirom.arbigent.ArbigentAvailableDevice
 import io.github.takahirom.arbigent.ArbigentDeviceOs
 import io.github.takahirom.arbigent.arbigentDebugLog
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.ensureActive
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 
 class DevicesStateHolder(val arbigentAvailableDeviceListFactory: (ArbigentDeviceOs) -> List<ArbigentAvailableDevice>) {
@@ -20,8 +24,14 @@ class DevicesStateHolder(val arbigentAvailableDeviceListFactory: (ArbigentDevice
   private val _selectedDevice: MutableStateFlow<ArbigentAvailableDevice?> = MutableStateFlow(null)
   val selectedDevice: StateFlow<ArbigentAvailableDevice?> = _selectedDevice.asStateFlow()
 
+  // One scope owned by the holder. A single collector re-fetches when the OS changes; each fetch is a
+  // cancellable one-shot whose predecessor is cancelled first, so refreshes never accumulate
+  // collectors or let a slow discovery overwrite a newer result out of order.
+  private val scope = CoroutineScope(ArbigentCoroutinesDispatcher.dispatcher + SupervisorJob())
+  private var fetchJob: Job? = null
+
   init {
-    fetchDevices()
+    selectedDeviceOs.onEach { fetchDevices() }.launchIn(scope)
   }
 
   fun onSelectedDeviceChanged(device: ArbigentAvailableDevice?) {
@@ -30,8 +40,16 @@ class DevicesStateHolder(val arbigentAvailableDeviceListFactory: (ArbigentDevice
   }
 
   fun fetchDevices() {
-    selectedDeviceOs.onEach { os ->
-      devices.value = arbigentAvailableDeviceListFactory(os)
-    }.launchIn(CoroutineScope(ArbigentCoroutinesDispatcher.dispatcher + SupervisorJob()))
+    fetchJob?.cancel()
+    fetchJob = scope.launch {
+      val os = selectedDeviceOs.value
+      // Device discovery (e.g. devicectl) blocks, so run it off the caller and drop the result if a
+      // newer fetch cancelled us while it ran.
+      val result = withContext(ArbigentCoroutinesDispatcher.dispatcher) {
+        arbigentAvailableDeviceListFactory(os)
+      }
+      ensureActive()
+      devices.value = result
+    }
   }
 }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/DevicesStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/DevicesStateHolder.kt
@@ -46,6 +46,10 @@ class DevicesStateHolder(val arbigentAvailableDeviceListFactory: (ArbigentDevice
 
   fun fetchDevices() {
     synchronized(fetchLock) {
+      // Accepted tradeoff: cancel() only requests cancellation, so a just-cancelled predecessor may
+      // still be unwinding its (read-only) discovery when the replacement starts, briefly running
+      // two discoveries. That is harmless — discovery mutates no device state, and the ensureActive()
+      // guard below means only the latest job ever publishes its result.
       fetchJob?.cancel()
       fetchJob = scope.launch {
         val os = selectedDeviceOs.value
@@ -64,17 +68,12 @@ class DevicesStateHolder(val arbigentAvailableDeviceListFactory: (ArbigentDevice
 
   // Rediscovery produces fresh device objects that are never reference-equal to the previously
   // selected one (these device classes deliberately don't override equals), so re-point the
-  // selection at the matching entry in the new list by a stable identity, or clear it if the
+  // selection at the matching entry in the new list by its stable identity, or clear it if the
   // device is gone. Without this the UI keeps a stale object selected that no list entry matches.
+  // stableKey carries the full device identifier (never displayed), so two real iPhones sharing a
+  // masked UDID prefix are told apart and the selection can never re-point at the wrong device.
   private fun reconcileSelection(newDevices: List<ArbigentAvailableDevice>) {
     val previous = _selectedDevice.value ?: return
-    _selectedDevice.value = newDevices.firstOrNull { deviceIdentity(it) == deviceIdentity(previous) }
-  }
-
-  private fun deviceIdentity(device: ArbigentAvailableDevice): String = when (device) {
-    // Real iPhones share model names, so key on the masked UDID (never the raw one) plus name.
-    is ArbigentAvailableDevice.IosReal -> "iosreal:${device.maskedUdid}:${device.name}"
-    // Android name is the adb serial; simulator/web names are stable per device.
-    else -> "${device.deviceOs.name}:${device.name}"
+    _selectedDevice.value = newDevices.firstOrNull { it.stableKey == previous.stableKey }
   }
 }


### PR DESCRIPTION
## What
Polish on top of #399:

- **UI**: the device dropdown now lists paired physical iPhones alongside booted simulators (`fetchAvailableDevicesByOs(includeAllIosDevices = true)` — UI only; CLI auto-selection behavior is unchanged)
- **Tests**: hermetic CLI tests proving `ios-xctest-apple-team-id` / `ios-real-device-id` / `ios-real-device-port` resolve from `.arbigent` settings yaml (global and `run.`-scoped), which PR #399's clikt integration already supported
- **Docs**: README "iOS real devices" section — prerequisites (Xcode platform, iproxy, paired+unlocked device, any Apple Development identity incl. free accounts), quickstart, settings yaml example, troubleshooting (lock screen, automation-mode timeout, codesign prompt, missing iOS platform). Placeholder IDs only

## Verification
- `./gradlew test installDist` green (full suite incl. UiTests first-run green)
- Real-device UI listing is compile+unit verified only (no iPhone connected during this change); the underlying connection path was smoke-verified on a real iPhone SE in #399