### PR TITLE
Unify scenario dependency and reusable resolution in one resolver

### DIFF
--- a/arbigent-cli/src/main/kotlin/InstructionCommand.kt
+++ b/arbigent-cli/src/main/kotlin/InstructionCommand.kt
@@ -124,83 +124,46 @@ class ArbigentInstructionCommand : CliktCommand(name = "instruction") {
   }
 
   /**
-   * Walks [target]'s dependency chain (dependency-first) and expands reusable `uses`/`steps` calls
-   * into the concrete leaves that actually execute, resolving `{{inputs.*}}` bindings along the way.
-   * Mirrors the runtime expansion in `createArbigentScenario`, but keeps each leaf's own
-   * initialization methods and image assertions so they can be rendered.
+   * Resolves [target] into the concrete leaves that actually execute (dependency chain first,
+   * reusable calls expanded, `{{inputs.*}}` bound) and renders each one. `instruction` refuses to
+   * print a partial chain, so every diagnostic the resolver reports becomes a [CliktError].
    */
   private fun resolveChain(
     scenariosById: Map<String, ArbigentScenarioContent>,
     reusableById: Map<String, ArbigentScenarioContent>,
     target: ArbigentScenarioContent,
   ): List<ResolvedStep> {
-    val steps = mutableListOf<ResolvedStep>()
-    val visited = mutableSetOf<String>()
-
-    fun leaf(content: ArbigentScenarioContent, bindings: Map<String, String>) {
+    val resolution = ArbigentScenarioResolver.resolveChain(
+      target = target,
+      reusableScenarios = reusableById.values.toList(),
+      scenarioLookup = scenariosById::get,
+    )
+    resolution.diagnostics.firstOrNull()?.let { diagnostic ->
+      throw CliktError(
+        when (diagnostic) {
+          // The call site is obvious from the printed chain, so keep the short wording.
+          is ArbigentScenarioDiagnostic.UnresolvedReusable ->
+            "Reusable scenario '${diagnostic.uses}' is not defined in reusableScenarios"
+          else -> diagnostic.message
+        }
+      )
+    }
+    return resolution.leaves.map { leaf ->
+      val content = requireNotNull(leaf.content)
+      val bindings = leaf.bindings.orEmpty()
       @Suppress("DEPRECATION")
       val rawInitializationMethods =
         content.initializationMethods.ifEmpty { listOf(content.initializeMethods) }
-      steps.add(
-        ResolvedStep(
-          id = content.id,
-          goal = ReusableInputsResolver.resolve(content.goal, bindings),
-          initializationMethods = rawInitializationMethods.map { resolveInitializationMethod(it, bindings) },
-          note = ReusableInputsResolver.resolve(content.noteForHumans, bindings),
-          imageAssertions = content.imageAssertions.map {
-            it.copy(assertionPrompt = ReusableInputsResolver.resolve(it.assertionPrompt, bindings))
-          },
-        )
+      ResolvedStep(
+        id = content.id,
+        goal = ReusableInputsResolver.resolve(content.goal, bindings),
+        initializationMethods = rawInitializationMethods.map { resolveInitializationMethod(it, bindings) },
+        note = ReusableInputsResolver.resolve(content.noteForHumans, bindings),
+        imageAssertions = content.imageAssertions.map {
+          it.copy(assertionPrompt = ReusableInputsResolver.resolve(it.assertionPrompt, bindings))
+        },
       )
     }
-
-    fun expandStep(
-      step: ArbigentScenarioContent.ReusableStep,
-      parentBindings: Map<String, String>,
-      expansionStack: List<String>,
-    ) {
-      if (expansionStack.contains(step.uses)) {
-        throw CliktError(
-          "Cyclic reusable scenario reference detected: ${(expansionStack + step.uses).joinToString(" -> ")}"
-        )
-      }
-      val reusable = reusableById[step.uses] ?: throw CliktError(
-        "Reusable scenario '${step.uses}' is not defined in reusableScenarios"
-      )
-      val resolvedWith = step.withValues.mapValues { (_, value) ->
-        ReusableInputsResolver.resolve(value, parentBindings)
-      }
-      val defaults = reusable.inputs.mapNotNull { (name, input) -> input.default?.let { name to it } }.toMap()
-      val bindings = defaults + resolvedWith
-      if (reusable.isCallForm()) {
-        reusable.callSteps().forEach { expandStep(it, bindings, expansionStack + step.uses) }
-      } else {
-        leaf(reusable, bindings)
-      }
-    }
-
-    fun dfs(scenario: ArbigentScenarioContent, dependencyStack: List<String>) {
-      if (dependencyStack.contains(scenario.id)) {
-        throw CliktError(
-          "Cyclic scenario dependency detected: ${(dependencyStack + scenario.id).joinToString(" -> ")}"
-        )
-      }
-      if (!visited.add(scenario.id)) return
-      scenario.dependencyId?.let { dependencyId ->
-        val dependency = scenariosById[dependencyId] ?: throw CliktError(
-          "Scenario '${scenario.id}' depends on unknown scenario '$dependencyId'."
-        )
-        dfs(dependency, dependencyStack + scenario.id)
-      }
-      if (scenario.isCallForm()) {
-        scenario.callSteps().forEach { expandStep(it, emptyMap(), emptyList()) }
-      } else {
-        leaf(scenario, emptyMap())
-      }
-    }
-
-    dfs(target, emptyList())
-    return steps
   }
 
   private fun resolveInitializationMethod(

--- a/arbigent-cli/src/main/kotlin/InstructionCommand.kt
+++ b/arbigent-cli/src/main/kotlin/InstructionCommand.kt
@@ -135,8 +135,11 @@ class ArbigentInstructionCommand : CliktCommand(name = "instruction") {
   ): List<ResolvedStep> {
     val resolution = ArbigentScenarioResolver.resolveChain(
       target = target,
-      reusableScenarios = reusableById.values.toList(),
+      // Both indexes are `associateBy`, so a duplicate id resolves to the last declaration
+      // here while the runtime resolves it to the first. Preserved rather than unified,
+      // because load-time validation rejects duplicates before either can be reached.
       scenarioLookup = scenariosById::get,
+      reusableLookup = reusableById::get,
     )
     resolution.diagnostics.firstOrNull()?.let { diagnostic ->
       throw CliktError(

--- a/arbigent-cli/src/test/kotlin/InstructionCommandTest.kt
+++ b/arbigent-cli/src/test/kotlin/InstructionCommandTest.kt
@@ -125,8 +125,10 @@ scenarios:
     )
     val result = run("--scenario-ids=child")
     assertNotEquals(0, result.statusCode, result.output)
-    assertContains(result.output, "child")
-    assertContains(result.output, "missing-parent")
+    assertContains(
+      result.output,
+      "Scenario 'child' depends on unknown scenario 'missing-parent'."
+    )
   }
 
   @Test

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -338,15 +338,12 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
   fixedScenarios: List<FixedScenario> = emptyList(),
   reusableScenarios: List<ArbigentScenarioContent> = emptyList()
 ): ArbigentScenario {
-  val visited = mutableSetOf<ArbigentScenarioContent>()
-  val result = mutableListOf<ArbigentAgentTask>()
-
-  fun addLeafTask(
+  fun agentTask(
     taskScenarioId: String,
     nodeScenario: ArbigentScenarioContent,
     inputBindings: Map<String, String>?,
     callBreadcrumb: String?
-  ) {
+  ): ArbigentAgentTask {
     // Determine which device form factor to use
     val effectiveDeviceFormFactor = if (nodeScenario.deviceFormFactor is ArbigentScenarioDeviceFormFactor.Unspecified) {
       if (projectSettings.deviceFormFactor is ArbigentScenarioDeviceFormFactor.Unspecified) {
@@ -378,93 +375,67 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
       fixedScenarios = fixedScenarios
     )
 
-    result.add(
-      ArbigentAgentTask(
-        scenarioId = taskScenarioId,
-        goal = goal,
-        maxStep = nodeScenario.maxStep,
+    return ArbigentAgentTask(
+      scenarioId = taskScenarioId,
+      goal = goal,
+      maxStep = nodeScenario.maxStep,
+      deviceFormFactor = effectiveDeviceFormFactor,
+      additionalActions = mergedAdditionalActions,
+      mcpOptions = nodeScenario.mcpOptions,
+      callBreadcrumb = callBreadcrumb,
+      agentConfig = AgentConfigBuilder(
+        prompt = projectSettings.prompt,
+        scenarioType = nodeScenario.type,
         deviceFormFactor = effectiveDeviceFormFactor,
-        additionalActions = mergedAdditionalActions,
-        mcpOptions = nodeScenario.mcpOptions,
-        callBreadcrumb = callBreadcrumb,
-        agentConfig = AgentConfigBuilder(
-          prompt = projectSettings.prompt,
-          scenarioType = nodeScenario.type,
-          deviceFormFactor = effectiveDeviceFormFactor,
-          initializationMethods = initializationMethods,
-          imageAssertions = ArbigentImageAssertions(
-            nodeScenario.imageAssertions,
-            nodeScenario.imageAssertionHistoryCount
-          ),
-          aiDecisionCache = aiDecisionCache,
-          cacheOptions = nodeScenario.cacheOptions ?: ArbigentScenarioCacheOptions(),
-          mcpClient = if (projectSettings.mcpJson.isNotBlank() && projectSettings.mcpJson != DefaultMcpJson) {
-            MCPClient(projectSettings.mcpJson, appSettings)
-          } else {
-            null
-          },
-          fixedScenarios = fixedScenarios,
-          appSettings = appSettings
-        ).apply {
-          aiOptions(projectSettings.aiOptions?.mergeWith(nodeScenario.aiOptions) ?: nodeScenario.aiOptions)
-          aiFactory(aiFactory)
-          deviceFactory(deviceFactory)
-        }.build(),
-      )
+        initializationMethods = initializationMethods,
+        imageAssertions = ArbigentImageAssertions(
+          nodeScenario.imageAssertions,
+          nodeScenario.imageAssertionHistoryCount
+        ),
+        aiDecisionCache = aiDecisionCache,
+        cacheOptions = nodeScenario.cacheOptions ?: ArbigentScenarioCacheOptions(),
+        mcpClient = if (projectSettings.mcpJson.isNotBlank() && projectSettings.mcpJson != DefaultMcpJson) {
+          MCPClient(projectSettings.mcpJson, appSettings)
+        } else {
+          null
+        },
+        fixedScenarios = fixedScenarios,
+        appSettings = appSettings
+      ).apply {
+        aiOptions(projectSettings.aiOptions?.mergeWith(nodeScenario.aiOptions) ?: nodeScenario.aiOptions)
+        aiFactory(aiFactory)
+        deviceFactory(deviceFactory)
+      }.build(),
     )
   }
 
-  fun expandStep(
-    taskScenarioId: String,
-    step: ArbigentScenarioContent.ReusableStep,
-    parentBindings: Map<String, String>,
-    breadcrumb: List<String>,
-    expansionStack: List<String>
-  ) {
-    if (expansionStack.contains(step.uses)) {
-      throw ArbigentProjectValidationException(
-        "Cyclic reusable scenario reference detected: ${(expansionStack + step.uses).joinToString(" -> ")}"
-      )
-    }
-    val reusable = reusableScenarios.firstOrNull { it.id == step.uses }
-      ?: throw ArbigentProjectValidationException(
-        "Reusable scenario '${step.uses}' referenced from '${breadcrumb.lastOrNull() ?: taskScenarioId}' is not defined in reusableScenarios"
-      )
-    // Explicit propagation: with-values may reference the caller's own inputs via {{inputs.*}}.
-    val resolvedWith = step.withValues.mapValues { (_, value) ->
-      ReusableInputsResolver.resolve(value, parentBindings)
-    }
-    val defaults = reusable.inputs.mapNotNull { (name, input) -> input.default?.let { name to it } }.toMap()
-    val bindings = defaults + resolvedWith
-    // Label with the effective bindings (including defaults) so reports show the full snapshot.
-    val crumb = breadcrumb + ReusableInputsResolver.breadcrumbLabel(reusable.id, bindings)
-    if (reusable.isCallForm()) {
-      reusable.callSteps().forEach {
-        expandStep(taskScenarioId, it, bindings, crumb, expansionStack + step.uses)
-      }
-    } else {
-      addLeafTask(taskScenarioId, reusable, bindings, crumb.joinToString(" › "))
+  val resolution = ArbigentScenarioResolver.resolveChain(
+    target = scenario,
+    reusableScenarios = reusableScenarios,
+    // Duplicate ids resolve to the first declaration, as `first { it.id == ... }` always did.
+    scenarioLookup = { id -> firstOrNull { it.id == id } },
+  )
+  // The runtime has never validated `dependency`: a cycle is silently cut short by the resolver's
+  // visited set, and only a dangling reference is fatal.
+  resolution.diagnostics.forEach { diagnostic ->
+    when (diagnostic) {
+      is ArbigentScenarioDiagnostic.DanglingDependency ->
+        throw NoSuchElementException("Collection contains no element matching the predicate.")
+      is ArbigentScenarioDiagnostic.UnresolvedReusable,
+      is ArbigentScenarioDiagnostic.CyclicReusable ->
+        throw ArbigentProjectValidationException(diagnostic.message)
+      is ArbigentScenarioDiagnostic.CyclicDependency,
+      is ArbigentScenarioDiagnostic.DuplicateScenarioId -> Unit
     }
   }
-
-  fun dfs(nodeScenario: ArbigentScenarioContent) {
-    if (visited.contains(nodeScenario)) {
-      return
-    }
-    visited.add(nodeScenario)
-    nodeScenario.dependencyId?.let { dependency ->
-      val dependencyScenario = first { it.id == dependency }
-      dfs(dependencyScenario)
-    }
-    if (nodeScenario.isCallForm()) {
-      nodeScenario.callSteps().forEach { step ->
-        expandStep(nodeScenario.id, step, emptyMap(), listOf(nodeScenario.id), emptyList())
-      }
-    } else {
-      addLeafTask(nodeScenario.id, nodeScenario, null, null)
-    }
+  val result = resolution.leaves.map { leaf ->
+    agentTask(
+      taskScenarioId = leaf.rootScenarioId,
+      nodeScenario = requireNotNull(leaf.content),
+      inputBindings = leaf.bindings,
+      callBreadcrumb = leaf.callPath.takeIf { it.isNotEmpty() }?.joinToString(" › "),
+    )
   }
-  dfs(scenario)
   arbigentDebugLog("Built scenario ${scenario.id} with ${result.size} tasks: ${result.map { it.scenarioId }}")
   // Determine which device form factor to use for the scenario
   val effectiveScenarioDeviceFormFactor = if (scenario.deviceFormFactor is ArbigentScenarioDeviceFormFactor.Unspecified) {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -411,9 +411,10 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
 
   val resolution = ArbigentScenarioResolver.resolveChain(
     target = scenario,
-    reusableScenarios = reusableScenarios,
-    // Duplicate ids resolve to the first declaration, as `first { it.id == ... }` always did.
+    // Both lookups resolve a duplicate id to the first declaration, as the runtime's
+    // `first { it.id == ... }` / `firstOrNull { it.id == step.uses }` always did.
     scenarioLookup = { id -> firstOrNull { it.id == id } },
+    reusableLookup = { id -> reusableScenarios.firstOrNull { it.id == id } },
   )
   // The runtime has never validated `dependency`: a cycle is silently cut short by the resolver's
   // visited set, and only a dangling reference is fatal.

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -431,7 +431,11 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
   val result = resolution.leaves.map { leaf ->
     agentTask(
       taskScenarioId = leaf.rootScenarioId,
-      nodeScenario = requireNotNull(leaf.content),
+      // Non-null because the loop above throws for the only two diagnostics that produce a
+      // content-less leaf (UnresolvedReusable / CyclicReusable).
+      nodeScenario = requireNotNull(leaf.content) {
+        "Unresolved leaf '${leaf.uses}' reached task creation without a diagnostic"
+      },
       inputBindings = leaf.bindings,
       callBreadcrumb = leaf.callPath.takeIf { it.isNotEmpty() }?.joinToString(" › "),
     )

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioGraph.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioGraph.kt
@@ -102,7 +102,9 @@ public data class ArbigentScenarioGraph(
           .expandCalls(scenario, projectFileContent.reusableScenarios)
           .leaves
         leaves.forEach { leaf ->
-          val key = "call#${callNodeCounter++}:${leaf.uses}"
+          // `uses` is always set for a leaf from expandCalls; orEmpty keeps the key readable
+          // rather than encoding "null" if that ever stops holding. The counter makes it unique.
+          val key = "call#${callNodeCounter++}:${leaf.uses.orEmpty()}"
           nodes += Node(
             key = key,
             title = leaf.callLabel,

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioGraph.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioGraph.kt
@@ -74,60 +74,11 @@ public data class ArbigentScenarioGraph(
     private const val MAX_GOAL_LENGTH = 60
 
     public fun from(projectFileContent: ArbigentProjectFileContent): ArbigentScenarioGraph {
-      val reusableById = projectFileContent.reusableScenarios.associateBy { it.id }
       val nodes = mutableListOf<Node>()
       val edges = mutableListOf<Edge>()
       // Call-node keys carry a monotonic counter so they can never collide with a
       // scenario key (scenario ids are unrestricted and could imitate any path scheme).
       var callNodeCounter = 0
-
-      /**
-       * Expands one call step. Leaves become nodes chained after [previousKey]; composites are
-       * flattened by recursing into their steps, accumulating the path into [viaPath]. Returns
-       * the key of the last emitted node so the next sibling step can chain from it. Bindings
-       * are resolved like the runtime expansion (`defaults + with` resolved against the caller's
-       * bindings). [expansionStack] guards against cyclic references on content that has not
-       * gone through load-time validation.
-       */
-      fun expandStep(
-        step: ArbigentScenarioContent.ReusableStep,
-        parentBindings: Map<String, String>,
-        viaPath: List<String>,
-        previousKey: String,
-        expansionStack: List<String>,
-      ): String {
-        val key = "call#${callNodeCounter++}:${step.uses}"
-        val target = reusableById[step.uses]
-        val resolvedWith = step.withValues.mapValues { (_, value) ->
-          ReusableInputsResolver.resolve(value, parentBindings)
-        }
-        val defaults = target?.inputs.orEmpty()
-          .mapNotNull { (name, input) -> input.default?.let { name to it } }.toMap()
-        val bindings = defaults + resolvedWith
-        val label = ReusableInputsResolver.breadcrumbLabel(step.uses, bindings)
-        // Unresolved references (target == null) are reported by validation; keep a leaf node.
-        if (target == null || !target.isCallForm() || step.uses in expansionStack) {
-          nodes += Node(
-            key = key,
-            title = label,
-            subtitle = if (viaPath.isEmpty()) "" else "via ${viaPath.joinToString(" › ")}",
-            kind = NodeKind.ReusableCall,
-          )
-          edges += Edge(fromKey = previousKey, toKey = key, kind = EdgeKind.Call)
-          return key
-        }
-        var lastKey = previousKey
-        target.callSteps().forEach { nestedStep ->
-          lastKey = expandStep(
-            step = nestedStep,
-            parentBindings = bindings,
-            viaPath = viaPath + label,
-            previousKey = lastKey,
-            expansionStack = expansionStack + step.uses,
-          )
-        }
-        return lastKey
-      }
 
       fun scenarioKey(id: String) = "scenario:$id"
 
@@ -140,23 +91,32 @@ public data class ArbigentScenarioGraph(
         )
       }
       // First expand every scenario's call chain and remember where it ends, because a
-      // dependency edge starts from the dependency scenario's last executed node.
+      // dependency edge starts from the dependency scenario's last executed node. The
+      // expansion emits leaves in execution order, so each leaf simply chains after the
+      // previous one; broken references still emit a leaf, since the graph renders an
+      // invalid project instead of rejecting it (diagnostics are reported by validation).
       val lastKeyByScenarioId = mutableMapOf<String, String>()
       projectFileContent.scenarioContents.forEach { scenario ->
         var lastKey = scenarioKey(scenario.id)
-        scenario.callSteps().forEach { step ->
-          lastKey = expandStep(
-            step = step,
-            parentBindings = emptyMap(),
-            viaPath = emptyList(),
-            previousKey = lastKey,
-            expansionStack = emptyList(),
+        val leaves = ArbigentScenarioResolver
+          .expandCalls(scenario, projectFileContent.reusableScenarios)
+          .leaves
+        leaves.forEach { leaf ->
+          val key = "call#${callNodeCounter++}:${leaf.uses}"
+          nodes += Node(
+            key = key,
+            title = leaf.callLabel,
+            subtitle = leaf.viaPath.let { if (it.isEmpty()) "" else "via ${it.joinToString(" › ")}" },
+            kind = NodeKind.ReusableCall,
           )
+          edges += Edge(fromKey = lastKey, toKey = key, kind = EdgeKind.Call)
+          lastKey = key
         }
         lastKeyByScenarioId[scenario.id] = lastKey
       }
       projectFileContent.scenarioContents.forEach { scenario ->
         scenario.dependencyId?.let { dependencyId ->
+          // A dangling dependency silently loses its edge; the rest of the graph still renders.
           lastKeyByScenarioId[dependencyId]?.let { fromKey ->
             edges += Edge(
               fromKey = fromKey,

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioGraph.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioGraph.kt
@@ -79,6 +79,9 @@ public data class ArbigentScenarioGraph(
       // Call-node keys carry a monotonic counter so they can never collide with a
       // scenario key (scenario ids are unrestricted and could imitate any path scheme).
       var callNodeCounter = 0
+      // `associateBy` resolves a duplicate reusable id to the last declaration, which is what
+      // the graph has always drawn; the runtime resolves it to the first.
+      val reusableById = projectFileContent.reusableScenarios.associateBy { it.id }
 
       fun scenarioKey(id: String) = "scenario:$id"
 
@@ -99,7 +102,7 @@ public data class ArbigentScenarioGraph(
       projectFileContent.scenarioContents.forEach { scenario ->
         var lastKey = scenarioKey(scenario.id)
         val leaves = ArbigentScenarioResolver
-          .expandCalls(scenario, projectFileContent.reusableScenarios)
+          .expandCalls(scenario, reusableById::get)
           .leaves
         leaves.forEach { leaf ->
           // `uses` is always set for a leaf from expandCalls; orEmpty keeps the key readable

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
@@ -1,0 +1,237 @@
+package io.github.takahirom.arbigent
+
+/**
+ * Single implementation of "scenario -> ordered list of things that actually execute".
+ *
+ * Two independent walks live here, because a project has two kinds of references:
+ * - `dependency`: a scenario runs after the scenario it depends on (at most one parent, so the
+ *   dependency structure is a forest of chains).
+ * - `uses`/`steps`: a call site expands into the reusable leaves it eventually reaches, with
+ *   `{{inputs.*}}` bound from `with` + declared defaults.
+ *
+ * The resolver never throws. Broken references are reported as [ArbigentScenarioDiagnostic]s
+ * alongside a best-effort result, so each caller keeps its own policy: the runtime and the CLI
+ * turn diagnostics into errors, the graph renders the broken project anyway.
+ */
+public object ArbigentScenarioResolver {
+
+  /**
+   * One executable leaf. [content] is null for a call that could not be resolved (dangling or
+   * cyclic reference); the accompanying diagnostic explains why, and [callPath] still carries the
+   * label so renderers can show the broken call.
+   */
+  public data class ResolvedLeaf(
+    /** Id of the scenario whose expansion produced this leaf (the agent task's scenario id). */
+    public val rootScenarioId: String,
+    /** The `uses` id of the call site, or null when the leaf is the scenario itself. */
+    public val uses: String?,
+    public val content: ArbigentScenarioContent?,
+    /** Input bindings in effect, or null when the leaf is the scenario itself (no call involved). */
+    public val bindings: Map<String, String>?,
+    /**
+     * `[rootScenarioId, enclosing composite labels..., this leaf's label]`, empty for a scenario
+     * that is not reached through a call.
+     */
+    public val callPath: List<String>,
+  ) {
+    /** Label of this leaf's own call site, e.g. `login (user=paid)`. */
+    public val callLabel: String get() = callPath.last()
+
+    /** Enclosing composite labels between the scenario and this leaf. */
+    public val viaPath: List<String> get() = callPath.drop(1).dropLast(1)
+  }
+
+  public data class Resolution(
+    public val leaves: List<ResolvedLeaf>,
+    public val diagnostics: List<ArbigentScenarioDiagnostic>,
+  )
+
+  /**
+   * Walks [target]'s `dependency` chain root-first and expands each scenario's calls, returning
+   * the leaves in execution order.
+   *
+   * [scenarioLookup] resolves a dependency id; callers pass their existing index so duplicate ids
+   * keep resolving the way they always did.
+   */
+  public fun resolveChain(
+    target: ArbigentScenarioContent,
+    reusableScenarios: List<ArbigentScenarioContent>,
+    scenarioLookup: (String) -> ArbigentScenarioContent?,
+  ): Resolution {
+    val leaves = mutableListOf<ResolvedLeaf>()
+    val diagnostics = mutableListOf<ArbigentScenarioDiagnostic>()
+    val visited = mutableSetOf<String>()
+
+    fun dfs(scenario: ArbigentScenarioContent, dependencyStack: List<String>) {
+      if (dependencyStack.contains(scenario.id)) {
+        diagnostics += ArbigentScenarioDiagnostic.CyclicDependency(dependencyStack + scenario.id)
+        return
+      }
+      if (!visited.add(scenario.id)) return
+      scenario.dependencyId?.let { dependencyId ->
+        val dependency = scenarioLookup(dependencyId)
+        if (dependency == null) {
+          diagnostics += ArbigentScenarioDiagnostic.DanglingDependency(scenario.id, dependencyId)
+        } else {
+          dfs(dependency, dependencyStack + scenario.id)
+        }
+      }
+      val expansion = expandCalls(scenario, reusableScenarios)
+      leaves += expansion.leaves
+      diagnostics += expansion.diagnostics
+      if (!scenario.isCallForm()) {
+        leaves += ResolvedLeaf(
+          rootScenarioId = scenario.id,
+          uses = null,
+          content = scenario,
+          bindings = null,
+          callPath = emptyList(),
+        )
+      }
+    }
+
+    dfs(target, emptyList())
+    return Resolution(leaves, diagnostics)
+  }
+
+  /**
+   * Expands only [scenario]'s own `uses`/`steps` (no dependency walk), flattening composites into
+   * the leaves that actually execute. Empty for a scenario that has no calls.
+   */
+  public fun expandCalls(
+    scenario: ArbigentScenarioContent,
+    reusableScenarios: List<ArbigentScenarioContent>,
+  ): Resolution {
+    if (!scenario.isCallForm()) return Resolution(emptyList(), emptyList())
+    val reusableById = reusableScenarios.associateBy { it.id }
+    val leaves = mutableListOf<ResolvedLeaf>()
+    val diagnostics = mutableListOf<ArbigentScenarioDiagnostic>()
+
+    fun expandStep(
+      step: ArbigentScenarioContent.ReusableStep,
+      parentBindings: Map<String, String>,
+      breadcrumb: List<String>,
+      expansionStack: List<String>,
+    ) {
+      val target = reusableById[step.uses]
+      // Explicit propagation: with-values may reference the caller's own inputs via {{inputs.*}}.
+      val resolvedWith = step.withValues.mapValues { (_, value) ->
+        ReusableInputsResolver.resolve(value, parentBindings)
+      }
+      val defaults = target?.inputs.orEmpty()
+        .mapNotNull { (name, input) -> input.default?.let { name to it } }.toMap()
+      // Label with the effective bindings (including defaults) so reports show the full snapshot.
+      val bindings = defaults + resolvedWith
+      val callPath = breadcrumb + ReusableInputsResolver.breadcrumbLabel(step.uses, bindings)
+
+      fun unresolvedLeaf() {
+        leaves += ResolvedLeaf(
+          rootScenarioId = scenario.id,
+          uses = step.uses,
+          content = null,
+          bindings = bindings,
+          callPath = callPath,
+        )
+      }
+
+      if (expansionStack.contains(step.uses)) {
+        diagnostics += ArbigentScenarioDiagnostic.CyclicReusable(expansionStack + step.uses)
+        unresolvedLeaf()
+        return
+      }
+      if (target == null) {
+        diagnostics += ArbigentScenarioDiagnostic.UnresolvedReusable(
+          referencedFrom = breadcrumb.lastOrNull() ?: scenario.id,
+          uses = step.uses,
+        )
+        unresolvedLeaf()
+        return
+      }
+      if (target.isCallForm()) {
+        target.callSteps().forEach {
+          expandStep(it, bindings, callPath, expansionStack + step.uses)
+        }
+      } else {
+        leaves += ResolvedLeaf(
+          rootScenarioId = scenario.id,
+          uses = step.uses,
+          content = target,
+          bindings = bindings,
+          callPath = callPath,
+        )
+      }
+    }
+
+    scenario.callSteps().forEach { step ->
+      expandStep(step, emptyMap(), listOf(scenario.id), emptyList())
+    }
+    return Resolution(leaves, diagnostics)
+  }
+
+  /**
+   * Orders [items] as a dependency forest and pairs each with its depth: roots first, each
+   * followed by its dependents. An item whose dependency is not in [items] (or is itself) is a
+   * root. Reference-based so the UI can order live scenario state holders, which have no stable id.
+   */
+  public fun <T> dependencyForestWithDepth(
+    items: List<T>,
+    dependencyOf: (T) -> T?,
+  ): List<Pair<T, Int>> {
+    val dependents = mutableMapOf<T, MutableList<T>>()
+    val roots = mutableListOf<T>()
+
+    items.forEach { item ->
+      val dependency = items.firstOrNull { it == dependencyOf(item) }
+      if (dependency == null || dependency == item) {
+        roots.add(item)
+      } else {
+        dependents.getOrPut(dependency) { mutableListOf() }.add(item)
+      }
+    }
+
+    val result = mutableListOf<Pair<T, Int>>()
+    fun walk(item: T, depth: Int) {
+      result.add(item to depth)
+      dependents[item]?.forEach { walk(it, depth + 1) }
+    }
+    roots.forEach { walk(it, 0) }
+    return result
+  }
+}
+
+/** A broken reference found while resolving scenarios. Callers decide whether it is fatal. */
+public sealed interface ArbigentScenarioDiagnostic {
+  public val message: String
+
+  public data class DanglingDependency(
+    public val scenarioId: String,
+    public val dependencyId: String,
+  ) : ArbigentScenarioDiagnostic {
+    override val message: String
+      get() = "Scenario '$scenarioId' depends on unknown scenario '$dependencyId'."
+  }
+
+  /** [path] repeats the scenario that closes the cycle, e.g. `a -> b -> a`. */
+  public data class CyclicDependency(public val path: List<String>) : ArbigentScenarioDiagnostic {
+    override val message: String
+      get() = "Cyclic scenario dependency detected: ${path.joinToString(" -> ")}"
+  }
+
+  public data class DuplicateScenarioId(public val id: String) : ArbigentScenarioDiagnostic {
+    override val message: String
+      get() = "scenarios: duplicate id '$id'"
+  }
+
+  public data class UnresolvedReusable(
+    public val referencedFrom: String,
+    public val uses: String,
+  ) : ArbigentScenarioDiagnostic {
+    override val message: String
+      get() = "Reusable scenario '$uses' referenced from '$referencedFrom' is not defined in reusableScenarios"
+  }
+
+  public data class CyclicReusable(public val path: List<String>) : ArbigentScenarioDiagnostic {
+    override val message: String
+      get() = "Cyclic reusable scenario reference detected: ${path.joinToString(" -> ")}"
+  }
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
@@ -55,33 +55,45 @@ public object ArbigentScenarioResolver {
    * Walks [target]'s `dependency` chain root-first and expands each scenario's calls, returning
    * the leaves in execution order.
    *
-   * [scenarioLookup] resolves a dependency id; callers pass their existing index so duplicate ids
-   * keep resolving the way they always did.
+   * [scenarioLookup] and [reusableLookup] resolve a dependency id and a `uses` id. Callers pass
+   * their existing index, because they disagree on which declaration wins for a duplicate id and
+   * that difference is observable for content that never went through load-time validation.
    */
   public fun resolveChain(
     target: ArbigentScenarioContent,
-    reusableScenarios: List<ArbigentScenarioContent>,
     scenarioLookup: (String) -> ArbigentScenarioContent?,
+    reusableLookup: (String) -> ArbigentScenarioContent?,
   ): Resolution {
     val leaves = mutableListOf<ResolvedLeaf>()
     val diagnostics = mutableListOf<ArbigentScenarioDiagnostic>()
-    val visited = mutableSetOf<String>()
+    // Keyed by instance, not by id: `ArbigentScenarioContent` does not override `equals`, and the
+    // runtime's `visited` set has always been identity-based. Two declarations sharing an id are
+    // therefore both expanded, which only in-memory content can produce — load-time validation
+    // rejects duplicate scenario ids.
+    val visited = mutableSetOf<ArbigentScenarioContent>()
 
-    fun dfs(scenario: ArbigentScenarioContent, dependencyStack: List<String>) {
-      if (dependencyStack.contains(scenario.id)) {
-        diagnostics += ArbigentScenarioDiagnostic.CyclicDependency(dependencyStack + scenario.id)
+    // Both the path guard and [visited] are keyed by instance, not by id, because
+    // `ArbigentScenarioContent` does not override `equals` and the runtime's cut-off has always
+    // been identity-based. Two declarations sharing an id are therefore both expanded instead of
+    // the second looking like a cycle. Only in-memory content can produce that — load-time
+    // validation rejects duplicate scenario ids.
+    fun dfs(scenario: ArbigentScenarioContent, dependencyStack: List<ArbigentScenarioContent>) {
+      if (dependencyStack.any { it === scenario }) {
+        diagnostics += ArbigentScenarioDiagnostic.CyclicDependency(
+          (dependencyStack + scenario).map { it.id }
+        )
         return
       }
-      if (!visited.add(scenario.id)) return
+      if (!visited.add(scenario)) return
       scenario.dependencyId?.let { dependencyId ->
         val dependency = scenarioLookup(dependencyId)
         if (dependency == null) {
           diagnostics += ArbigentScenarioDiagnostic.DanglingDependency(scenario.id, dependencyId)
         } else {
-          dfs(dependency, dependencyStack + scenario.id)
+          dfs(dependency, dependencyStack + scenario)
         }
       }
-      val expansion = expandCalls(scenario, reusableScenarios)
+      val expansion = expandCalls(scenario, reusableLookup)
       leaves += expansion.leaves
       diagnostics += expansion.diagnostics
       if (!scenario.isCallForm()) {
@@ -102,13 +114,16 @@ public object ArbigentScenarioResolver {
   /**
    * Expands only [scenario]'s own `uses`/`steps` (no dependency walk), flattening composites into
    * the leaves that actually execute. Empty for a scenario that has no calls.
+   *
+   * [reusableLookup] is supplied by the caller for the same reason as in [resolveChain]: the
+   * runtime resolves a duplicate `uses` id to the first declaration while the graph and the CLI
+   * resolve it to the last.
    */
   public fun expandCalls(
     scenario: ArbigentScenarioContent,
-    reusableScenarios: List<ArbigentScenarioContent>,
+    reusableLookup: (String) -> ArbigentScenarioContent?,
   ): Resolution {
     if (!scenario.isCallForm()) return Resolution(emptyList(), emptyList())
-    val reusableById = reusableScenarios.associateBy { it.id }
     val leaves = mutableListOf<ResolvedLeaf>()
     val diagnostics = mutableListOf<ArbigentScenarioDiagnostic>()
 
@@ -118,7 +133,7 @@ public object ArbigentScenarioResolver {
       breadcrumb: List<String>,
       expansionStack: List<String>,
     ) {
-      val target = reusableById[step.uses]
+      val target = reusableLookup(step.uses)
       // Explicit propagation: with-values may reference the caller's own inputs via {{inputs.*}}.
       val resolvedWith = step.withValues.mapValues { (_, value) ->
         ReusableInputsResolver.resolve(value, parentBindings)

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
@@ -34,7 +34,12 @@ public object ArbigentScenarioResolver {
      */
     public val callPath: List<String>,
   ) {
-    /** Label of this leaf's own call site, e.g. `login (user=paid)`. */
+    /**
+     * Label of this leaf's own call site, e.g. `login (user=paid)`.
+     * Only defined for a leaf reached through a call ([uses] is non-null); [expandCalls] emits
+     * only such leaves, while [resolveChain] can also emit the scenario itself with an empty
+     * [callPath], for which there is no call site to label.
+     */
     public val callLabel: String get() = callPath.last()
 
     /** Enclosing composite labels between the scenario and this leaf. */
@@ -171,7 +176,13 @@ public object ArbigentScenarioResolver {
   /**
    * Orders [items] as a dependency forest and pairs each with its depth: roots first, each
    * followed by its dependents. An item whose dependency is not in [items] (or is itself) is a
-   * root. Reference-based so the UI can order live scenario state holders, which have no stable id.
+   * root. Items are matched with `==` and used as map keys, so the UI can order live scenario
+   * state holders (which have no stable id) by identity — `ArbigentScenarioStateHolder` does not
+   * override `equals`.
+   *
+   * Items that only reach each other form no root, so a dependency cycle is omitted from the
+   * result entirely. That is what the UI has always done; see
+   * `mutualDependencyCycleIsOmittedFromTheForest`.
    */
   public fun <T> dependencyForestWithDepth(
     items: List<T>,

--- a/arbigent-core/src/test/java/ScenarioResolutionCharacterizationTest.kt
+++ b/arbigent-core/src/test/java/ScenarioResolutionCharacterizationTest.kt
@@ -103,6 +103,73 @@ class ScenarioResolutionCharacterizationTest {
     assertEquals(listOf("first", "A"), goals)
   }
 
+  /**
+   * The runtime and the graph disagree on which declaration wins for a duplicate reusable id:
+   * `createArbigentScenario` looked it up with `firstOrNull { it.id == step.uses }` while
+   * `ArbigentScenarioGraph` and `instruction` used `associateBy`. Loading YAML rejects duplicate
+   * reusable ids, so only in-memory content — what the UI holds while editing — can reach this.
+   */
+  @Test
+  fun duplicateReusableIdResolvesToTheFirstAtRuntimeAndTheLastInTheGraph() {
+    // Each duplicate is a composite reaching a differently-named leaf, so the winner is visible
+    // in both the executed goals and the rendered node titles.
+    val scenarios = listOf(ArbigentScenarioContent(id = "caller", uses = "part"))
+    val reusableScenarios = listOf(
+      ArbigentScenarioContent(
+        id = "part",
+        steps = listOf(ArbigentScenarioContent.ReusableStep(uses = "leaf-of-first")),
+      ),
+      ArbigentScenarioContent(
+        id = "part",
+        steps = listOf(ArbigentScenarioContent.ReusableStep(uses = "leaf-of-last")),
+      ),
+      ArbigentScenarioContent(id = "leaf-of-first", goal = "reached the first declaration"),
+      ArbigentScenarioContent(id = "leaf-of-last", goal = "reached the last declaration"),
+    )
+
+    val goals = scenarios.createArbigentScenario(
+      projectSettings = ArbigentProjectSettings(),
+      scenario = scenarios.single(),
+      aiFactory = { FakeAi() },
+      deviceFactory = { FakeDevice() },
+      aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache(),
+      reusableScenarios = reusableScenarios,
+    ).agentTasks.map { it.goal }
+    assertEquals(listOf("reached the first declaration"), goals)
+
+    val graph = ArbigentScenarioGraph.from(
+      ArbigentProjectFileContent(
+        scenarioContents = scenarios,
+        reusableScenarios = reusableScenarios,
+      )
+    )
+    assertEquals(listOf("caller", "leaf-of-last"), graph.nodes.map { it.title })
+  }
+
+  /**
+   * The runtime's `visited` set is keyed by instance, not by id, because
+   * `ArbigentScenarioContent` does not override `equals`. Two declarations sharing an id are both
+   * expanded rather than the second being swallowed. Only in-memory content reaches this — load
+   * rejects duplicate scenario ids.
+   */
+  @Test
+  fun duplicateScenarioIdInMemoryExpandsBothDeclarations() {
+    val first = ArbigentScenarioContent(id = "dup", goal = "dup-first")
+    val middle = ArbigentScenarioContent(id = "x", goal = "x", dependencyId = "dup")
+    val second = ArbigentScenarioContent(id = "dup", goal = "dup-second", dependencyId = "x")
+    val scenarios = listOf(first, middle, second)
+
+    val goals = scenarios.createArbigentScenario(
+      projectSettings = ArbigentProjectSettings(),
+      scenario = second,
+      aiFactory = { FakeAi() },
+      deviceFactory = { FakeDevice() },
+      aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache(),
+    ).agentTasks.map { it.goal }
+
+    assertEquals(listOf("dup-first", "x", "dup-second"), goals)
+  }
+
   @Test
   fun graphSilentlyDropsDanglingDependencyEdge() {
     val graph = ArbigentScenarioGraph.from(load(danglingDependency))

--- a/arbigent-core/src/test/java/ScenarioResolutionCharacterizationTest.kt
+++ b/arbigent-core/src/test/java/ScenarioResolutionCharacterizationTest.kt
@@ -148,6 +148,82 @@ class ScenarioResolutionCharacterizationTest {
     )
   }
 
+  /**
+   * A mutual cycle gives every item a dependency inside the list, so no root exists and the
+   * whole cycle drops out of the ordering. The UI has always behaved this way: the pre-refactor
+   * `sortedScenarioAndDepth` built the same roots/dependents split, and its
+   * `if (v.isEmpty()) roots.add(k)` branch was unreachable because `getOrPut` always inserted a
+   * non-empty list.
+   *
+   * This matters beyond ordering, because `getCurrentProjectFileContent()` serializes
+   * `sortedScenariosAndDepthsStateFlow`, so scenarios in a cycle are dropped when the project is
+   * saved. That is a pre-existing bug rather than something this refactoring introduces, and it
+   * is pinned here so a fix has to change this test deliberately.
+   */
+  @Test
+  fun mutualDependencyCycleIsOmittedFromTheForest() {
+    class Item(val name: String, var dependency: Item? = null)
+
+    val a = Item("a")
+    val b = Item("b", a)
+    a.dependency = b
+    val unrelated = Item("unrelated")
+
+    val ordered = ArbigentScenarioResolver.dependencyForestWithDepth(listOf(a, b, unrelated)) {
+      it.dependency
+    }
+
+    assertEquals(listOf("unrelated" to 0), ordered.map { (item, depth) -> item.name to depth })
+  }
+
+  /**
+   * `createArbigentScenario` turns an unresolvable or cyclic `uses` into an exception. Without
+   * that throw the null-content leaf the resolver emits for those diagnostics would reach
+   * `requireNotNull(leaf.content)`, so the branch is pinned here.
+   *
+   * Loading YAML cannot reach it — reusable references are validated at load time — so these
+   * cases build the content in memory, the way the UI does while a project is being edited.
+   */
+  private fun buildTasks(
+    scenarios: List<ArbigentScenarioContent>,
+    reusableScenarios: List<ArbigentScenarioContent> = emptyList(),
+  ) = scenarios.createArbigentScenario(
+    projectSettings = ArbigentProjectSettings(),
+    scenario = scenarios.first(),
+    aiFactory = { FakeAi() },
+    deviceFactory = { FakeDevice() },
+    aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache(),
+    reusableScenarios = reusableScenarios,
+  )
+
+  @Test
+  fun runtimeRejectsUnresolvedReusableReference() {
+    val failure = assertFailsWith<ArbigentProjectValidationException> {
+      buildTasks(listOf(ArbigentScenarioContent(id = "a", uses = "nowhere")))
+    }
+    assertEquals(
+      "Reusable scenario 'nowhere' referenced from 'a' is not defined in reusableScenarios",
+      failure.message
+    )
+  }
+
+  @Test
+  fun runtimeRejectsCyclicReusableReference() {
+    val failure = assertFailsWith<ArbigentProjectValidationException> {
+      buildTasks(
+        scenarios = listOf(ArbigentScenarioContent(id = "a", uses = "first")),
+        reusableScenarios = listOf(
+          ArbigentScenarioContent(id = "first", uses = "second"),
+          ArbigentScenarioContent(id = "second", uses = "first"),
+        ),
+      )
+    }
+    assertEquals(
+      "Cyclic reusable scenario reference detected: first -> second -> first",
+      failure.message
+    )
+  }
+
   @Test
   fun reusableExpansionKeepsBreadcrumbsAndOrder() {
     val project = load(

--- a/arbigent-core/src/test/java/ScenarioResolutionCharacterizationTest.kt
+++ b/arbigent-core/src/test/java/ScenarioResolutionCharacterizationTest.kt
@@ -1,0 +1,198 @@
+package io.github.takahirom.arbigent.sample.test
+
+import io.github.takahirom.arbigent.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+
+/**
+ * Records how each caller of the scenario-resolution logic reacts to broken `dependency` graphs
+ * today. The four callers deliberately disagree, so this test pins the current behavior down
+ * before the resolution logic is unified; it must keep passing across the refactoring.
+ */
+class ScenarioResolutionCharacterizationTest {
+  private fun load(yaml: String): ArbigentProjectFileContent = ArbigentProjectSerializer().load(yaml)
+
+  private fun ArbigentProjectFileContent.scenario(id: String) =
+    scenarioContents.first { it.id == id }
+
+  private fun ArbigentProjectFileContent.taskIdsOf(id: String): List<String> =
+    scenarioContents.createArbigentScenario(
+      projectSettings = settings,
+      scenario = scenario(id),
+      aiFactory = { FakeAi() },
+      deviceFactory = { FakeDevice() },
+      aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache(),
+      fixedScenarios = fixedScenarios,
+      reusableScenarios = reusableScenarios,
+    ).agentTasks.map { it.scenarioId }
+
+  private val danglingDependency = """
+    scenarios:
+    - id: "a"
+      goal: "A"
+      dependency: "missing"
+    """
+
+  private val cyclicDependency = """
+    scenarios:
+    - id: "a"
+      goal: "A"
+      dependency: "c"
+    - id: "b"
+      goal: "B"
+      dependency: "a"
+    - id: "c"
+      goal: "C"
+      dependency: "b"
+    """
+
+  private val duplicateScenarioIds = """
+    scenarios:
+    - id: "a"
+      goal: "first"
+    - id: "a"
+      goal: "second"
+    """
+
+  @Test
+  fun brokenDependenciesLoadWithoutValidationError() {
+    // `dependency` is not validated at load time; only reusable scenarios are.
+    load(danglingDependency)
+    load(cyclicDependency)
+    load(duplicateScenarioIds)
+  }
+
+  @Test
+  fun runtimeThrowsNoSuchElementOnDanglingDependency() {
+    val project = load(danglingDependency)
+    val failure = assertFailsWith<NoSuchElementException> { project.taskIdsOf("a") }
+    assertEquals("Collection contains no element matching the predicate.", failure.message)
+  }
+
+  @Test
+  fun runtimeSilentlyTruncatesCyclicDependency() {
+    // No error: the `visited` set cuts the cycle and the remaining tasks are emitted.
+    val project = load(cyclicDependency)
+    assertEquals(listOf("b", "c", "a"), project.taskIdsOf("a"))
+    assertEquals(listOf("c", "a", "b"), project.taskIdsOf("b"))
+    assertEquals(listOf("a", "b", "c"), project.taskIdsOf("c"))
+  }
+
+  @Test
+  fun runtimeResolvesDuplicateScenarioIdToTheFirstDeclaration() {
+    val project = load(
+      """
+      scenarios:
+      - id: "dep"
+        goal: "first"
+      - id: "dep"
+        goal: "second"
+      - id: "a"
+        goal: "A"
+        dependency: "dep"
+      """
+    )
+    val goals = project.scenarioContents.createArbigentScenario(
+      projectSettings = project.settings,
+      scenario = project.scenario("a"),
+      aiFactory = { FakeAi() },
+      deviceFactory = { FakeDevice() },
+      aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache(),
+    ).agentTasks.map { it.goal }
+    assertEquals(listOf("first", "A"), goals)
+  }
+
+  @Test
+  fun graphSilentlyDropsDanglingDependencyEdge() {
+    val graph = ArbigentScenarioGraph.from(load(danglingDependency))
+    assertEquals(listOf("a"), graph.nodes.map { it.title })
+    assertEquals(emptyList(), graph.edges)
+  }
+
+  @Test
+  fun graphKeepsCyclicDependencyEdges() {
+    val graph = ArbigentScenarioGraph.from(load(cyclicDependency))
+    assertEquals(
+      listOf(
+        "scenario:c" to "scenario:a",
+        "scenario:a" to "scenario:b",
+        "scenario:b" to "scenario:c",
+      ),
+      graph.edges.map { it.fromKey to it.toKey }
+    )
+  }
+
+  /**
+   * The UI tree ordering: roots first, dependents indented under them. A scenario pointing at
+   * something outside the list (the UI's shape of a dangling dependency) is shown as a root.
+   */
+  @Test
+  fun dependencyForestTreatsMissingAndSelfDependenciesAsRoots() {
+    class Item(val name: String, var dependency: Item? = null)
+
+    val root = Item("root")
+    val child = Item("child", root)
+    val grandChild = Item("grandChild", child)
+    val orphan = Item("orphan", Item("not-in-list"))
+    val selfie = Item("selfie")
+    selfie.dependency = selfie
+
+    val ordered = ArbigentScenarioResolver.dependencyForestWithDepth(
+      listOf(root, child, grandChild, orphan, selfie)
+    ) { it.dependency }
+
+    assertEquals(
+      listOf("root" to 0, "child" to 1, "grandChild" to 2, "orphan" to 0, "selfie" to 0),
+      ordered.map { (item, depth) -> item.name to depth }
+    )
+  }
+
+  @Test
+  fun reusableExpansionKeepsBreadcrumbsAndOrder() {
+    val project = load(
+      """
+      scenarios:
+      - id: "setup"
+        goal: "Setup"
+      - id: "buy"
+        dependency: "setup"
+        steps:
+        - uses: "prepare"
+          with:
+            user: "paid"
+        - uses: "checkout"
+      reusableScenarios:
+      - id: "prepare"
+        inputs:
+          user:
+            default: "free"
+        steps:
+        - uses: "login"
+          with:
+            user: "{{inputs.user}}"
+      - id: "login"
+        inputs:
+          user:
+            default: "free"
+        goal: "Log in as {{inputs.user}}"
+      - id: "checkout"
+        goal: "Checkout"
+      """
+    )
+    val tasks = project.scenarioContents.createArbigentScenario(
+      projectSettings = project.settings,
+      scenario = project.scenario("buy"),
+      aiFactory = { FakeAi() },
+      deviceFactory = { FakeDevice() },
+      aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache(),
+      reusableScenarios = project.reusableScenarios,
+    ).agentTasks
+    assertEquals(listOf("setup", "buy", "buy"), tasks.map { it.scenarioId })
+    assertEquals(listOf("Setup", "Log in as paid", "Checkout"), tasks.map { it.goal })
+    assertEquals(
+      listOf(null, "buy › prepare (user=paid) › login (user=paid)", "buy › checkout"),
+      tasks.map { it.callBreadcrumb }
+    )
+  }
+}

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -466,43 +466,12 @@ class ArbigentAppStateHolder(
         reusableScenarios = this@ArbigentAppStateHolder._reusableScenariosFlow.value
       )
 
-  private fun sortedScenarioAndDepth(allScenarios: List<ArbigentScenarioStateHolder>): List<Pair<ArbigentScenarioStateHolder, Int>> {
-    // Build dependency map using goals as keys
-    val dependentMap =
-      mutableMapOf<ArbigentScenarioStateHolder, MutableList<ArbigentScenarioStateHolder>>()
-    val rootScenarios = mutableListOf<ArbigentScenarioStateHolder>()
-
-    allScenarios.forEach { scenario ->
-      allScenarios.firstOrNull { it == scenario.dependencyScenarioStateHolderStateFlow.value }
-        ?.let {
-          if (it == scenario) {
-            rootScenarios.add(scenario)
-            return@forEach
-          }
-          dependentMap.getOrPut(it) { mutableListOf() }.add(scenario)
-        } ?: run {
-        rootScenarios.add(scenario)
-      }
+  // A scenario whose dependency is gone (or is itself) is shown as a root, matching how the
+  // dependency forest is walked everywhere else.
+  private fun sortedScenarioAndDepth(allScenarios: List<ArbigentScenarioStateHolder>): List<Pair<ArbigentScenarioStateHolder, Int>> =
+    ArbigentScenarioResolver.dependencyForestWithDepth(allScenarios) {
+      it.dependencyScenarioStateHolderStateFlow.value
     }
-    dependentMap.forEach { (k, v) ->
-      if (v.isEmpty()) {
-        rootScenarios.add(k)
-      }
-    }
-
-    // Assign depths using BFS
-    val result = mutableListOf<Pair<ArbigentScenarioStateHolder, Int>>()
-    fun dfs(scenario: ArbigentScenarioStateHolder, depth: Int) {
-      result.add(scenario to depth)
-      dependentMap[scenario]?.forEach {
-        dfs(it, depth + 1)
-      }
-    }
-    rootScenarios.forEach {
-      dfs(it, 0)
-    }
-    return result
-  }
 
   fun runAllFailed() {
     job?.cancel()


### PR DESCRIPTION
Pure refactoring. **No observable behavior changes** — see the verification section.

## Problem

Walking `dependency` and expanding reusable `uses`/`steps` calls was implemented four times, and the four implementations disagreed about broken projects:

| implementation | dangling `dependency` | cyclic `dependency` |
|---|---|---|
| runtime `createArbigentScenario` | `NoSuchElementException` from `first { it.id == dependency }` | silently cut short by `visited` |
| `arbigent instruction` `resolveChain` | `CliktError` naming both scenarios | `CliktError` with the path |
| `ArbigentScenarioGraph.from` | edge silently dropped | not detected |
| UI `sortedScenarioAndDepth` | treated as a root | not detected |

The reusable expansion around `ReusableInputsResolver` (binding resolution, composite flattening, breadcrumb building) was duplicated across three of them.

## What this PR does

Adds `ArbigentScenarioResolver` in `arbigent-core` as the single implementation:

- `resolveChain(target, reusableScenarios, scenarioLookup)` — dependency chain root-first, calls expanded into the leaves that actually execute.
- `expandCalls(scenario, reusableScenarios)` — one scenario's calls only (what the graph needs).
- `dependencyForestWithDepth(items, dependencyOf)` — the UI's roots-then-dependents ordering, reference-based so it works on live state holders.

**The resolver never throws.** Broken references come back as `ArbigentScenarioDiagnostic` values (`DanglingDependency`, `CyclicDependency`, `UnresolvedReusable`, `CyclicReusable`, `DuplicateScenarioId`) next to a best-effort result, so each caller keeps its own policy. That is what makes this PR behavior-preserving while still putting the walk in one place — and it is the hook PR2 uses to make the four agree.

All four call sites now delegate, each keeping exactly the reaction it has today:

- runtime: throws `NoSuchElementException` with the same message on a dangling dependency, ignores the cycle diagnostic
- `instruction`: same `CliktError` messages, thrown on the first diagnostic in discovery order
- graph: ignores diagnostics entirely and renders the broken project
- UI: dangling dependency still shows up as a root

Not touched: the YAML format, `isLeaf`, `RunCommand`'s scenario selection, task ordering.

## Verification

**Characterization tests written first** (`ScenarioResolutionCharacterizationTest`), passing on unmodified `main` before any production code changed, and still passing after:

- broken `dependency` graphs load without a validation error (no `dependency` validation exists today)
- runtime throws `NoSuchElementException("Collection contains no element matching the predicate.")` on a dangling dependency
- runtime silently truncates a 3-scenario cycle, exact task order pinned for all three entry points
- runtime resolves a duplicate scenario id to the *first* declaration
- graph drops the dangling dependency edge and keeps all three edges of a cyclic one
- `dependencyForestWithDepth` puts missing-dependency and self-dependency items at depth 0
- reusable expansion: task ids, goals with `{{inputs.*}}` resolved, and `callBreadcrumb` strings pinned

`InstructionCommandTest`'s dangling-dependency test was tightened from "output mentions both ids" to the exact message.

**End-to-end output diff.** Built the CLI before and after the change and compared `arbigent graph` and `arbigent instruction` (all scenarios) across all 7 projects in `sample-test/src/main/resources/projects/` — including `e2e-test-android.yaml`, which exercises reusable calls with bound inputs. Output is byte-identical.

`./gradlew :arbigent-core:test :arbigent-cli:test` and `./gradlew installDist` pass.
