### PR TITLE
Thread iOS real-device config through discovery instead of a global singleton

### DIFF
--- a/arbigent-cli/src/main/kotlin/CommonOptions.kt
+++ b/arbigent-cli/src/main/kotlin/CommonOptions.kt
@@ -172,20 +172,21 @@ fun connectDevice(
           ArbigentDeviceOs.entries
             .joinToString(", ") { it.name.toLowerCasePreservingASCIIRules() }
         }")
-  // Publish iOS real-device options for discovery/connection to read. Only relevant for --os=ios
-  // with a physical iPhone; simulators and other OSes ignore it.
-  ArbigentIosRealDeviceSettings.current = ArbigentIosRealDeviceConfiguration(
+  // iOS real-device options, threaded into discovery so each discovered IosReal carries them to
+  // connection time. Only relevant for --os=ios with a physical iPhone; simulators and other OSes
+  // ignore it.
+  val iosConfig = ArbigentIosRealDeviceConfiguration(
     appleTeamId = iosAppleTeamId?.takeIf { it.isNotBlank() },
     deviceId = iosRealDeviceId?.takeIf { it.isNotBlank() },
     port = iosRealDevicePort,
   )
-  val candidates = fetchAvailableDevicesByOs(deviceOs)
+  val candidates = fetchAvailableDevicesByOs(deviceOs, iosConfig = iosConfig)
   val chosen = candidates.firstOrNull() ?: throw IllegalArgumentException("No available device found")
   // When the device we would connect is a physical iPhone and the user gave no explicit id, refuse to
   // guess between several connected iPhones (devicectl ordering is not stable). List the candidates by
   // a short, masked UDID prefix so the user can pick one with --ios-real-device-id.
   if (chosen is ArbigentAvailableDevice.IosReal &&
-    ArbigentIosRealDeviceSettings.resolvedDeviceId() == null
+    ArbigentIosRealDeviceSettings.resolvedDeviceId(iosConfig) == null
   ) {
     val realCandidates = candidates.filterIsInstance<ArbigentAvailableDevice.IosReal>()
     if (realCandidates.size > 1) {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceOs.kt
@@ -173,6 +173,9 @@ public sealed interface ArbigentAvailableDevice {
     private val coreDeviceIdentifier: String,
     private val hardwareUdid: String,
     override val name: String,
+    // Resolved real-device knobs, baked in at discovery so connection reads them off this instance
+    // rather than a process-wide global. Defaults keep env/auto-detect fallbacks in effect.
+    private val config: ArbigentIosRealDeviceConfiguration = ArbigentIosRealDeviceConfiguration(),
   ) : ArbigentAvailableDevice {
     override val deviceOs: ArbigentDeviceOs = ArbigentDeviceOs.Ios
 
@@ -186,9 +189,8 @@ public sealed interface ArbigentAvailableDevice {
     public val maskedUdid: String get() = hardwareUdid.take(8) + "…"
 
     override fun connectToDevice(): ArbigentDevice {
-      val config = ArbigentIosRealDeviceSettings.current
       val host = "127.0.0.1"
-      val port = ArbigentIosRealDeviceSettings.resolvedPort()
+      val port = ArbigentIosRealDeviceSettings.resolvedPort(config)
       val teamId = IosCodeSigningTeamResolver.resolve(config)
       val productsDir = IosRealDriverProducts(teamId = teamId, deviceUdid = hardwareUdid)
         .resolveBuildProductsDir()

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/DeviceFinder.kt
@@ -11,6 +11,10 @@ public fun fetchAvailableDevicesByOs(
   // opt-in (see below). The UI lets the user pick explicitly, so it passes true to list every
   // connected iOS device (booted simulators and paired iPhones) at once.
   includeAllIosDevices: Boolean = false,
+  // iOS real-device knobs (Apple team id / device id / port), threaded explicitly from the caller
+  // and baked into each discovered IosReal so connection reads them off the instance rather than a
+  // global. The default keeps env-variable fallbacks in effect for callers with no explicit config.
+  iosConfig: ArbigentIosRealDeviceConfiguration = ArbigentIosRealDeviceConfiguration(),
 ): List<ArbigentAvailableDevice> {
   return when (deviceType) {
     ArbigentDeviceOs.Android -> {
@@ -22,12 +26,12 @@ public fun fetchAvailableDevicesByOs(
       if (includeAllIosDevices) {
         // Interactive selection: surface both kinds. Always wake tunnels so a paired iPhone shows
         // up even when a simulator is also booted.
-        fetchConnectedIosRealDevices(wakeTunnels = true) + simulators
+        fetchConnectedIosRealDevices(wakeTunnels = true, config = iosConfig) + simulators
       } else {
-        val optedIn = isRealIosDeviceOptedIn()
+        val optedIn = isRealIosDeviceOptedIn(iosConfig)
         // Wake the CoreDevice tunnel (read-only) when the user opted in, or when there is no booted
         // simulator to fall back on so a lone connected iPhone still "just works".
-        val realDevices = fetchConnectedIosRealDevices(wakeTunnels = optedIn || simulators.isEmpty())
+        val realDevices = fetchConnectedIosRealDevices(wakeTunnels = optedIn || simulators.isEmpty(), config = iosConfig)
         // Prefer a physical device only when the user has opted in (Apple team id or a specific
         // real-device id). Otherwise a booted simulator wins, keeping the common `--os=ios` dev flow
         // unchanged. connectDevice() picks the first entry.
@@ -69,8 +73,9 @@ private fun fetchBootedIosSimulators(): List<ArbigentAvailableDevice.IOS> =
 public fun fetchConnectedIosRealDevices(
   wakeTunnels: Boolean = true,
   executor: ArbigentCommandExecutor = DefaultArbigentCommandExecutor(),
+  config: ArbigentIosRealDeviceConfiguration = ArbigentIosRealDeviceConfiguration(),
 ): List<ArbigentAvailableDevice.IosReal> {
-  val deviceIdFilter = ArbigentIosRealDeviceSettings.resolvedDeviceId()
+  val deviceIdFilter = ArbigentIosRealDeviceSettings.resolvedDeviceId(config)
   return try {
     val localDevice = util.LocalIOSDevice()
     var devices = localDevice.listDeviceViaDeviceCtl()
@@ -103,6 +108,7 @@ public fun fetchConnectedIosRealDevices(
           coreDeviceIdentifier = identifier,
           hardwareUdid = udid,
           name = device.deviceProperties?.name ?: udid,
+          config = config,
         )
       }
   } catch (e: Exception) {
@@ -124,10 +130,7 @@ private fun wakeIosRealDeviceTunnels(identifiers: List<String>, executor: Arbige
   }
 }
 
-private fun isRealIosDeviceOptedIn(env: (String) -> String? = System::getenv): Boolean {
-  val config = ArbigentIosRealDeviceSettings.current
-  if (!config.appleTeamId.isNullOrBlank()) return true
-  if (!config.deviceId.isNullOrBlank()) return true
-  if (!env(ArbigentIosRealDeviceSettings.ENV_APPLE_TEAM_ID).isNullOrBlank()) return true
-  return !env(ArbigentIosRealDeviceSettings.ENV_DEVICE_ID).isNullOrBlank()
-}
+private fun isRealIosDeviceOptedIn(
+  config: ArbigentIosRealDeviceConfiguration,
+  env: (String) -> String? = System::getenv,
+): Boolean = ArbigentIosRealDeviceSettings.isOptedIn(config, env)

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosCodeSigningTeamResolver.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosCodeSigningTeamResolver.kt
@@ -28,7 +28,7 @@ public object IosCodeSigningTeamResolver {
     Regex("""-----BEGIN CERTIFICATE-----.*?-----END CERTIFICATE-----""", RegexOption.DOT_MATCHES_ALL)
 
   public fun resolve(
-    config: ArbigentIosRealDeviceConfiguration = ArbigentIosRealDeviceSettings.current,
+    config: ArbigentIosRealDeviceConfiguration,
     env: (String) -> String? = System::getenv,
     executor: ArbigentCommandExecutor = DefaultArbigentCommandExecutor(),
   ): String {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDeviceConfiguration.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/IosRealDeviceConfiguration.kt
@@ -4,9 +4,10 @@ package io.github.takahirom.arbigent
  * Runtime configuration for the iOS real-device (physical iPhone) XCTest backend.
  *
  * These knobs only apply to physical devices discovered via `xcrun devicectl`; simulators are
- * unaffected. Values flow from the CLI/settings into [ArbigentIosRealDeviceSettings.current] before
- * device discovery, and each field falls back to an environment variable and finally a sensible
- * default (see [ArbigentIosRealDeviceSettings]).
+ * unaffected. The CLI/settings build one of these and thread it explicitly through discovery
+ * ([fetchAvailableDevicesByOs]) into each discovered [ArbigentAvailableDevice.IosReal], which
+ * carries it to connection time. Each field falls back to an environment variable and finally a
+ * sensible default (see the resolver functions on [ArbigentIosRealDeviceSettings]).
  */
 public class ArbigentIosRealDeviceConfiguration(
   /**
@@ -24,9 +25,10 @@ public class ArbigentIosRealDeviceConfiguration(
 )
 
 /**
- * Process-wide holder for [ArbigentIosRealDeviceConfiguration], mirroring [ArbigentFiles]. The CLI
- * populates [current] from options/settings; discovery and connection read it. Environment-variable
- * fallbacks live here so both the holder default and callers agree on precedence.
+ * Environment-variable names, the default port, and the resolver functions for
+ * [ArbigentIosRealDeviceConfiguration]. This is a stateless namespace: every resolver takes the
+ * config explicitly (there is no process-wide `current`), so precedence lives in one place while the
+ * config itself is threaded through discovery and carried on each device instance.
  */
 public object ArbigentIosRealDeviceSettings {
   public const val ENV_APPLE_TEAM_ID: String = "ARBIGENT_IOS_XCTEST_APPLE_TEAM_ID"
@@ -37,19 +39,23 @@ public object ArbigentIosRealDeviceSettings {
   // PORT env is unset). Keeping this as the host/iproxy port keeps both ends in sync.
   public const val DEFAULT_PORT: Int = 22087
 
-  public var current: ArbigentIosRealDeviceConfiguration = ArbigentIosRealDeviceConfiguration()
-
   /** Resolved device UDID filter: explicit config, then env, else null (auto-select single device). */
-  public fun resolvedDeviceId(env: (String) -> String? = System::getenv): String? =
-    current.deviceId?.takeIf { it.isNotBlank() } ?: env(ENV_DEVICE_ID)?.takeIf { it.isNotBlank() }
+  public fun resolvedDeviceId(
+    config: ArbigentIosRealDeviceConfiguration,
+    env: (String) -> String? = System::getenv,
+  ): String? =
+    config.deviceId?.takeIf { it.isNotBlank() } ?: env(ENV_DEVICE_ID)?.takeIf { it.isNotBlank() }
 
   /**
    * Resolved runner port: explicit config, then env, else [DEFAULT_PORT]. A configured or env value
    * outside `1..65535` — or non-numeric env text — fails loudly rather than silently falling back to
    * the default, which would mask a misconfiguration.
    */
-  public fun resolvedPort(env: (String) -> String? = System::getenv): Int {
-    current.port?.let { return requireValidPort(it) { "configured iOS real-device port" } }
+  public fun resolvedPort(
+    config: ArbigentIosRealDeviceConfiguration,
+    env: (String) -> String? = System::getenv,
+  ): Int {
+    config.port?.let { return requireValidPort(it) { "configured iOS real-device port" } }
     val raw = env(ENV_PORT)?.trim()
     if (!raw.isNullOrEmpty()) {
       val parsed = raw.toIntOrNull()
@@ -57,6 +63,21 @@ public object ArbigentIosRealDeviceSettings {
       return requireValidPort(parsed) { ENV_PORT }
     }
     return DEFAULT_PORT
+  }
+
+  /**
+   * Whether the user opted into physical-iPhone selection — an explicit Apple team id or device id
+   * (config or env). Discovery uses this to decide whether a physical device should be preferred
+   * over a booted simulator.
+   */
+  public fun isOptedIn(
+    config: ArbigentIosRealDeviceConfiguration,
+    env: (String) -> String? = System::getenv,
+  ): Boolean {
+    if (!config.appleTeamId.isNullOrBlank()) return true
+    if (!config.deviceId.isNullOrBlank()) return true
+    if (!env(ENV_APPLE_TEAM_ID).isNullOrBlank()) return true
+    return !env(ENV_DEVICE_ID).isNullOrBlank()
   }
 
   private inline fun requireValidPort(port: Int, name: () -> String): Int {

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
@@ -112,22 +112,25 @@ class IosRealDeviceTest {
 
   @Test
   fun resolvedPort_defaultsToRunnerPort() {
-    ArbigentIosRealDeviceSettings.current = ArbigentIosRealDeviceConfiguration()
-    assertEquals(ArbigentIosRealDeviceSettings.DEFAULT_PORT, ArbigentIosRealDeviceSettings.resolvedPort { null })
+    assertEquals(
+      ArbigentIosRealDeviceSettings.DEFAULT_PORT,
+      ArbigentIosRealDeviceSettings.resolvedPort(ArbigentIosRealDeviceConfiguration()) { null },
+    )
   }
 
   @Test
   fun resolvedPort_configWinsOverEnv() {
-    ArbigentIosRealDeviceSettings.current = ArbigentIosRealDeviceConfiguration(port = 30000)
-    assertEquals(30000, ArbigentIosRealDeviceSettings.resolvedPort { "40000" })
+    assertEquals(
+      30000,
+      ArbigentIosRealDeviceSettings.resolvedPort(ArbigentIosRealDeviceConfiguration(port = 30000)) { "40000" },
+    )
   }
 
   @Test
   fun resolvedDeviceId_fallsBackToEnv() {
-    ArbigentIosRealDeviceSettings.current = ArbigentIosRealDeviceConfiguration(deviceId = null)
     assertEquals(
       "UDID-FROM-ENV",
-      ArbigentIosRealDeviceSettings.resolvedDeviceId { name ->
+      ArbigentIosRealDeviceSettings.resolvedDeviceId(ArbigentIosRealDeviceConfiguration(deviceId = null)) { name ->
         if (name == ArbigentIosRealDeviceSettings.ENV_DEVICE_ID) "UDID-FROM-ENV" else null
       },
     )


### PR DESCRIPTION
Removes the process-wide mutable `ArbigentIosRealDeviceSettings.current` and threads the iOS real-device config explicitly.

## Problem
`ArbigentIosRealDeviceSettings.current` was a process-wide `var`, written once by the CLI (`connectDevice`) and read deep in discovery, connection, and the team resolver. Reading what port/team/deviceId `IosReal.connectToDevice()` would use required knowing an unrelated earlier call had mutated a global; tests had to mutate (and race on) that global; and the UI never set it, so UI real-device connections silently saw only the default config.

## Change
- Delete `var current`. `ArbigentIosRealDeviceSettings` becomes a stateless namespace: `resolvedDeviceId(config, env)`, `resolvedPort(config, env)`, and a new `isOptedIn(config, env)` all take the config explicitly, keeping precedence/validation in one place.
- `fetchAvailableDevicesByOs(..., iosConfig)` threads the config through discovery and bakes it into each `ArbigentAvailableDevice.IosReal` (new `config` field), so `connectToDevice()` reads `this.config`.
- CLI `connectDevice` builds the config from its options and passes it into discovery (no global write).
- `IosCodeSigningTeamResolver.resolve(config)` no longer defaults to the global.
- Tests pass config directly instead of mutating the singleton.

Env-variable fallbacks are unchanged (a default/empty config still falls back to env), so the UI and env-driven flows behave exactly as before.

## Verification
- `:arbigent-core`, `:arbigent-cli`, `:arbigent-ui` compile.
- `IosRealDeviceTest` green (port/device-id resolution now asserted through explicit config).

This is the first of a series of "eliminate process-wide mutable singletons" refactors identified in an architecture review; it establishes the thread-the-config pattern the follow-ups reuse.