### PR TITLE
Add project-YAML and CLI/settings reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,6 +654,8 @@ ArbigentProject o--"*" ArbigentScenario
 The project file is saved in YAML format and contains scenarios with goals, initialization methods, and cleanup data. Dependencies between scenarios are also defined.
 You can write a project file in YAML format by hand or create it using the Arbigent UI.
 
+For a complete field-by-field reference of every project YAML key (type, default, and description), see [arbigent-yaml-reference.md](arbigent-yaml-reference.md). For the CLI flags and how they map to `.arbigent/settings*.yml` / `.yaml` keys and environment variables, see [arbigent-cli-reference.md](arbigent-cli-reference.md).
+
 The id is auto-generated UUID by Arbigent UI but you can change it to any string.
 
 #### Available Initialization Methods
@@ -664,7 +666,6 @@ The id is auto-generated UUID by Arbigent UI but you can change it to any string
 - **CleanupData**: Clear application data
 - **OpenLink**: Open a URL/link
 - **MaestroYaml**: Execute a predefined Maestro YAML scenario
-- **Reconnect**: Disconnect and reconnect the device
 
 ```yaml
 scenarios:

--- a/arbigent-cli-reference.md
+++ b/arbigent-cli-reference.md
@@ -1,0 +1,185 @@
+# Arbigent CLI & settings reference
+
+This reference maps every arbigent CLI flag to its equivalent **settings-file YAML
+key** and **environment variable**, and explains which one wins.
+
+For the *project* YAML (scenarios, goals, assertions) see
+[arbigent-yaml-reference.md](arbigent-yaml-reference.md). This file is about the CLI
+options and the `.arbigent/settings*.yml` (and `.yaml`) config, which is a different
+thing.
+
+## How settings files map to flags
+
+The CLI is built on [Clikt](https://ajalt.github.io/clikt/). Most options are
+"settings-aware": they can be supplied from a settings file instead of the command
+line. **The YAML key is the option's primary long flag with `--` removed** — it is
+*not* nested per provider. (Only the canonical long flag works as a key; short
+aliases such as `--openai-key` or `--azure-openai-key` are not valid keys — use
+`openai-api-key` / `azure-openai-api-key`.)
+
+```yaml
+# .arbigent/settings.local.yml
+ai-type: openai
+openai-endpoint: https://openrouter.ai/api/v1/
+openai-api-key: sk-...              # <-- key is "openai-api-key", NOT "openai.apikey"
+openai-model-name: google/gemini-2.5-flash
+os: android
+log-level: info
+```
+
+### Global vs command-scoped keys
+
+A top-level key applies to all commands. Nesting a key under a **command name** scopes
+it to that command and takes priority over the global key (the parser flattens nested
+maps with `.`, so `run: { log-level: debug }` becomes the key `run.log-level`).
+Subcommands nest fully — `run task` uses `run.task.<key>`:
+
+```yaml
+log-level: info        # global default for every command
+run:
+  log-level: debug     # only the `run` command uses debug
+  task:
+    max-step: 15       # only `run task`
+```
+
+### Which settings files are read
+
+The CLI reads **all** of these that exist (relative to the working directory) and
+chains them as fallbacks — a value from a higher file wins, but a lower file still
+supplies keys the higher one omits:
+
+1. `.arbigent/settings.local.yml`
+2. `.arbigent/settings.local.yaml`
+3. `.arbigent/settings.yml`
+4. `.arbigent/settings.yaml`
+
+## Precedence (what wins)
+
+For a normal settings-aware option, Clikt resolves in this order:
+
+```
+command-line flag  >  environment variable  >  settings file  >  built-in default
+```
+
+Within the settings files the order is: for each file (in the priority list above),
+the command-scoped key (`<command>.<key>`) first, then the global key (`<key>`).
+
+> **iOS real-device options are the exception.** They have no Clikt `envvar`, so their
+> environment fallback happens later inside `arbigent-core`, *after* the settings file.
+> For those three options the order is: **flag > settings file > env var > default**.
+
+## AI provider / API key mapping
+
+Provider options are only in effect for the matching `--ai-type`. API keys are enforced
+at runtime (not by Clikt), so a missing key fails when the run starts, not at parse
+time.
+
+| Setting | CLI flag(s) | Settings key | Env var | Default |
+|---|---|---|---|---|
+| AI type | `--ai-type` | `ai-type` | — | `openai` |
+| OpenAI API key | `--openai-api-key`, `--openai-key` | `openai-api-key` | `OPENAI_API_KEY` | (required) |
+| OpenAI endpoint | `--openai-endpoint` | `openai-endpoint` | — | `https://api.openai.com/v1/` |
+| OpenAI model | `--openai-model-name` | `openai-model-name` | — | `gpt-4.1` |
+| Gemini API key | `--gemini-api-key` | `gemini-api-key` | `GEMINI_API_KEY` | (required) |
+| Gemini endpoint | `--gemini-endpoint` | `gemini-endpoint` | — | `https://generativelanguage.googleapis.com/v1beta/openai/` |
+| Gemini model | `--gemini-model-name` | `gemini-model-name` | — | `gemini-1.5-flash` |
+| Azure API key | `--azure-openai-api-key`, `--azure-openai-key` | `azure-openai-api-key` | `AZURE_OPENAI_API_KEY` | (required) |
+| Azure endpoint | `--azure-openai-endpoint` | `azure-openai-endpoint` | — | (required) |
+| Azure API version | `--azure-openai-api-version` | `azure-openai-api-version` | — | `2024-10-21` |
+| Azure model / deployment | `--azure-openai-model-name` | `azure-openai-model-name` | — | `gpt-4.1` |
+
+> API keys and other sensitive values are masked as `****` in `--help` output (any key
+> containing `key`, `token`, `secret`, `password`, or `team`).
+
+## iOS real-device mapping
+
+Used with `--os=ios` on a physical device. Env var is *lower* priority than the
+settings file here (see the note above).
+
+| Setting | CLI flag | Settings key | Env var | Default |
+|---|---|---|---|---|
+| Apple team id | `--ios-xctest-apple-team-id` | `ios-xctest-apple-team-id` | `ARBIGENT_IOS_XCTEST_APPLE_TEAM_ID` | auto-detect when signing certs resolve to one team |
+| Device UDID | `--ios-real-device-id` | `ios-real-device-id` | `ARBIGENT_IOS_REAL_DEVICE_ID` | auto (when one device) |
+| Runner port | `--ios-real-device-port` | `ios-real-device-port` | `ARBIGENT_IOS_REAL_DEVICE_PORT` | `22087` |
+
+## Common options (per command)
+
+All of the following are settings-aware (readable from the settings file) unless noted.
+
+### `run`
+
+| Flag | Settings key | Type | Default |
+|---|---|---|---|
+| `--project-file` | `project-file` | String | required at runtime |
+| `--ai-type` | `ai-type` | `openai` / `gemini` / `azureopenai` | `openai` |
+| `--os` | `os` | `android` / `ios` / `web` | `android` |
+| `--variables` | `variables` | `k=v,...` map | (none) |
+| `--scenario-ids` | `scenario-ids` | comma list | (none → runs all leaf scenarios) |
+| `--tags` | `tags` | comma list (OR) | (none) |
+| `--shard` | `shard` | `n/m` | `1/1` |
+| `--dry-run` | `dry-run` | flag | `false` |
+| `--ai-api-logging` | `ai-api-logging` | flag | `false` |
+| `--log-level` | `log-level` | `debug`/`info`/`warn`/`error` | `info` |
+| `--log-file` | `log-file` | String | `arbigent-result/arbigent.log` |
+| `--working-directory` | `working-directory` | String | (none) |
+| `--path` | `path` | String | (none) |
+| `--ios-*` | see iOS table above | | |
+
+Plus the AI-provider group options for the selected `--ai-type`.
+
+### `run task`
+
+Takes a positional `goal` argument (required), the AI-provider group, `--os`,
+`--ios-*`, `--ai-api-logging`, `--log-level`, `--log-file`, `--working-directory`, plus:
+
+| Flag | Settings key | Type | Default |
+|---|---|---|---|
+| `--max-step` | `max-step` | Int | `10` |
+| `--max-retry` | `max-retry` | Int | `3` |
+
+### `scenarios` / `tags`
+
+| Flag | Settings key |
+|---|---|
+| `--project-file` | `project-file` |
+| `--working-directory` | `working-directory` |
+| `--log-level` | `log-level` |
+
+### `graph`
+
+`--project-file`, `--log-level` (both settings-aware).
+
+### `instruction`
+
+All settings-aware (keys `scenario-ids`, `include-app-ui-structure`, etc., or
+scoped as `instruction.<key>`).
+
+| Flag | Settings key | Notes |
+|---|---|---|
+| `--project-file` | `project-file` | |
+| `--log-level` | `log-level` | |
+| `--scenario-ids` | `scenario-ids` | required, comma list |
+| `--include-app-ui-structure` | `include-app-ui-structure` | flag, default `false` |
+
+### `guide`
+
+No options. Subcommands are documentation topics that print text: `setup`,
+`writing-yaml`, `inspecting-project`, `running-scenarios`, `debugging-failures`,
+`reproducing-manually`.
+
+## Full example settings file
+
+```yaml
+# .arbigent/settings.local.yml
+project-file: e2e/project.yaml
+ai-type: openai
+openai-endpoint: https://api.openai.com/v1/
+openai-api-key: sk-...
+openai-model-name: gpt-4.1
+os: android
+log-level: info
+
+# command-scoped override: only `run` logs at debug
+run:
+  log-level: debug
+```

--- a/arbigent-cli/src/main/kotlin/GuideCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GuideCommand.kt
@@ -106,6 +106,10 @@ or AZURE_OPENAI_API_KEY (mapped to the same options).
 `arbigent run --help` annotates options already configured in
 `settings.local.yml` as `(currently: '...' from ...)`, with API keys masked.
 
+For a full flag ↔ settings-key ↔ environment-variable mapping table (all commands,
+with defaults and precedence), see `arbigent-cli-reference.md` in the arbigent
+repository.
+
 Done when: both commands above succeed with no flags, and `git status` shows
 `.gitignore` updated and no `settings.local.yml` staged.
 """.trimIndent(),
@@ -204,6 +208,9 @@ reusableScenarios:
 
 Real examples live in `sample-test/src/main/resources/projects/` in the arbigent
 repository (e.g. `e2e-test-android.yaml`).
+
+For an exhaustive field-by-field reference (every YAML key, its type and default),
+see `arbigent-yaml-reference.md` in the arbigent repository.
 
 Done when: `arbigent scenarios --project-file=<file>` lists your scenario ids without errors.
 """.trimIndent(),

--- a/arbigent-cli/src/main/kotlin/GuideCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GuideCommand.kt
@@ -107,8 +107,8 @@ or AZURE_OPENAI_API_KEY (mapped to the same options).
 `settings.local.yml` as `(currently: '...' from ...)`, with API keys masked.
 
 For a full flag ↔ settings-key ↔ environment-variable mapping table (all commands,
-with defaults and precedence), see `arbigent-cli-reference.md` in the arbigent
-repository.
+with defaults and precedence), see
+https://github.com/takahirom/arbigent/blob/main/arbigent-cli-reference.md
 
 Done when: both commands above succeed with no flags, and `git status` shows
 `.gitignore` updated and no `settings.local.yml` staged.
@@ -210,7 +210,7 @@ Real examples live in `sample-test/src/main/resources/projects/` in the arbigent
 repository (e.g. `e2e-test-android.yaml`).
 
 For an exhaustive field-by-field reference (every YAML key, its type and default),
-see `arbigent-yaml-reference.md` in the arbigent repository.
+see https://github.com/takahirom/arbigent/blob/main/arbigent-yaml-reference.md
 
 Done when: `arbigent scenarios --project-file=<file>` lists your scenario ids without errors.
 """.trimIndent(),

--- a/arbigent-yaml-reference.md
+++ b/arbigent-yaml-reference.md
@@ -1,0 +1,252 @@
+# Arbigent project YAML reference
+
+This is a complete reference for the fields in an arbigent **project file** (the YAML
+passed to commands via `--project-file`, or resolved from a `.arbigent/settings.yml`
+/ `.arbigent/settings.local.yml` file — `.yaml` variants are also accepted).
+
+> [!WARNING]
+> The YAML format is still under development and may change in the future.
+
+For a task-oriented introduction (how to write scenarios, variables, reusable
+scenarios), see `arbigent guide writing-yaml`. Real examples live in
+`sample-test/src/main/resources/projects/` (e.g. `e2e-test-android.yaml`,
+`nowinandroidsample.yaml`).
+
+## How to read this reference
+
+- The serializer is **not strict**: unknown keys are silently ignored, so a typo in an
+  optional field name does not fail the load — it just does nothing. Running
+  `arbigent scenarios --project-file=<file>` confirms the file loads and lists the
+  resulting scenario ids, but it cannot detect an ignored optional-key typo.
+- Defaults are **not written** when a file is saved (`encodeDefaults = false`), so a
+  real file usually shows only a subset of these keys. An optional field left out takes
+  its default; a required field left out fails decoding.
+- Sealed types (`type`, `initializationMethods`, `deviceFormFactor`,
+  `cacheStrategy.aiDecisionCacheStrategy`, `cleanupData`, launch argument values) are
+  tagged with a `type:` field that selects the variant.
+
+## Top level: project file
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `scenarios` | list of [Scenario](#scenario) | **required** | Scenarios to run. |
+| `reusableScenarios` | list of [Scenario](#scenario) | `[]` | Parameterized scenarios that other scenarios call via `uses`/`steps`. |
+| `fixedScenarios` | list of [FixedScenario](#fixedscenario) | `[]` | Named Maestro YAML snippets used by the `MaestroYaml` initialization method. |
+| `settings` | [Settings](#settings) | `{}` | Project-wide settings (prompts, cache, AI options). |
+
+## Scenario
+
+Used both in `scenarios` and `reusableScenarios`.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `id` | String | random UUID | Stable identifier used by `--scenario-ids` and `dependency`. Avoid `/`, `#`, `@`. |
+| `goal` | String (multiline) | `""` | Natural-language goal the AI agent tries to achieve. |
+| `type` | [ScenarioType](#scenariotype) | `Scenario` | Scenario kind (a `type:`-tagged object, not a scalar). |
+| `dependency` | String? | `null` | `id` of a scenario that must run first. |
+| `uses` | String? | `null` | `id` of a reusable scenario to invoke (single call). |
+| `with` | Map<String,String> | `{}` | Bindings for the reusable scenario's `inputs`. |
+| `steps` | list of [ReusableStep](#reusablestep) | `[]` | Multiple reusable-scenario calls in order. |
+| `inputs` | Map<String,[ReusableInput](#reusableinput)> | `{}` | Declared inputs (only meaningful on a `reusableScenarios` entry). |
+| `initializationMethods` | list of [InitializationMethod](#initializationmethod) | `[]` | Setup actions run before the goal. |
+| `initializeMethods` | [InitializationMethod](#initializationmethod) | `Noop` | **Deprecated**; use `initializationMethods`. |
+| `noteForHumans` | String (multiline) | `""` | Free-form note; not sent to the AI. |
+| `maxRetry` | Int | `3` | Retries on failure. |
+| `maxStep` | Int | `10` | Max AI steps per attempt. |
+| `tags` | Set of [Tag](#tag) | `[]` | Tags for `run --tags` (serialized as a sequence). |
+| `deviceFormFactor` | [DeviceFormFactor](#deviceformfactor) | `Unspecified` | Target form factor. |
+| `cleanupData` | [CleanupData](#cleanupdata) | `Noop` | **Legacy / no longer used** (kept for backward compatibility). |
+| `imageAssertionHistoryCount` | Int | `1` | Number of recent screenshots the image assertion looks at. |
+| `imageAssertions` | list of [ImageAssertion](#imageassertion) | `[]` | AI checks against the final screenshot(s). |
+| `userPromptTemplate` | String | built-in default | Overrides the per-step user prompt template. |
+| `aiOptions` | [AiOptions](#aioptions)? | `null` | Per-scenario AI options. |
+| `cacheOptions` | [CacheOptions](#cacheoptions)? | `null` | Per-scenario cache overrides. |
+| `additionalActions` | `List<String>?` | `null` | Extra actions available to the agent. |
+| `mcpOptions` | [McpOptions](#mcpoptions)? | `null` | Per-scenario MCP server enable/disable. |
+
+> A calling scenario (one that sets `uses`/`steps`) is validated at load time: `uses`
+> and `steps` are mutually exclusive, and it must NOT set `goal`, `maxStep`,
+> `initializationMethods`, `imageAssertions`, `userPromptTemplate`, `type: Execution`,
+> a non-default `imageAssertionHistoryCount`, or the legacy `initializeMethods` — those
+> belong to the reusable definition. Reusable definitions must NOT have `dependency` or
+> `tags`.
+
+### ScenarioType
+
+The `type` field is itself a `type:`-tagged object (property polymorphism), not a
+scalar. Variants: `Scenario` (default) and `Execution`, neither with extra fields:
+
+```yaml
+type:
+  type: "Execution"
+```
+
+### CleanupData
+
+Legacy scenario-level field, tagged by `type:`. Distinct from the `CleanupData`
+[initialization method](#initializationmethod).
+
+| `type` | Fields |
+|---|---|
+| `Noop` | (none) |
+| `Cleanup` | `packageName: String` |
+
+## Settings
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `prompt` | [Prompt](#prompt) | `{}` | System/user prompt configuration. |
+| `cacheStrategy` | [CacheStrategy](#cachestrategy) | `{}` | AI-decision caching. |
+| `aiOptions` | [AiOptions](#aioptions)? | `null` | Project-wide AI options. |
+| `mcpJson` | String (multiline) | `"{}"` | MCP server configuration as a JSON string. |
+| `deviceFormFactor` | [DeviceFormFactor](#deviceformfactor) | `Unspecified` | Default form factor for all scenarios. |
+| `additionalActions` | `List<String>?` | `null` | Project-wide extra actions. |
+
+### Prompt
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `systemPrompts` | list of String | built-in | System prompts for mobile/web. |
+| `systemPromptsForTv` | list of String | built-in | System prompts for TV form factor. |
+| `additionalSystemPrompts` | list of String | `[]` | Extra system prompts appended to the defaults. |
+| `userPromptTemplate` | String | built-in default | Per-step user prompt template. |
+| `appUiStructure` | String (multiline) | `""` | Description of the app's screens/navigation given to the AI. |
+| `scenarioGenerationCustomInstruction` | String (multiline) | `""` | Custom instruction used when generating scenarios. |
+
+### CacheStrategy
+
+`cacheStrategy.aiDecisionCacheStrategy` selects an [AiDecisionCacheStrategy](#aidecisioncachestrategy)
+(default `Disabled`).
+
+#### AiDecisionCacheStrategy
+
+Tagged by `type:`.
+
+| `type` | Fields |
+|---|---|
+| `Disabled` | (none) |
+| `InMemory` | `maxCacheSize: Long = 100`, `expireAfterWriteMs: Long` (default 24h in ms) |
+| `Disk` | `maxCacheSize: Long` (default `524288000`, i.e. 500 MiB) |
+
+## AiOptions
+
+Available on a scenario and on `settings`.
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `temperature` | Double? | `null` | Sampling temperature. |
+| `imageDetail` | `high` \| `low` | `null` | Image detail hint sent to the model. |
+| `imageFormat` | `png` \| `webp` \| `lossy_webp` | `null` | Screenshot encoding sent to the model. |
+| `historicalStepLimit` | Int? | `null` | How many prior steps to include in the prompt. |
+| `extraBody` | `JsonObject?` (YAML map) | `null` | Extra fields merged into the request body. |
+| `useResponsesApi` | Boolean? | `null` | Use the OpenAI Responses API. |
+
+## InitializationMethod
+
+Each entry is tagged by `type:`.
+
+| `type` | Fields | Description |
+|---|---|---|
+| `LaunchApp` | `packageName: String` (required), `launchArguments: Map<String,`[ArgumentValue](#argumentvalue)`> = {}` | Launch an app. |
+| `CleanupData` | `packageName: String` (required) | Clear app data. |
+| `Back` | `times: Int = 3` | Press back N times. |
+| `Wait` | `durationMs: Long` (required) | Wait a fixed duration. |
+| `OpenLink` | `link: String` (required) | Open a URL/deeplink. |
+| `MaestroYaml` | `scenarioId: String` (required), `yamlContent: String? = null` | Run a `fixedScenarios` entry (or inline Maestro YAML). |
+| `Noop` | (none) | Do nothing. |
+
+### ArgumentValue
+
+Values in `launchArguments`, tagged by `type:`.
+
+| `type` | Fields |
+|---|---|
+| `String` | `value: String` |
+| `Int` | `value: Int` |
+| `Boolean` | `value: Boolean` |
+
+## ImageAssertion
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `assertionPrompt` | String | **required** | Statement the AI verifies against the screenshot. |
+| `requiredFulfillmentPercent` | Int | `80` | Minimum confidence for the assertion to pass. |
+
+## CacheOptions
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `forceCacheDisabled` | Boolean | `false` | Disable AI-decision caching for this scenario. |
+
+## McpOptions
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `mcpServerOptions` | `List<`[McpServerOption](#mcpserveroption)`>?` | `null` | Per-server enable/disable. |
+
+### McpServerOption
+
+| Key | Type | Description |
+|---|---|---|
+| `name` | String | Server name (must match a key in `settings.mcpJson`). |
+| `enabled` | Boolean | Whether the server is enabled for this scenario. |
+
+## FixedScenario
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `id` | String | random UUID | Identifier. |
+| `type` | String | `"maestro yaml"` | Snippet type. |
+| `title` | String | **required** | Human-readable title. |
+| `description` | String | **required** | Human-readable description. |
+| `yamlText` | String (multiline) | **required** | The Maestro YAML body. |
+
+## ReusableStep
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `uses` | String | **required** | `id` of the reusable scenario to invoke. |
+| `with` | Map<String,String> | `{}` | Input bindings for that scenario. |
+
+## ReusableInput
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `required` | Boolean | `false` | Whether the input must be supplied. |
+| `default` | String? | `null` | Value used when not supplied. |
+
+## Tag
+
+| Key | Type | Description |
+|---|---|---|
+| `name` | String | Tag name; matched by `run --tags`. |
+
+## DeviceFormFactor
+
+Tagged by `type:`: `Mobile`, `Tv`, or `Unspecified` (default). No other fields.
+
+## Minimal example
+
+```yaml
+scenarios:
+- id: "launch-settings"
+  goal: "Open the Settings app and confirm the top screen is shown"
+  initializationMethods:
+  - type: "CleanupData"
+    packageName: "com.android.settings"
+  - type: "LaunchApp"
+    packageName: "com.android.settings"
+  tags:
+  - name: "Settings"
+- id: "open-about-page"
+  goal: "Scroll down and open the 'About emulated device' page. Be careful not to open other pages"
+  dependency: "launch-settings"
+  maxStep: 15
+  imageAssertions:
+  - assertionPrompt: "The About page is displayed"
+    requiredFulfillmentPercent: 80
+settings:
+  prompt:
+    appUiStructure: |-
+      The Settings app opens on a scrollable list of top-level entries...
+```


### PR DESCRIPTION
# What
Add two Markdown reference documents at the repo root, and link to them from the README and the `guide` command:

- `arbigent-yaml-reference.md` — every project-YAML field with its type, default, and description (scenarios, settings, initialization methods, assertions, reusable scenarios, MCP, etc.).
- `arbigent-cli-reference.md` — a table mapping each CLI flag to its `.arbigent/settings*.yml` key and environment variable, plus the resolution precedence.

# Why
The project-YAML fields and the CLI-flag ↔ settings-key ↔ env-var relationship were only documented in prose scattered across the README and `arbigent guide`. A single field-by-field reference for each makes the full surface discoverable and easy to look up.