### PR TITLE
Replace the coroutine dispatcher singleton with composition-root injection

### DIFF
--- a/arbigent-cli/src/main/kotlin/CommonOptions.kt
+++ b/arbigent-cli/src/main/kotlin/CommonOptions.kt
@@ -6,6 +6,7 @@ import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.CliktError
 import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.types.choice
+import kotlinx.coroutines.CoroutineDispatcher
 import io.github.takahirom.arbigent.*
 import io.ktor.client.request.*
 import io.ktor.util.*
@@ -140,6 +141,7 @@ fun loadArbigentProject(
   aiFactory: () -> ArbigentAi,
   deviceFactory: () -> ArbigentDevice,
   appSettings: ArbigentAppSettings,
+  dispatcher: CoroutineDispatcher,
 ): ArbigentProject {
   return if (isJourneyProjectSource(projectFile)) {
     val projectFileContent = ArbigentJourneyXmlImporter.loadProjectContent(File(projectFile))
@@ -148,6 +150,7 @@ fun loadArbigentProject(
       aiFactory = aiFactory,
       deviceFactory = deviceFactory,
       appSettings = appSettings,
+      dispatcher = dispatcher,
     )
   } else {
     ArbigentProject(
@@ -155,6 +158,7 @@ fun loadArbigentProject(
       aiFactory = aiFactory,
       deviceFactory = deviceFactory,
       appSettings = appSettings,
+      dispatcher = dispatcher,
     )
   }
 }

--- a/arbigent-cli/src/main/kotlin/RunCommand.kt
+++ b/arbigent-cli/src/main/kotlin/RunCommand.kt
@@ -29,6 +29,7 @@ import com.jakewharton.mosaic.ui.Column
 import com.jakewharton.mosaic.ui.Row
 import com.jakewharton.mosaic.ui.Text
 import io.github.takahirom.arbigent.*
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
@@ -160,11 +161,14 @@ class ArbigentRunCommand : CliktCommand(name = "run") {
       path = path,
       variables = variables
     )
+    // Composition root for the `run` command: the one place the production dispatcher is created and
+    // threaded down (no per-signature defaults, no process-wide global).
     val arbigentProject = loadArbigentProject(
       projectFile = projectFilePath,
       aiFactory = { ai },
       deviceFactory = { device ?: throw UnsupportedOperationException("Device not available in dry-run mode") },
-      appSettings = appSettings
+      appSettings = appSettings,
+      dispatcher = Dispatchers.Default,
     )
     if (scenarioIds.isNotEmpty() && tags.isNotEmpty()) {
       throw IllegalArgumentException("Cannot specify both scenario IDs and tags. Please create an issue if you need this feature.")

--- a/arbigent-cli/src/main/kotlin/RunTaskCommand.kt
+++ b/arbigent-cli/src/main/kotlin/RunTaskCommand.kt
@@ -16,6 +16,7 @@ import com.jakewharton.mosaic.ui.Color.Companion.White
 import com.jakewharton.mosaic.ui.Column
 import com.jakewharton.mosaic.ui.Text
 import io.github.takahirom.arbigent.*
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import java.io.File
@@ -97,7 +98,9 @@ class ArbigentRunTaskCommand : CliktCommand(name = "task") {
         )
       )
       val appSettings = CliAppSettings(workingDirectory = workingDirectory, path = null)
-      val arbigentProject = ArbigentProject(projectFileContent, aiFactory = { ai }, deviceFactory = { device }, appSettings = appSettings)
+      // Composition root for the `run task` command: the one place the production dispatcher is
+      // created and threaded down (no per-signature defaults, no process-wide global).
+      val arbigentProject = ArbigentProject(projectFileContent, aiFactory = { ai }, deviceFactory = { device }, appSettings = appSettings, dispatcher = Dispatchers.Default)
       val scenarios = arbigentProject.scenarios
 
       Runtime.getRuntime().addShutdownHook(object : Thread() {

--- a/arbigent-cli/src/main/kotlin/ScenariosCommand.kt
+++ b/arbigent-cli/src/main/kotlin/ScenariosCommand.kt
@@ -2,6 +2,8 @@
 
 package io.github.takahirom.arbigent.cli
 
+import kotlinx.coroutines.Dispatchers
+
 import com.github.ajalt.clikt.core.CliktCommand
 import io.github.takahirom.arbigent.*
 
@@ -32,9 +34,12 @@ class ArbigentScenariosCommand : CliktCommand(name = "scenarios") {
       appSettings = CliAppSettings(
         workingDirectory = workingDirectory,
         path = null,
-      )
+      ),
+      // Read-only command: the project builds executors on construction, so a dispatcher is required
+      // even though no scenario is run here.
+      dispatcher = Dispatchers.Default,
     )
-    
+
     arbigentInfoLog("Scenarios in $projectFile:")
     arbigentProject.scenarios.forEach { scenario ->
       arbigentInfoLog("- ${scenario.id}: ${scenario.agentTasks.lastOrNull()?.goal?.take(80)}...")

--- a/arbigent-cli/src/main/kotlin/TagsCommand.kt
+++ b/arbigent-cli/src/main/kotlin/TagsCommand.kt
@@ -2,6 +2,8 @@
 
 package io.github.takahirom.arbigent.cli
 
+import kotlinx.coroutines.Dispatchers
+
 import com.github.ajalt.clikt.core.CliktCommand
 import io.github.takahirom.arbigent.*
 
@@ -24,9 +26,12 @@ class ArbigentTagsCommand : CliktCommand(name = "tags") {
       appSettings = CliAppSettings(
         workingDirectory = workingDirectory,
         path = null,
-      )
+      ),
+      // Read-only command: the project builds executors on construction, so a dispatcher is required
+      // even though no scenario is run here.
+      dispatcher = Dispatchers.Default,
     )
-    
+
     val allTags = arbigentProject.scenarios
       .flatMap { it.tags }
       .map { it.name }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -29,9 +29,10 @@ import kotlin.time.Duration.Companion.hours
 
 public class ArbigentAgent(
   agentConfig: AgentConfig,
-  // Injected so tests can drive execution on a TestDispatcher instead of mutating a process-wide
-  // global. The scenario executor threads its own dispatcher in here.
-  dispatcher: CoroutineDispatcher = Dispatchers.Default,
+  // Required (no default): the scenario executor threads its own dispatcher in, which ultimately
+  // originates at the application composition root. Keeping it mandatory means the compiler rejects
+  // any construction path that forgets to propagate it, so there is no silent fallback.
+  dispatcher: CoroutineDispatcher,
 ) {
   private val ai by lazy { agentConfig.aiFactory() }
   public val device: ArbigentDevice by lazy { agentConfig.deviceFactory() }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -28,7 +28,10 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.hours
 
 public class ArbigentAgent(
-  agentConfig: AgentConfig
+  agentConfig: AgentConfig,
+  // Injected so tests can drive execution on a TestDispatcher instead of mutating a process-wide
+  // global. The scenario executor threads its own dispatcher in here.
+  dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
   private val ai by lazy { agentConfig.aiFactory() }
   public val device: ArbigentDevice by lazy { agentConfig.deviceFactory() }
@@ -132,7 +135,7 @@ public class ArbigentAgent(
   }
   
   private val coroutineScope =
-    CoroutineScope(ArbigentCoroutinesDispatcher.dispatcher + SupervisorJob())
+    CoroutineScope(dispatcher + SupervisorJob())
   private var job: Job? = null
   private val arbigentContextHistoryStateFlow: MutableStateFlow<List<ArbigentContextHolder>> =
     MutableStateFlow(listOf())

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentCoroutinesDispatcher.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentCoroutinesDispatcher.kt
@@ -1,8 +1,0 @@
-package io.github.takahirom.arbigent
-
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-
-public object ArbigentCoroutinesDispatcher {
-  public var dispatcher: CoroutineDispatcher = Dispatchers.Default
-}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
@@ -3,7 +3,6 @@ package io.github.takahirom.arbigent
 import io.github.takahirom.arbigent.result.ArbigentProjectExecutionResult
 import io.github.takahirom.arbigent.result.ArbigentScenarioDeviceFormFactor
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -17,10 +16,9 @@ public class ArbigentProject(
   public val settings: ArbigentProjectSettings,
   initialScenarios: List<ArbigentScenario>,
   public val appSettings: ArbigentAppSettings,
-  // Dispatcher for the per-scenario executors this project creates. Defaults to Dispatchers.Default
-  // (unchanged production behavior); tests inject a TestDispatcher so scenario execution runs on the
-  // same virtual clock the test drives, instead of the former process-wide dispatcher global.
-  dispatcher: CoroutineDispatcher = Dispatchers.Default,
+  // Required: dispatcher for the per-scenario executors this project creates, originating at the
+  // application composition root. No default so the compiler rejects any path that forgets it.
+  dispatcher: CoroutineDispatcher,
 ) {
   private val _scenarioAssignmentsFlow =
     MutableStateFlow<List<ArbigentScenarioAssignment>>(listOf())
@@ -35,7 +33,7 @@ public class ArbigentProject(
   init {
     val projectDispatcher = dispatcher
     _scenarioAssignmentsFlow.value = initialScenarios.map { scenario ->
-      ArbigentScenarioAssignment(scenario, ArbigentScenarioExecutor { this.dispatcher = projectDispatcher })
+      ArbigentScenarioAssignment(scenario, ArbigentScenarioExecutor(projectDispatcher))
     }
   }
 
@@ -137,7 +135,7 @@ public fun ArbigentProject(
   aiFactory: () -> ArbigentAi,
   deviceFactory: () -> ArbigentDevice,
   appSettings: ArbigentAppSettings,
-  dispatcher: CoroutineDispatcher = Dispatchers.Default,
+  dispatcher: CoroutineDispatcher,
 ): ArbigentProject {
   return ArbigentProject(
     settings = projectFileContent.settings,
@@ -163,7 +161,7 @@ public fun ArbigentProject(
   aiFactory: () -> ArbigentAi,
   deviceFactory: () -> ArbigentDevice,
   appSettings: ArbigentAppSettings,
-  dispatcher: CoroutineDispatcher = Dispatchers.Default,
+  dispatcher: CoroutineDispatcher,
 ): ArbigentProject {
   val projectContentFileContent = ArbigentProjectSerializer().load(file)
   return ArbigentProject(projectContentFileContent, aiFactory, deviceFactory, appSettings, dispatcher)

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
@@ -2,6 +2,8 @@ package io.github.takahirom.arbigent
 
 import io.github.takahirom.arbigent.result.ArbigentProjectExecutionResult
 import io.github.takahirom.arbigent.result.ArbigentScenarioDeviceFormFactor
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asSharedFlow
@@ -14,7 +16,11 @@ public class FailedToArchiveException(message: String) : RuntimeException(messag
 public class ArbigentProject(
   public val settings: ArbigentProjectSettings,
   initialScenarios: List<ArbigentScenario>,
-  public val appSettings: ArbigentAppSettings
+  public val appSettings: ArbigentAppSettings,
+  // Dispatcher for the per-scenario executors this project creates. Defaults to Dispatchers.Default
+  // (unchanged production behavior); tests inject a TestDispatcher so scenario execution runs on the
+  // same virtual clock the test drives, instead of the former process-wide dispatcher global.
+  dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
   private val _scenarioAssignmentsFlow =
     MutableStateFlow<List<ArbigentScenarioAssignment>>(listOf())
@@ -27,8 +33,9 @@ public class ArbigentProject(
   public val scenarios: List<ArbigentScenario> get() = scenarioAssignments().map { it.scenario }
 
   init {
+    val projectDispatcher = dispatcher
     _scenarioAssignmentsFlow.value = initialScenarios.map { scenario ->
-      ArbigentScenarioAssignment(scenario, ArbigentScenarioExecutor())
+      ArbigentScenarioAssignment(scenario, ArbigentScenarioExecutor { this.dispatcher = projectDispatcher })
     }
   }
 
@@ -129,7 +136,8 @@ public fun ArbigentProject(
   projectFileContent: ArbigentProjectFileContent,
   aiFactory: () -> ArbigentAi,
   deviceFactory: () -> ArbigentDevice,
-  appSettings: ArbigentAppSettings
+  appSettings: ArbigentAppSettings,
+  dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ): ArbigentProject {
   return ArbigentProject(
     settings = projectFileContent.settings,
@@ -145,7 +153,8 @@ public fun ArbigentProject(
         reusableScenarios = projectFileContent.reusableScenarios
       )
     },
-    appSettings = appSettings
+    appSettings = appSettings,
+    dispatcher = dispatcher,
   )
 }
 
@@ -153,10 +162,11 @@ public fun ArbigentProject(
   file: File,
   aiFactory: () -> ArbigentAi,
   deviceFactory: () -> ArbigentDevice,
-  appSettings: ArbigentAppSettings
+  appSettings: ArbigentAppSettings,
+  dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ): ArbigentProject {
   val projectContentFileContent = ArbigentProjectSerializer().load(file)
-  return ArbigentProject(projectContentFileContent, aiFactory, deviceFactory, appSettings)
+  return ArbigentProject(projectContentFileContent, aiFactory, deviceFactory, appSettings, dispatcher)
 }
 
 public data class ArbigentScenario(

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -65,10 +65,8 @@ public sealed interface ArbigentScenarioExecutorState {
 }
 
 public class ArbigentScenarioExecutor internal constructor(
-  // Injected (via Builder, which defaults it to Dispatchers.Default) so tests drive execution on a
-  // TestDispatcher rather than mutating a process-wide global. Threaded into every ArbigentAgent
-  // this executor creates. No default here so the no-arg `ArbigentScenarioExecutor()` factory
-  // function stays unambiguous against this constructor.
+  // Required: threaded into every ArbigentAgent this executor creates, originating at the
+  // application composition root. No default so the compiler rejects any path that forgets it.
   private val dispatcher: CoroutineDispatcher,
 ) {
   private val _taskAssignmentsStateFlow =
@@ -290,17 +288,21 @@ public class ArbigentScenarioExecutor internal constructor(
     }"
   }
 
-  public class Builder {
-    // Defaults to Dispatchers.Default; tests set a TestDispatcher so execution is deterministic.
-    public var dispatcher: CoroutineDispatcher = Dispatchers.Default
+  public class Builder(
+    // Required — supplied by the ArbigentScenarioExecutor(dispatcher) factory.
+    public val dispatcher: CoroutineDispatcher,
+  ) {
     public fun build(): ArbigentScenarioExecutor {
       return ArbigentScenarioExecutor(dispatcher)
     }
   }
 }
 
-public fun ArbigentScenarioExecutor(block: ArbigentScenarioExecutor.Builder.() -> Unit = {}): ArbigentScenarioExecutor {
-  val builder = ArbigentScenarioExecutor.Builder()
+public fun ArbigentScenarioExecutor(
+  dispatcher: CoroutineDispatcher,
+  block: ArbigentScenarioExecutor.Builder.() -> Unit = {},
+): ArbigentScenarioExecutor {
+  val builder = ArbigentScenarioExecutor.Builder(dispatcher)
   builder.block()
   return builder.build()
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -64,7 +64,13 @@ public sealed interface ArbigentScenarioExecutorState {
   }
 }
 
-public class ArbigentScenarioExecutor {
+public class ArbigentScenarioExecutor internal constructor(
+  // Injected (via Builder, which defaults it to Dispatchers.Default) so tests drive execution on a
+  // TestDispatcher rather than mutating a process-wide global. Threaded into every ArbigentAgent
+  // this executor creates. No default here so the no-arg `ArbigentScenarioExecutor()` factory
+  // function stays unambiguous against this constructor.
+  private val dispatcher: CoroutineDispatcher,
+) {
   private val _taskAssignmentsStateFlow =
     MutableStateFlow<List<ArbigentTaskAssignment>>(listOf())
   private val _taskAssignmentsHistoryStateFlow =
@@ -81,7 +87,7 @@ public class ArbigentScenarioExecutor {
   public fun taskAssignments(): List<ArbigentTaskAssignment> = _taskAssignmentsStateFlow.value
   private var executeJob: Job? = null
   private val coroutineScope =
-    CoroutineScope(ArbigentCoroutinesDispatcher.dispatcher + SupervisorJob())
+    CoroutineScope(dispatcher + SupervisorJob())
   private val _arbigentScenarioRunningInfoStateFlow: MutableStateFlow<ArbigentScenarioRunningInfo?> =
     MutableStateFlow(null)
   public val runningInfoFlow: StateFlow<ArbigentScenarioRunningInfo?> =
@@ -192,7 +198,7 @@ public class ArbigentScenarioExecutor {
           it.agent.cancel()
         }
         _taskAssignmentsStateFlow.value = scenario.agentTasks.map { task ->
-          ArbigentTaskAssignment(task, ArbigentAgent(task.agentConfig))
+          ArbigentTaskAssignment(task, ArbigentAgent(task.agentConfig, dispatcher))
         }
         _taskAssignmentsHistoryStateFlow.value += listOf(taskAssignments())
         for ((index, taskAgent) in taskAssignments().withIndex()) {
@@ -285,8 +291,10 @@ public class ArbigentScenarioExecutor {
   }
 
   public class Builder {
+    // Defaults to Dispatchers.Default; tests set a TestDispatcher so execution is deterministic.
+    public var dispatcher: CoroutineDispatcher = Dispatchers.Default
     public fun build(): ArbigentScenarioExecutor {
-      return ArbigentScenarioExecutor()
+      return ArbigentScenarioExecutor(dispatcher)
     }
   }
 }

--- a/arbigent-core/src/test/java/ArbigentAgentExecutorTest.kt
+++ b/arbigent-core/src/test/java/ArbigentAgentExecutorTest.kt
@@ -10,7 +10,7 @@ class ArbigentAgentExecutorTest {
   @OptIn(ExperimentalStdlibApi::class)
   @Test
   fun testCacheKeyFormat() = runTest {
-    ArbigentCoroutinesDispatcher.dispatcher = coroutineContext[CoroutineDispatcher]!!
+    val testDispatcher = coroutineContext[CoroutineDispatcher]!!
 
     val testDevice = FakeDevice()
     val cacheKeyCapture = FakeAi.Status.CacheKeyCapture()
@@ -24,7 +24,7 @@ class ArbigentAgentExecutorTest {
     }
 
     val task = ArbigentAgentTask("id1", "Test goal", agentConfig)
-    ArbigentAgent(agentConfig).execute(task, MCPClient())
+    ArbigentAgent(agentConfig, testDispatcher).execute(task, MCPClient())
     advanceUntilIdle()
 
     // Verify cache key format
@@ -42,14 +42,14 @@ class ArbigentAgentExecutorTest {
   @OptIn(ExperimentalStdlibApi::class)
   @Test
   fun tests() = runTest {
-    ArbigentCoroutinesDispatcher.dispatcher = coroutineContext[CoroutineDispatcher]!!
+    val testDispatcher = coroutineContext[CoroutineDispatcher]!!
     val agentConfig = AgentConfig {
       deviceFactory { FakeDevice() }
       aiFactory { FakeAi() }
     }
 
     val task = ArbigentAgentTask("id1", "goal1", agentConfig)
-    ArbigentAgent(agentConfig)
+    ArbigentAgent(agentConfig, testDispatcher)
       .execute(task, MCPClient())
 
     advanceUntilIdle()

--- a/arbigent-core/src/test/java/ArbigentProjectFileContentTest.kt
+++ b/arbigent-core/src/test/java/ArbigentProjectFileContentTest.kt
@@ -53,7 +53,7 @@ class ArbigentProjectFileContentTest {
         deviceFactory = { FakeDevice() },
         aiDecisionCache = AiDecisionCacheStrategy.InMemory().toCache()
       )
-      val executor = ArbigentScenarioExecutor { dispatcher = testDispatcher }
+      val executor = ArbigentScenarioExecutor(testDispatcher)
       executor.execute(executorScenario, MCPClient())
       assertTrue {
         executor.isGoalAchieved()

--- a/arbigent-core/src/test/java/ArbigentProjectFileContentTest.kt
+++ b/arbigent-core/src/test/java/ArbigentProjectFileContentTest.kt
@@ -42,7 +42,7 @@ class ArbigentProjectFileContentTest {
   @OptIn(ExperimentalStdlibApi::class)
   @Test
   fun tests() = runTest {
-    ArbigentCoroutinesDispatcher.dispatcher = coroutineContext[CoroutineDispatcher]!!
+    val testDispatcher = coroutineContext[CoroutineDispatcher]!!
 
     val projectFileContent: ArbigentProjectFileContent = basicProject
     projectFileContent.scenarioContents.forEach { scenarioContent ->
@@ -53,7 +53,7 @@ class ArbigentProjectFileContentTest {
         deviceFactory = { FakeDevice() },
         aiDecisionCache = AiDecisionCacheStrategy.InMemory().toCache()
       )
-      val executor = ArbigentScenarioExecutor()
+      val executor = ArbigentScenarioExecutor { dispatcher = testDispatcher }
       executor.execute(executorScenario, MCPClient())
       assertTrue {
         executor.isGoalAchieved()

--- a/arbigent-core/src/test/java/ArbigentScenarioContentExecutorTest.kt
+++ b/arbigent-core/src/test/java/ArbigentScenarioContentExecutorTest.kt
@@ -17,9 +17,7 @@ class ArbigentScenarioContentExecutorTest {
       deviceFactory { FakeDevice() }
       aiFactory { fakeAi }
     }
-    val arbigentScenarioExecutor = ArbigentScenarioExecutor {
-      dispatcher = testDispatcher
-    }
+    val arbigentScenarioExecutor = ArbigentScenarioExecutor(testDispatcher)
     val arbigentScenario = ArbigentScenario(
       id = "id2",
       agentTasks = listOf(
@@ -71,9 +69,7 @@ class ArbigentScenarioContentExecutorTest {
         }
       )
     }
-    val arbigentScenarioExecutor = ArbigentScenarioExecutor {
-      dispatcher = testDispatcher
-    }
+    val arbigentScenarioExecutor = ArbigentScenarioExecutor(testDispatcher)
     val arbigentScenario = ArbigentScenario(
       id = "id2",
       listOf(
@@ -143,9 +139,7 @@ class ArbigentScenarioContentExecutorTest {
         }
       )
     }
-    val arbigentScenarioExecutor = ArbigentScenarioExecutor {
-      dispatcher = testDispatcher
-    }
+    val arbigentScenarioExecutor = ArbigentScenarioExecutor(testDispatcher)
     val arbigentScenario = ArbigentScenario(
       id = "id2",
       listOf(

--- a/arbigent-core/src/test/java/ArbigentScenarioContentExecutorTest.kt
+++ b/arbigent-core/src/test/java/ArbigentScenarioContentExecutorTest.kt
@@ -11,13 +11,14 @@ class ArbigentScenarioContentExecutorTest {
   @OptIn(ExperimentalStdlibApi::class)
   @Test
   fun tests() = runTest {
-    ArbigentCoroutinesDispatcher.dispatcher = coroutineContext[CoroutineDispatcher]!!
+    val testDispatcher = coroutineContext[CoroutineDispatcher]!!
     val fakeAi = FakeAi()
     val agentConfig = AgentConfig {
       deviceFactory { FakeDevice() }
       aiFactory { fakeAi }
     }
     val arbigentScenarioExecutor = ArbigentScenarioExecutor {
+      dispatcher = testDispatcher
     }
     val arbigentScenario = ArbigentScenario(
       id = "id2",
@@ -39,7 +40,7 @@ class ArbigentScenarioContentExecutorTest {
   @OptIn(ExperimentalStdlibApi::class)
   @Test
   fun lastInitializerInterceptorCalledFirst() = runTest {
-    ArbigentCoroutinesDispatcher.dispatcher = coroutineContext[CoroutineDispatcher]!!
+    val testDispatcher = coroutineContext[CoroutineDispatcher]!!
     val order = mutableListOf<String>()
     val fakeAi = FakeAi()
     val agentConfig = AgentConfig {
@@ -71,6 +72,7 @@ class ArbigentScenarioContentExecutorTest {
       )
     }
     val arbigentScenarioExecutor = ArbigentScenarioExecutor {
+      dispatcher = testDispatcher
     }
     val arbigentScenario = ArbigentScenario(
       id = "id2",
@@ -108,7 +110,7 @@ class ArbigentScenarioContentExecutorTest {
   @OptIn(ExperimentalStdlibApi::class)
   @Test
   fun lastStepInterceptorCalledFirst() = runTest {
-    ArbigentCoroutinesDispatcher.dispatcher = coroutineContext[CoroutineDispatcher]!!
+    val testDispatcher = coroutineContext[CoroutineDispatcher]!!
     val order = mutableListOf<String>()
     val fakeAi = FakeAi()
     val agentConfig = AgentConfig {
@@ -142,6 +144,7 @@ class ArbigentScenarioContentExecutorTest {
       )
     }
     val arbigentScenarioExecutor = ArbigentScenarioExecutor {
+      dispatcher = testDispatcher
     }
     val arbigentScenario = ArbigentScenario(
       id = "id2",

--- a/arbigent-core/src/test/java/ReusableScenariosTest.kt
+++ b/arbigent-core/src/test/java/ReusableScenariosTest.kt
@@ -180,16 +180,10 @@ class ReusableScenariosTest {
 
   @Test
   fun maestroYamlInputsAreSubstitutedAndExecuted() = runTest {
-    val previousDispatcher = ArbigentCoroutinesDispatcher.dispatcher
-    ArbigentCoroutinesDispatcher.dispatcher = coroutineContext[CoroutineDispatcher]!!
-    try {
-      maestroYamlInputsAreSubstitutedAndExecutedBody()
-    } finally {
-      ArbigentCoroutinesDispatcher.dispatcher = previousDispatcher
-    }
+    maestroYamlInputsAreSubstitutedAndExecutedBody(coroutineContext[CoroutineDispatcher]!!)
   }
 
-  private suspend fun maestroYamlInputsAreSubstitutedAndExecutedBody() {
+  private suspend fun maestroYamlInputsAreSubstitutedAndExecutedBody(dispatcher: CoroutineDispatcher) {
     val executedCommands = mutableListOf<MaestroCommand>()
     val fakeDevice = FakeDevice()
     val recordingDevice = object : ArbigentDevice by fakeDevice {
@@ -235,7 +229,7 @@ class ReusableScenariosTest {
       fixedScenarios = project.fixedScenarios,
       reusableScenarios = project.reusableScenarios
     )
-    val executor = ArbigentScenarioExecutor()
+    val executor = ArbigentScenarioExecutor { this.dispatcher = dispatcher }
     executor.execute(scenario, MCPClient())
     assertTrue(executor.isGoalAchieved())
     val openLink = executedCommands.mapNotNull { it.openLinkCommand }.firstOrNull()

--- a/arbigent-core/src/test/java/ReusableScenariosTest.kt
+++ b/arbigent-core/src/test/java/ReusableScenariosTest.kt
@@ -229,7 +229,7 @@ class ReusableScenariosTest {
       fixedScenarios = project.fixedScenarios,
       reusableScenarios = project.reusableScenarios
     )
-    val executor = ArbigentScenarioExecutor { this.dispatcher = dispatcher }
+    val executor = ArbigentScenarioExecutor(dispatcher)
     executor.execute(scenario, MCPClient())
     assertTrue(executor.isGoalAchieved())
     val openLink = executedCommands.mapNotNull { it.openLinkCommand }.firstOrNull()

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -27,8 +27,9 @@ class ArbigentAppStateHolder(
     fetchAvailableDevicesByOs(os, includeAllIosDevices = true)
   },
   // Threaded into every holder and scope this owns so tests drive them on a TestDispatcher instead
-  // of mutating a process-wide global.
-  private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
+  // of mutating a process-wide global. internal so editor dialogs that build their own holders
+  // (e.g. the reusable-scenario editor) can keep them on the same dispatcher.
+  internal val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
   private val _fixedScenariosFlow = MutableStateFlow<List<FixedScenario>>(emptyList())
   val fixedScenariosFlow: StateFlow<List<FixedScenario>> = _fixedScenariosFlow.asStateFlow()
@@ -424,7 +425,8 @@ class ArbigentAppStateHolder(
       initialScenarios = allScenarioStateHoldersStateFlow.value.map { scenario ->
         scenario.createScenario(allScenarioStateHoldersStateFlow.value)
       },
-      appSettings = appSettings
+      appSettings = appSettings,
+      dispatcher = dispatcher,
     )
     projectStateFlow.value = arbigentProject
     allScenarioStateHoldersStateFlow.value.forEach { scenarioStateHolder ->
@@ -618,7 +620,8 @@ class ArbigentAppStateHolder(
           arbigentScenarioStateHolders
         )
       },
-      appSettings = appSettings
+      appSettings = appSettings,
+      dispatcher = dispatcher,
     )
     allScenarioStateHoldersStateFlow.value = arbigentScenarioStateHolders
     // Use the loaded content directly to avoid format differences

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -26,10 +26,10 @@ class ArbigentAppStateHolder(
     // paired iPhones) rather than the CLI's auto-select subset.
     fetchAvailableDevicesByOs(os, includeAllIosDevices = true)
   },
-  // Threaded into every holder and scope this owns so tests drive them on a TestDispatcher instead
-  // of mutating a process-wide global. internal so editor dialogs that build their own holders
+  // Required: threaded into every holder and scope this owns so they share one dispatcher supplied
+  // by the UI composition root (Main). internal so editor dialogs that build their own holders
   // (e.g. the reusable-scenario editor) can keep them on the same dispatcher.
-  internal val dispatcher: CoroutineDispatcher = Dispatchers.Default,
+  internal val dispatcher: CoroutineDispatcher,
 ) {
   private val _fixedScenariosFlow = MutableStateFlow<List<FixedScenario>>(emptyList())
   val fixedScenariosFlow: StateFlow<List<FixedScenario>> = _fixedScenariosFlow.asStateFlow()

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -25,7 +25,10 @@ class ArbigentAppStateHolder(
     // The UI selects a device explicitly, so list every connected iOS device (simulators and
     // paired iPhones) rather than the CLI's auto-select subset.
     fetchAvailableDevicesByOs(os, includeAllIosDevices = true)
-  }
+  },
+  // Threaded into every holder and scope this owns so tests drive them on a TestDispatcher instead
+  // of mutating a process-wide global.
+  private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
   private val _fixedScenariosFlow = MutableStateFlow<List<FixedScenario>>(emptyList())
   val fixedScenariosFlow: StateFlow<List<FixedScenario>> = _fixedScenariosFlow.asStateFlow()
@@ -243,7 +246,7 @@ class ArbigentAppStateHolder(
   // AppSettings for working directory
   val appSettingsStateHolder = AppSettingsStateHolder()
   val appSettings get() = appSettingsStateHolder.appSettings
-  val devicesStateHolder = DevicesStateHolder(availableDeviceListFactory)
+  val devicesStateHolder = DevicesStateHolder(availableDeviceListFactory, dispatcher)
 
   sealed interface DeviceConnectionState {
     data object NotConnected : DeviceConnectionState
@@ -287,7 +290,7 @@ class ArbigentAppStateHolder(
         result
       }
       .stateIn(
-        scope = CoroutineScope(ArbigentCoroutinesDispatcher.dispatcher + SupervisorJob()),
+        scope = CoroutineScope(dispatcher + SupervisorJob()),
         started = SharingStarted.WhileSubscribed(),
         initialValue = emptyList()
       )
@@ -299,7 +302,7 @@ class ArbigentAppStateHolder(
   val mcpServerNamesFlow: StateFlow<List<String>> = mcpJsonFlow
     .map { json -> parseMcpServerNames(json) }
     .stateIn(
-      scope = CoroutineScope(ArbigentCoroutinesDispatcher.dispatcher + SupervisorJob()),
+      scope = CoroutineScope(dispatcher + SupervisorJob()),
       started = SharingStarted.Eagerly,
       initialValue = emptyList()
     )
@@ -312,7 +315,7 @@ class ArbigentAppStateHolder(
       decisionCacheStrategy.toCache()
     }
     .stateIn(
-      scope = CoroutineScope(ArbigentCoroutinesDispatcher.dispatcher + SupervisorJob()),
+      scope = CoroutineScope(dispatcher + SupervisorJob()),
       started = SharingStarted.Eagerly,
       initialValue = ArbigentAiDecisionCache.Disabled
     )
@@ -321,7 +324,7 @@ class ArbigentAppStateHolder(
 
   val selectedScenarioIndex: MutableStateFlow<Int> = MutableStateFlow(0)
   private val coroutineScope =
-    CoroutineScope(ArbigentCoroutinesDispatcher.dispatcher + SupervisorJob())
+    CoroutineScope(dispatcher + SupervisorJob())
 
   val stepFeedbacks: MutableStateFlow<Set<StepFeedback>> = MutableStateFlow(setOf())
   
@@ -340,7 +343,7 @@ class ArbigentAppStateHolder(
   }
 
   fun addSubScenario(parent: ArbigentScenarioStateHolder) {
-    val scenarioStateHolder = ArbigentScenarioStateHolder(tagManager = tagManager).apply {
+    val scenarioStateHolder = ArbigentScenarioStateHolder(tagManager = tagManager, dispatcher = dispatcher).apply {
       onAddAsSubScenario(parent)
     }
     allScenarioStateHoldersStateFlow.value += scenarioStateHolder
@@ -349,7 +352,7 @@ class ArbigentAppStateHolder(
   }
 
   fun addScenario() {
-    val scenarioStateHolder = ArbigentScenarioStateHolder(tagManager = tagManager)
+    val scenarioStateHolder = ArbigentScenarioStateHolder(tagManager = tagManager, dispatcher = dispatcher)
     allScenarioStateHoldersStateFlow.value += scenarioStateHolder
     selectedScenarioIndex.value =
       sortedScenariosAndDepths().indexOfFirst { it.first.id == scenarioStateHolder.id }
@@ -589,6 +592,7 @@ class ArbigentAppStateHolder(
       ArbigentScenarioStateHolder(
         id = scenarioContent.id,
         tagManager = tagManager,
+        dispatcher = dispatcher,
       ).apply {
         load(scenarioContent)
       }
@@ -765,7 +769,7 @@ class ArbigentAppStateHolder(
     )
     allScenarioStateHoldersStateFlow.value.forEach { it.cancel() }
     val scenarios = allScenarioStateHoldersStateFlow.value + generatedScenarios.scenarios.map {
-      ArbigentScenarioStateHolder(tagManager = tagManager).apply {
+      ArbigentScenarioStateHolder(tagManager = tagManager, dispatcher = dispatcher).apply {
         load(it)
         isNewlyGenerated.value = true
       }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentScenarioStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentScenarioStateHolder.kt
@@ -6,7 +6,6 @@ import io.github.takahirom.arbigent.coroutines.buildSingleSourceStateFlow
 import io.github.takahirom.arbigent.result.ArbigentScenarioDeviceFormFactor
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -23,8 +22,9 @@ class ArbigentScenarioStateHolder
 constructor(
   id: String = Uuid.random().toString(),
   private val tagManager: ArbigentTagManager,
-  // Injected so tests run this holder's flows on a TestDispatcher instead of a process-wide global.
-  dispatcher: CoroutineDispatcher = Dispatchers.Default,
+  // Required: the flow scope's dispatcher, supplied by whoever creates this holder (ultimately the
+  // UI composition root) so no construction path silently falls back to a default.
+  dispatcher: CoroutineDispatcher,
 ) {
   private val _id = MutableStateFlow(id)
   val idStateFlow: StateFlow<String> = _id

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentScenarioStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentScenarioStateHolder.kt
@@ -4,7 +4,9 @@ import androidx.compose.foundation.text.input.TextFieldState
 import io.github.takahirom.arbigent.*
 import io.github.takahirom.arbigent.coroutines.buildSingleSourceStateFlow
 import io.github.takahirom.arbigent.result.ArbigentScenarioDeviceFormFactor
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
@@ -20,7 +22,9 @@ class ArbigentScenarioStateHolder
 @OptIn(ExperimentalUuidApi::class)
 constructor(
   id: String = Uuid.random().toString(),
-  private val tagManager: ArbigentTagManager
+  private val tagManager: ArbigentTagManager,
+  // Injected so tests run this holder's flows on a TestDispatcher instead of a process-wide global.
+  dispatcher: CoroutineDispatcher = Dispatchers.Default,
 ) {
   private val _id = MutableStateFlow(id)
   val idStateFlow: StateFlow<String> = _id
@@ -76,7 +80,7 @@ constructor(
   val isNewlyGenerated = MutableStateFlow(false)
 
   private val coroutineScope = CoroutineScope(
-    ArbigentCoroutinesDispatcher.dispatcher + SupervisorJob()
+    dispatcher + SupervisorJob()
   )
   @OptIn(ArbigentInternalApi::class)
   val tags = coroutineScope.buildSingleSourceStateFlow(tagManager.scenarioToTagsStateFlow) {

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/DevicesStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/DevicesStateHolder.kt
@@ -6,7 +6,6 @@ import io.github.takahirom.arbigent.ArbigentDeviceOs
 import io.github.takahirom.arbigent.arbigentDebugLog
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.SupervisorJob
@@ -22,8 +21,9 @@ import kotlinx.coroutines.withContext
 
 class DevicesStateHolder(
   val arbigentAvailableDeviceListFactory: (ArbigentDeviceOs) -> List<ArbigentAvailableDevice>,
-  // Injected so tests run discovery on a TestDispatcher instead of a process-wide global.
-  private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
+  // Required: discovery dispatcher, supplied by the owner (ArbigentAppStateHolder) so it shares the
+  // composition root's dispatcher rather than silently defaulting.
+  private val dispatcher: CoroutineDispatcher,
 ) {
   val selectedDeviceOs: MutableStateFlow<ArbigentDeviceOs> = MutableStateFlow(ArbigentDeviceOs.Android)
   val devices: MutableStateFlow<List<ArbigentAvailableDevice>> = MutableStateFlow(listOf())

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/DevicesStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/DevicesStateHolder.kt
@@ -1,11 +1,12 @@
 package io.github.takahirom.arbigent.ui
 
 
-import io.github.takahirom.arbigent.ArbigentCoroutinesDispatcher
 import io.github.takahirom.arbigent.ArbigentAvailableDevice
 import io.github.takahirom.arbigent.ArbigentDeviceOs
 import io.github.takahirom.arbigent.arbigentDebugLog
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.SupervisorJob
@@ -19,7 +20,11 @@ import kotlinx.coroutines.runInterruptible
 import kotlinx.coroutines.withContext
 
 
-class DevicesStateHolder(val arbigentAvailableDeviceListFactory: (ArbigentDeviceOs) -> List<ArbigentAvailableDevice>) {
+class DevicesStateHolder(
+  val arbigentAvailableDeviceListFactory: (ArbigentDeviceOs) -> List<ArbigentAvailableDevice>,
+  // Injected so tests run discovery on a TestDispatcher instead of a process-wide global.
+  private val dispatcher: CoroutineDispatcher = Dispatchers.Default,
+) {
   val selectedDeviceOs: MutableStateFlow<ArbigentDeviceOs> = MutableStateFlow(ArbigentDeviceOs.Android)
   val devices: MutableStateFlow<List<ArbigentAvailableDevice>> = MutableStateFlow(listOf())
   private val _selectedDevice: MutableStateFlow<ArbigentAvailableDevice?> = MutableStateFlow(null)
@@ -28,7 +33,7 @@ class DevicesStateHolder(val arbigentAvailableDeviceListFactory: (ArbigentDevice
   // One scope owned by the holder. A single collector re-fetches when the OS changes; each fetch is a
   // cancellable one-shot whose predecessor is cancelled first, so refreshes never accumulate
   // collectors or let a slow discovery overwrite a newer result out of order.
-  private val scope = CoroutineScope(ArbigentCoroutinesDispatcher.dispatcher + SupervisorJob())
+  private val scope = CoroutineScope(dispatcher + SupervisorJob())
   private var fetchJob: Job? = null
   // Monotonic id of the latest fetch. A job publishes only if it still matches this when it finishes,
   // which makes the "am I still the newest?" check and the state writes atomic under fetchLock.
@@ -62,7 +67,7 @@ class DevicesStateHolder(val arbigentAvailableDeviceListFactory: (ArbigentDevice
         val os = selectedDeviceOs.value
         // Device discovery (e.g. devicectl) blocks, so run it off the caller under runInterruptible
         // so cancelling the job actually interrupts the blocking call.
-        val result = withContext(ArbigentCoroutinesDispatcher.dispatcher) {
+        val result = withContext(dispatcher) {
           runInterruptible { arbigentAvailableDeviceListFactory(os) }
         }
         synchronized(fetchLock) {

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/Main.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/Main.kt
@@ -34,6 +34,7 @@ import org.jetbrains.jewel.window.DecoratedWindow
 import org.jetbrains.jewel.window.TitleBar
 import org.jetbrains.jewel.window.styling.TitleBarStyle
 import java.awt.Window
+import kotlinx.coroutines.Dispatchers
 
 
 @OptIn(ArbigentInternalApi::class)
@@ -82,6 +83,9 @@ fun main() {
             throw IllegalArgumentException("Unsupported aiProviderSetting: $aiProviderSetting")
           }
         },
+        // Composition root for the desktop app: the one place the production dispatcher is created
+        // and threaded into the holder (and, through it, every scope/holder it owns).
+        dispatcher = Dispatchers.Default,
       )
     }
     AppWindow(

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ReusableScenariosDialog.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ReusableScenariosDialog.kt
@@ -180,7 +180,8 @@ private fun ReusableScenarioEditorDialog(
   val stateHolder = remember(existingScenario) {
     ArbigentScenarioStateHolder(
       id = existingScenario?.id ?: "new-reusable-scenario",
-      tagManager = ArbigentTagManager()
+      tagManager = ArbigentTagManager(),
+      dispatcher = appStateHolder.dispatcher,
     ).apply {
       existingScenario?.let { load(it) }
     }

--- a/arbigent-ui/src/test/kotlin/AdditionalActionsTest.kt
+++ b/arbigent-ui/src/test/kotlin/AdditionalActionsTest.kt
@@ -1,6 +1,7 @@
 package io.github.takahirom.arbigent.ui
 
 import io.github.takahirom.arbigent.*
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Before
@@ -23,7 +24,8 @@ class AdditionalActionsTest {
     @Test
     fun `ArbigentAppStateHolder onAdditionalActionsChanged should update flow`() = runBlocking {
         val appStateHolder = ArbigentAppStateHolder(
-            aiFactory = { FakeAi() }
+            aiFactory = { FakeAi() },
+            dispatcher = Dispatchers.Unconfined,
         )
         val testActions = listOf("ClickWithText", "ClickWithId")
 
@@ -35,7 +37,8 @@ class AdditionalActionsTest {
     @Test
     fun `ArbigentAppStateHolder onAdditionalActionsChanged should handle null`() = runBlocking {
         val appStateHolder = ArbigentAppStateHolder(
-            aiFactory = { FakeAi() }
+            aiFactory = { FakeAi() },
+            dispatcher = Dispatchers.Unconfined,
         )
 
         // First set some actions
@@ -50,7 +53,8 @@ class AdditionalActionsTest {
     @Test
     fun `ArbigentAppStateHolder onAdditionalActionsChanged should handle empty list`() = runBlocking {
         val appStateHolder = ArbigentAppStateHolder(
-            aiFactory = { FakeAi() }
+            aiFactory = { FakeAi() },
+            dispatcher = Dispatchers.Unconfined,
         )
 
         // Set empty list should be treated as null in UI (checkbox deselection logic)
@@ -61,7 +65,7 @@ class AdditionalActionsTest {
     @Test
     fun `ArbigentScenarioStateHolder onAdditionalActionsChanged should update flow`() {
         val tagManager = ArbigentTagManager()
-        val scenarioStateHolder = ArbigentScenarioStateHolder(tagManager = tagManager)
+        val scenarioStateHolder = ArbigentScenarioStateHolder(tagManager = tagManager, dispatcher = Dispatchers.Unconfined)
         val testActions = listOf("ClickWithText", "DpadTryAutoFocusById")
 
         scenarioStateHolder.onAdditionalActionsChanged(testActions)
@@ -72,7 +76,7 @@ class AdditionalActionsTest {
     @Test
     fun `ArbigentScenarioStateHolder onAdditionalActionsChanged should handle null`() {
         val tagManager = ArbigentTagManager()
-        val scenarioStateHolder = ArbigentScenarioStateHolder(tagManager = tagManager)
+        val scenarioStateHolder = ArbigentScenarioStateHolder(tagManager = tagManager, dispatcher = Dispatchers.Unconfined)
 
         // First set some actions
         scenarioStateHolder.onAdditionalActionsChanged(listOf("ClickWithId"))
@@ -86,7 +90,7 @@ class AdditionalActionsTest {
     @Test
     fun `ArbigentScenarioStateHolder createArbigentScenarioContent should include additionalActions`() {
         val tagManager = ArbigentTagManager()
-        val scenarioStateHolder = ArbigentScenarioStateHolder(tagManager = tagManager)
+        val scenarioStateHolder = ArbigentScenarioStateHolder(tagManager = tagManager, dispatcher = Dispatchers.Unconfined)
         val testActions = listOf("ClickWithText", "ClickWithId")
 
         scenarioStateHolder.onAdditionalActionsChanged(testActions)
@@ -100,7 +104,7 @@ class AdditionalActionsTest {
     @Test
     fun `ArbigentScenarioStateHolder load should restore additionalActions`() {
         val tagManager = ArbigentTagManager()
-        val scenarioStateHolder = ArbigentScenarioStateHolder(tagManager = tagManager)
+        val scenarioStateHolder = ArbigentScenarioStateHolder(tagManager = tagManager, dispatcher = Dispatchers.Unconfined)
         val testActions = listOf("DpadTryAutoFocusByText")
 
         val scenarioContent = ArbigentScenarioContent(

--- a/arbigent-ui/src/test/kotlin/ReusableScenarioUiStateTest.kt
+++ b/arbigent-ui/src/test/kotlin/ReusableScenarioUiStateTest.kt
@@ -1,6 +1,7 @@
 package io.github.takahirom.arbigent.ui
 
 import io.github.takahirom.arbigent.*
+import kotlinx.coroutines.Dispatchers
 import org.junit.Before
 import org.junit.Test
 import kotlin.test.assertEquals
@@ -14,7 +15,7 @@ class ReusableScenarioUiStateTest {
   }
 
   private fun holderOf(content: ArbigentScenarioContent) =
-    ArbigentScenarioStateHolder(id = content.id, tagManager = ArbigentTagManager()).apply {
+    ArbigentScenarioStateHolder(id = content.id, tagManager = ArbigentTagManager(), dispatcher = Dispatchers.Unconfined).apply {
       load(content)
     }
 
@@ -69,8 +70,8 @@ class ReusableScenarioUiStateTest {
 
   @Test
   fun `make this reusable moves content and converts scenario to call node`() {
-    val appStateHolder = ArbigentAppStateHolder(aiFactory = { FakeAi() })
-    val holder = ArbigentScenarioStateHolder(id = "login-test", tagManager = ArbigentTagManager()).apply {
+    val appStateHolder = ArbigentAppStateHolder(aiFactory = { FakeAi() }, dispatcher = Dispatchers.Unconfined)
+    val holder = ArbigentScenarioStateHolder(id = "login-test", tagManager = ArbigentTagManager(), dispatcher = Dispatchers.Unconfined).apply {
       load(
         ArbigentScenarioContent(
           id = "login-test",
@@ -104,12 +105,12 @@ class ReusableScenarioUiStateTest {
 
   @Test
   fun `renaming a reusable scenario rewrites references from scenarios and composites`() {
-    val appStateHolder = ArbigentAppStateHolder(aiFactory = { FakeAi() })
+    val appStateHolder = ArbigentAppStateHolder(aiFactory = { FakeAi() }, dispatcher = Dispatchers.Unconfined)
     appStateHolder.addReusableScenario(ArbigentScenarioContent(id = "part", goal = "goal"))
     appStateHolder.addReusableScenario(
       ArbigentScenarioContent(id = "composite", steps = listOf(ArbigentScenarioContent.ReusableStep(uses = "part")))
     )
-    val callerHolder = ArbigentScenarioStateHolder(id = "caller", tagManager = ArbigentTagManager()).apply {
+    val callerHolder = ArbigentScenarioStateHolder(id = "caller", tagManager = ArbigentTagManager(), dispatcher = Dispatchers.Unconfined).apply {
       load(ArbigentScenarioContent(id = "caller", uses = "part"))
     }
     // Register the caller so the rename can reach it (mirrors loadProjectContents wiring).
@@ -129,7 +130,7 @@ class ReusableScenarioUiStateTest {
 
   @Test
   fun `reusable scenario references are detected for delete protection`() {
-    val appStateHolder = ArbigentAppStateHolder(aiFactory = { FakeAi() })
+    val appStateHolder = ArbigentAppStateHolder(aiFactory = { FakeAi() }, dispatcher = Dispatchers.Unconfined)
     appStateHolder.addReusableScenario(ArbigentScenarioContent(id = "part", goal = "goal"))
     appStateHolder.addReusableScenario(
       ArbigentScenarioContent(id = "composite", steps = listOf(ArbigentScenarioContent.ReusableStep(uses = "part")))

--- a/arbigent-ui/src/test/kotlin/UiTests.kt
+++ b/arbigent-ui/src/test/kotlin/UiTests.kt
@@ -19,6 +19,7 @@ import io.github.takahirom.robospec.DescribedBehaviors
 import io.github.takahirom.robospec.describeBehaviors
 import io.github.takahirom.robospec.execute
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.advanceTimeBy
@@ -36,7 +37,6 @@ class UiTests(private val behavior: DescribedBehavior<TestRobot>) {
   @Test
   fun test() {
     val testDispatcher = StandardTestDispatcher()
-    ArbigentCoroutinesDispatcher.dispatcher = testDispatcher
     globalKeyStoreFactory = TestKeyStoreFactory()
     // Use fixed timestamp for deterministic UI tests
     TimeProvider.set(TestTimeProvider(1234567890000L))
@@ -899,6 +899,9 @@ class TestRobot(
       availableDeviceListFactory = {
         listOf(ArbigentAvailableDevice.Fake())
       },
+      // Run the holder's coroutines on the same test dispatcher runTest is driving, so the UI test
+      // stays deterministic now that there is no process-wide dispatcher global.
+      dispatcher = testScope.coroutineContext[CoroutineDispatcher]!!,
     )
     setContent {
       CompositionLocalProvider(

--- a/sample-test/src/test/kotlin/RealArbigentTest.kt
+++ b/sample-test/src/test/kotlin/RealArbigentTest.kt
@@ -2,6 +2,7 @@ package io.github.takahirom.arbigent.sample.test
 
 import io.github.takahirom.arbigent.*
 import dadb.Dadb
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.test.runTest
 import java.io.File
 import kotlin.test.Ignore
@@ -30,7 +31,8 @@ class RealArbigentTest {
           dadb = Dadb.discover()!!
         ).connectToDevice()
       },
-      appSettings = DefaultArbigentAppSettings
+      appSettings = DefaultArbigentAppSettings,
+      dispatcher = coroutineContext[CoroutineDispatcher]!!,
     )
     arbigentProject.execute()
   }


### PR DESCRIPTION
Removes the process-wide mutable `ArbigentCoroutinesDispatcher` singleton and replaces it with an explicitly injected dispatcher — **required everywhere, created only at composition roots, no per-signature defaults**.

## Why
`ArbigentCoroutinesDispatcher.dispatcher` was a mutable global read wherever a `CoroutineScope` was created. Tests mutated it (mostly without restoring), coupling them through process state. A first pass injected the dispatcher but with `= Dispatchers.Default` defaults on each constructor — that left N independent copies of the default and made it easy to forget threading (which caused a real bug: `ArbigentProject` created executors without the injected dispatcher, so UI screenshot tests ran scenario execution off the test's virtual clock and flaked).

## What
- Delete the `ArbigentCoroutinesDispatcher` object.
- Every `dispatcher` parameter is **required** — no `= Dispatchers.Default`. Threaded through `ArbigentScenarioExecutor` (factory) → `ArbigentAgent`, `ArbigentProject` (→ its executors), and the UI holders (`ArbigentAppStateHolder` → `ArbigentScenarioStateHolder` / `DevicesStateHolder` / owned scopes, and the reusable-scenario editor holder). The compiler now rejects any path that forgets to propagate it.
- The dispatcher is created in exactly one place per entry point (**composition root**): the desktop `main`, and each CLI command's `run()` (`run`, `task`, `scenarios`, `tags`).
- Tests inject their own dispatcher (TestDispatcher from the driving `TestScope` for the executor/UI Compose tests; `Dispatchers.Unconfined` for synchronous state unit tests) — no global mutation.

Public API surface is only the CLI and UI apps, so requiring the parameter breaks no external consumer.

## Verification
- All modules' main + test sources compile.
- Core execution tests (`ArbigentAgentExecutorTest`, `ArbigentScenarioContentExecutorTest`, `ArbigentProjectFileContentTest`, `ReusableScenariosTest`) and UI unit tests (`AdditionalActionsTest`, `ReusableScenarioUiStateTest`) pass.
- Verified no per-signature `: CoroutineDispatcher = ...` default remains; `Dispatchers.Default` appears only as explicit composition-root arguments.