### PR TITLE
Address CodeQL alerts: zip-slip guard and workflow token permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -6,6 +6,10 @@ on:
       - main
   pull_request:
 
+# Least-privilege token: this workflow only checks out code and uploads build artifacts.
+permissions:
+  contents: read
+
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx6g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevicectlIOSDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevicectlIOSDevice.kt
@@ -6,6 +6,7 @@ import device.IOSDevice
 import ios.devicectl.DeviceControlIOSDevice
 import util.IOSLaunchArguments.toIOSLaunchArguments
 import java.io.File
+import java.io.IOException
 import java.io.InputStream
 import java.util.zip.ZipInputStream
 
@@ -94,15 +95,19 @@ public class ArbigentDevicectlIOSDevice(
   }
 
   private fun unzip(stream: InputStream, targetDir: File) {
+    val targetRoot = targetDir.canonicalFile
     ZipInputStream(stream).use { zip ->
       var entry = zip.nextEntry
       while (entry != null) {
-        val outFile = File(targetDir, entry.name)
-        // Guard against zip-slip.
-        check(outFile.canonicalPath.startsWith(targetDir.canonicalPath + File.separator)) {
-          "Zip entry escapes target directory: ${entry!!.name}"
+        val currentEntry = entry!!
+        // Canonicalize the destination before any filesystem use, then confirm it stays within the
+        // target directory (zip-slip guard). Path.startsWith compares whole path components, so a
+        // traversing entry (../…) or a sibling like "<target>-evil" cannot escape.
+        val outFile = File(targetRoot, currentEntry.name).canonicalFile
+        if (!outFile.toPath().startsWith(targetRoot.toPath())) {
+          throw IOException("Zip entry escapes target directory: ${currentEntry.name}")
         }
-        if (entry.isDirectory) {
+        if (currentEntry.isDirectory) {
           outFile.mkdirs()
         } else {
           outFile.parentFile?.mkdirs()

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/IosRealDeviceTest.kt
@@ -397,7 +397,7 @@ class IosRealDeviceTest {
         zip.closeEntry()
       }
     }.toByteArray()
-    val e = assertFailsWith<IllegalStateException> {
+    val e = assertFailsWith<java.io.IOException> {
       controller.install(java.io.ByteArrayInputStream(malicious))
     }
     assertTrue(e.message!!.contains("escapes target directory"))


### PR DESCRIPTION
Resolves two CodeQL alerts on `main`.

## 1. Zip Slip in `ArbigentDevicectlIOSDevice.unzip` (`java/zipslip`)
The existing `check(outFile.canonicalPath.startsWith(targetDir.canonicalPath + File.separator))` guard was functionally safe (and covered by `install_rejectsZipSlipEntry`), but CodeQL didn't recognize the Kotlin `check {}` form as a sanitizer, and the file operations used the non-canonical `File`. Rewritten to the pattern CodeQL recognizes and that is also more robust:
- canonicalize the target root and each destination up front,
- validate with `Path.startsWith` (whole-path-component comparison — a traversing `../…` entry or a sibling like `<target>-evil` cannot escape), and
- operate on the validated canonical `File`, throwing `IOException` on escape.

The zip-slip rejection test is updated for the `IOException` type (same "escapes target directory" message).

## 2. Missing workflow permissions in `.github/workflows/test.yaml` (`actions/missing-workflow-permissions`)
Added a least-privilege top-level `permissions: { contents: read }` block. This workflow only checks out code and uploads build artifacts, so read-only contents is sufficient; every other workflow in the repo already declares permissions.

## Verification
- `:arbigent-core` main + test compile; `IosRealDeviceTest` (incl. the zip-slip rejection test) passes.