### PR TITLE
Validate scenario dependencies at project load time

### DIFF
--- a/arbigent-cli/src/main/kotlin/CommonOptions.kt
+++ b/arbigent-cli/src/main/kotlin/CommonOptions.kt
@@ -133,6 +133,26 @@ fun isJourneyProjectSource(projectFile: String): Boolean {
 }
 
 /**
+ * Loads [projectFile] as project content, choosing the Journeys XML importer or the YAML loader.
+ * A project file that fails validation is reported as a plain [CliktError] message rather than an
+ * uncaught exception, since the user's fix is in the YAML, not in the command line.
+ */
+fun loadArbigentProjectFileContent(projectFile: String): ArbigentProjectFileContent =
+  asCliktError {
+    if (isJourneyProjectSource(projectFile)) {
+      ArbigentJourneyXmlImporter.loadProjectContent(File(projectFile))
+    } else {
+      ArbigentProjectSerializer().load(File(projectFile))
+    }
+  }
+
+private fun <T> asCliktError(block: () -> T): T = try {
+  block()
+} catch (e: ArbigentProjectValidationException) {
+  throw CliktError(e.message)
+}
+
+/**
  * Builds an [ArbigentProject] from [projectFile], loading Journeys XML when the path is a
  * journey source and falling back to the normal YAML loader otherwise.
  */
@@ -142,8 +162,8 @@ fun loadArbigentProject(
   deviceFactory: () -> ArbigentDevice,
   appSettings: ArbigentAppSettings,
   dispatcher: CoroutineDispatcher,
-): ArbigentProject {
-  return if (isJourneyProjectSource(projectFile)) {
+): ArbigentProject = asCliktError {
+  if (isJourneyProjectSource(projectFile)) {
     val projectFileContent = ArbigentJourneyXmlImporter.loadProjectContent(File(projectFile))
     ArbigentProject(
       projectFileContent = projectFileContent,

--- a/arbigent-cli/src/main/kotlin/CommonOptions.kt
+++ b/arbigent-cli/src/main/kotlin/CommonOptions.kt
@@ -138,7 +138,7 @@ fun isJourneyProjectSource(projectFile: String): Boolean {
  * uncaught exception, since the user's fix is in the YAML, not in the command line.
  */
 fun loadArbigentProjectFileContent(projectFile: String): ArbigentProjectFileContent =
-  asCliktError {
+  asCliktError(projectFile) {
     if (isJourneyProjectSource(projectFile)) {
       ArbigentJourneyXmlImporter.loadProjectContent(File(projectFile))
     } else {
@@ -146,10 +146,17 @@ fun loadArbigentProjectFileContent(projectFile: String): ArbigentProjectFileCont
     }
   }
 
-private fun <T> asCliktError(block: () -> T): T = try {
+/**
+ * Turns a validation failure into a [CliktError], naming the file it came from — the core reports
+ * the violations but has no idea which path was loaded.
+ */
+private fun <T> asCliktError(projectFile: String, block: () -> T): T = try {
   block()
 } catch (e: ArbigentProjectValidationException) {
-  throw CliktError(e.message)
+  throw CliktError(
+    if (e.violations.isEmpty()) e.message
+    else arbigentValidationReport(e.violations, source = projectFile)
+  )
 }
 
 /**
@@ -162,7 +169,7 @@ fun loadArbigentProject(
   deviceFactory: () -> ArbigentDevice,
   appSettings: ArbigentAppSettings,
   dispatcher: CoroutineDispatcher,
-): ArbigentProject = asCliktError {
+): ArbigentProject = asCliktError(projectFile) {
   if (isJourneyProjectSource(projectFile)) {
     val projectFileContent = ArbigentJourneyXmlImporter.loadProjectContent(File(projectFile))
     ArbigentProject(

--- a/arbigent-cli/src/main/kotlin/GraphCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GraphCommand.kt
@@ -4,7 +4,6 @@ package io.github.takahirom.arbigent.cli
 
 import com.github.ajalt.clikt.core.CliktCommand
 import io.github.takahirom.arbigent.*
-import java.io.File
 
 /**
  * Prints the scenario dependency graph (dependency edges and reusable `uses` edges)
@@ -16,12 +15,7 @@ class ArbigentGraphCommand : CliktCommand(name = "graph") {
 
   override fun run() {
     applyLogLevel(logLevel)
-    val projectFilePath = requireProjectFile(projectFile)
-    val projectFileContent = if (isJourneyProjectSource(projectFilePath)) {
-      ArbigentJourneyXmlImporter.loadProjectContent(File(projectFilePath))
-    } else {
-      ArbigentProjectSerializer().load(File(projectFilePath))
-    }
+    val projectFileContent = loadArbigentProjectFileContent(requireProjectFile(projectFile))
     echo(ArbigentScenarioGraph.from(projectFileContent).toMermaid())
   }
 }

--- a/arbigent-cli/src/main/kotlin/InstructionCommand.kt
+++ b/arbigent-cli/src/main/kotlin/InstructionCommand.kt
@@ -135,16 +135,7 @@ class ArbigentInstructionCommand : CliktCommand(name = "instruction") {
       scenarioLookup = scenariosById::get,
       reusableLookup = reusableById::get,
     )
-    resolution.diagnostics.firstOrNull()?.let { diagnostic ->
-      throw CliktError(
-        when (diagnostic) {
-          // The call site is obvious from the printed chain, so keep the short wording.
-          is ArbigentScenarioDiagnostic.UnresolvedReusable ->
-            "Reusable scenario '${diagnostic.uses}' is not defined in reusableScenarios"
-          else -> diagnostic.message
-        }
-      )
-    }
+    resolution.diagnostics.firstOrNull()?.let { throw CliktError(it.message) }
     return resolution.leaves.map { leaf ->
       val content = requireNotNull(leaf.content)
       val bindings = leaf.bindings.orEmpty()

--- a/arbigent-cli/src/main/kotlin/InstructionCommand.kt
+++ b/arbigent-cli/src/main/kotlin/InstructionCommand.kt
@@ -11,7 +11,6 @@ import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.options.split
 import io.github.takahirom.arbigent.*
 import io.github.takahirom.arbigent.result.ArbigentScenarioDeviceFormFactor
-import java.io.File
 
 /**
  * Prints AI-oriented reproduction instructions for one or more scenarios: the ordered chain of
@@ -41,12 +40,7 @@ class ArbigentInstructionCommand : CliktCommand(name = "instruction") {
 
   override fun run() {
     applyLogLevel(logLevel)
-    val projectFilePath = requireProjectFile(projectFile)
-    val projectFileContent = if (isJourneyProjectSource(projectFilePath)) {
-      ArbigentJourneyXmlImporter.loadProjectContent(File(projectFilePath))
-    } else {
-      ArbigentProjectSerializer().load(File(projectFilePath))
-    }
+    val projectFileContent = loadArbigentProjectFileContent(requireProjectFile(projectFile))
 
     val scenariosById = projectFileContent.scenarioContents.associateBy { it.id }
     val reusableById = projectFileContent.reusableScenarios.associateBy { it.id }

--- a/arbigent-cli/src/test/kotlin/InstructionCommandTest.kt
+++ b/arbigent-cli/src/test/kotlin/InstructionCommandTest.kt
@@ -127,8 +127,11 @@ scenarios:
     assertNotEquals(0, result.statusCode, result.output)
     assertContains(
       result.output,
-      "Scenario 'child' depends on unknown scenario 'missing-parent'."
+      "scenarios 'child': dependency 'missing-parent' is not defined in scenarios"
     )
+    // The report names the file the violations came from.
+    assertContains(result.output, "Invalid project configuration in ")
+    assertContains(result.output, yaml.absolutePath)
   }
 
   @Test
@@ -146,7 +149,7 @@ scenarios:
     )
     val result = run("--scenario-ids=a")
     assertNotEquals(0, result.statusCode, result.output)
-    assertContains(result.output, "Cyclic scenario dependency detected")
+    assertContains(result.output, "cyclic dependency:")
     assertContains(result.output, "a -> b -> a")
   }
 
@@ -162,7 +165,7 @@ scenarios:
     )
     val result = run("--scenario-ids=selfie")
     assertNotEquals(0, result.statusCode, result.output)
-    assertContains(result.output, "Cyclic scenario dependency detected")
+    assertContains(result.output, "cyclic dependency:")
   }
 
   @Test

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -416,18 +416,10 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
     scenarioLookup = { id -> firstOrNull { it.id == id } },
     reusableLookup = { id -> reusableScenarios.firstOrNull { it.id == id } },
   )
-  // The runtime has never validated `dependency`: a cycle is silently cut short by the resolver's
-  // visited set, and only a dangling reference is fatal.
-  resolution.diagnostics.forEach { diagnostic ->
-    when (diagnostic) {
-      is ArbigentScenarioDiagnostic.DanglingDependency ->
-        throw NoSuchElementException("Collection contains no element matching the predicate.")
-      is ArbigentScenarioDiagnostic.UnresolvedReusable,
-      is ArbigentScenarioDiagnostic.CyclicReusable ->
-        throw ArbigentProjectValidationException(diagnostic.message)
-      is ArbigentScenarioDiagnostic.CyclicDependency,
-      is ArbigentScenarioDiagnostic.DuplicateScenarioId -> Unit
-    }
+  // Loading a project file already rejects every one of these, so reaching this point means the
+  // content was built in memory. Fail the same way rather than running a half-resolved chain.
+  resolution.diagnostics.firstOrNull()?.let {
+    throw ArbigentProjectValidationException(it.message)
   }
   val result = resolution.leaves.map { leaf ->
     agentTask(
@@ -648,14 +640,14 @@ public class ArbigentProjectSerializer(
 
   internal fun load(yamlString: String): ArbigentProjectFileContent {
     return yaml.decodeFromString(ArbigentProjectFileContent.serializer(), yamlString)
-      .also { it.validateReusableScenarios() }
+      .also { it.validateProject() }
   }
 
   private fun load(inputStream: InputStream): ArbigentProjectFileContent {
     val jsonString = fileSystem.readText(inputStream)
     val projectFileContent =
       yaml.decodeFromString(ArbigentProjectFileContent.serializer(), jsonString)
-    projectFileContent.validateReusableScenarios()
+    projectFileContent.validateProject()
     return projectFileContent
   }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
@@ -160,8 +160,12 @@ public object ArbigentScenarioResolver {
         return
       }
       if (target == null) {
+        // The owner is the innermost composite the call sits in, or the scenario itself for a
+        // direct call. `expansionStack` holds raw ids; `breadcrumb` holds display labels.
         diagnostics += ArbigentScenarioDiagnostic.UnresolvedReusable(
-          referencedFrom = breadcrumb.lastOrNull() ?: scenario.id,
+          referencedFromSection = if (expansionStack.isEmpty()) DeclarationSection.Scenarios
+          else DeclarationSection.ReusableScenarios,
+          referencedFrom = expansionStack.lastOrNull() ?: scenario.id,
           uses = step.uses,
         )
         unresolvedLeaf()
@@ -266,6 +270,12 @@ public object ArbigentScenarioResolver {
   }
 }
 
+/** Which project-file section a declaration lives in, used to point a violation at it. */
+public enum class DeclarationSection(public val sectionName: String) {
+  Scenarios("scenarios"),
+  ReusableScenarios("reusableScenarios"),
+}
+
 /**
  * A broken reference found while resolving scenarios. Callers decide whether it is fatal.
  *
@@ -287,11 +297,15 @@ public sealed interface ArbigentScenarioDiagnostic {
     override val detail: String get() = "dependency '$dependencyId' is not defined in scenarios"
   }
 
-  /** [path] repeats the scenario that closes the cycle, e.g. `a -> b -> a`. */
+  /** [path] ends with the scenario that closes the cycle, e.g. `a -> b -> a`. */
   public data class CyclicDependency(public val path: List<String>) : ArbigentScenarioDiagnostic {
-    // Attributed to where the cycle starts, so the line points at a scenario the user can edit.
-    override val where: String get() = "scenarios '${path.first()}'"
-    override val detail: String get() = "cyclic dependency: ${path.joinToString(" -> ")}"
+    init { require(path.isNotEmpty()) { "A cycle path needs at least the repeated scenario" } }
+
+    // A walk can enter a cycle from outside it (`tail -> a -> b -> a`), so the lead-in is trimmed
+    // before attributing: load-time and runtime detection must name the same scenario.
+    private val cycle: List<String> get() = path.dropWhile { it != path.last() }
+    override val where: String get() = "scenarios '${cycle.first()}'"
+    override val detail: String get() = "cyclic dependency: ${cycle.joinToString(" -> ")}"
   }
 
   public data class DuplicateScenarioId(
@@ -303,15 +317,25 @@ public sealed interface ArbigentScenarioDiagnostic {
   }
 
   public data class UnresolvedReusable(
+    /** Where the declaration holding the call lives. */
+    public val referencedFromSection: DeclarationSection,
+    /**
+     * Raw id of that declaration. Never a breadcrumb label like `outer (user=paid)`, which names
+     * a call site rather than something the user can open and edit.
+     */
     public val referencedFrom: String,
     public val uses: String,
   ) : ArbigentScenarioDiagnostic {
-    override val where: String get() = "scenarios '$referencedFrom'"
+    override val where: String get() = "${referencedFromSection.sectionName} '$referencedFrom'"
     override val detail: String get() = "uses '$uses' is not defined in reusableScenarios"
   }
 
+  /** [path] ends with the reusable scenario that closes the cycle, e.g. `y -> z -> y`. */
   public data class CyclicReusable(public val path: List<String>) : ArbigentScenarioDiagnostic {
-    override val where: String get() = "reusableScenarios '${path.first()}'"
-    override val detail: String get() = "cyclic reusable reference: ${path.joinToString(" -> ")}"
+    init { require(path.isNotEmpty()) { "A cycle path needs at least the repeated reusable" } }
+
+    private val cycle: List<String> get() = path.dropWhile { it != path.last() }
+    override val where: String get() = "reusableScenarios '${cycle.first()}'"
+    override val detail: String get() = "cyclic reusable reference: ${cycle.joinToString(" -> ")}"
   }
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
@@ -189,6 +189,47 @@ public object ArbigentScenarioResolver {
   }
 
   /**
+   * Whole-project `dependency` diagnostics, in a stable order: duplicate ids, then dangling
+   * references in declaration order, then each cycle once. Used by load-time validation so a
+   * broken project is rejected with every violation at once instead of one per run.
+   */
+  public fun diagnoseDependencies(
+    scenarios: List<ArbigentScenarioContent>,
+  ): List<ArbigentScenarioDiagnostic> {
+    val diagnostics = mutableListOf<ArbigentScenarioDiagnostic>()
+    scenarios.groupBy { it.id }.filterValues { it.size > 1 }.keys.forEach {
+      diagnostics += ArbigentScenarioDiagnostic.DuplicateScenarioId(it)
+    }
+    val byId = scenarios.associateBy { it.id }
+    scenarios.forEach { scenario ->
+      scenario.dependencyId?.let { dependencyId ->
+        if (!byId.containsKey(dependencyId)) {
+          diagnostics += ArbigentScenarioDiagnostic.DanglingDependency(scenario.id, dependencyId)
+        }
+      }
+    }
+
+    // Three-color walk so a cycle shared by several scenarios is reported once.
+    val visiting = mutableSetOf<String>()
+    val done = mutableSetOf<String>()
+    fun visit(id: String, path: List<String>) {
+      if (id in visiting) {
+        diagnostics += ArbigentScenarioDiagnostic.CyclicDependency(
+          path.dropWhile { it != id } + id
+        )
+        return
+      }
+      if (id in done) return
+      visiting += id
+      byId[id]?.dependencyId?.takeIf { byId.containsKey(it) }?.let { visit(it, path + id) }
+      visiting -= id
+      done += id
+    }
+    scenarios.forEach { visit(it.id, emptyList()) }
+    return diagnostics
+  }
+
+  /**
    * Orders [items] as a dependency forest and pairs each with its depth: roots first, each
    * followed by its dependents. An item whose dependency is not in [items] (or is itself) is a
    * root. Items are matched with `==` and used as map keys, so the UI can order live scenario

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
@@ -197,8 +197,8 @@ public object ArbigentScenarioResolver {
     scenarios: List<ArbigentScenarioContent>,
   ): List<ArbigentScenarioDiagnostic> {
     val diagnostics = mutableListOf<ArbigentScenarioDiagnostic>()
-    scenarios.groupBy { it.id }.filterValues { it.size > 1 }.keys.forEach {
-      diagnostics += ArbigentScenarioDiagnostic.DuplicateScenarioId(it)
+    scenarios.groupBy { it.id }.filterValues { it.size > 1 }.forEach { (id, declarations) ->
+      diagnostics += ArbigentScenarioDiagnostic.DuplicateScenarioId(id, declarations.size)
     }
     val byId = scenarios.associateBy { it.id }
     scenarios.forEach { scenario ->
@@ -266,39 +266,52 @@ public object ArbigentScenarioResolver {
   }
 }
 
-/** A broken reference found while resolving scenarios. Callers decide whether it is fatal. */
+/**
+ * A broken reference found while resolving scenarios. Callers decide whether it is fatal.
+ *
+ * [message] follows the same shape as every other validation message —
+ * `<section> '<id>': <what is wrong>`, no trailing period — so a report that mixes dependency
+ * and reusable violations reads as one list.
+ */
 public sealed interface ArbigentScenarioDiagnostic {
-  public val message: String
+  /** Section and id the violation is attributed to, e.g. `scenarios 'checkout'`. */
+  public val where: String
+  public val detail: String
+  public val message: String get() = "$where: $detail"
 
   public data class DanglingDependency(
     public val scenarioId: String,
     public val dependencyId: String,
   ) : ArbigentScenarioDiagnostic {
-    override val message: String
-      get() = "Scenario '$scenarioId' depends on unknown scenario '$dependencyId'."
+    override val where: String get() = "scenarios '$scenarioId'"
+    override val detail: String get() = "dependency '$dependencyId' is not defined in scenarios"
   }
 
   /** [path] repeats the scenario that closes the cycle, e.g. `a -> b -> a`. */
   public data class CyclicDependency(public val path: List<String>) : ArbigentScenarioDiagnostic {
-    override val message: String
-      get() = "Cyclic scenario dependency detected: ${path.joinToString(" -> ")}"
+    // Attributed to where the cycle starts, so the line points at a scenario the user can edit.
+    override val where: String get() = "scenarios '${path.first()}'"
+    override val detail: String get() = "cyclic dependency: ${path.joinToString(" -> ")}"
   }
 
-  public data class DuplicateScenarioId(public val id: String) : ArbigentScenarioDiagnostic {
-    override val message: String
-      get() = "scenarios: duplicate id '$id'"
+  public data class DuplicateScenarioId(
+    public val id: String,
+    public val declarationCount: Int,
+  ) : ArbigentScenarioDiagnostic {
+    override val where: String get() = "scenarios '$id'"
+    override val detail: String get() = "duplicate id (declared $declarationCount times)"
   }
 
   public data class UnresolvedReusable(
     public val referencedFrom: String,
     public val uses: String,
   ) : ArbigentScenarioDiagnostic {
-    override val message: String
-      get() = "Reusable scenario '$uses' referenced from '$referencedFrom' is not defined in reusableScenarios"
+    override val where: String get() = "scenarios '$referencedFrom'"
+    override val detail: String get() = "uses '$uses' is not defined in reusableScenarios"
   }
 
   public data class CyclicReusable(public val path: List<String>) : ArbigentScenarioDiagnostic {
-    override val message: String
-      get() = "Cyclic reusable scenario reference detected: ${path.joinToString(" -> ")}"
+    override val where: String get() = "reusableScenarios '${path.first()}'"
+    override val detail: String get() = "cyclic reusable reference: ${path.joinToString(" -> ")}"
   }
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReusableScenarios.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReusableScenarios.kt
@@ -1,10 +1,25 @@
 package io.github.takahirom.arbigent
 
 /**
- * Thrown when a project file violates the reusable-scenario rules.
+ * Thrown when a project file violates the scenario or reusable-scenario rules.
  * All violations are detected at load time so that a part is never silently skipped at runtime.
+ *
+ * [violations] keeps the individual lines so a caller that knows more about the source than the
+ * core does — the CLI knows which file was loaded — can re-render the report with that context
+ * via [arbigentValidationReport].
  */
-public class ArbigentProjectValidationException(message: String) : RuntimeException(message)
+public class ArbigentProjectValidationException(
+  message: String,
+  public val violations: List<String> = emptyList(),
+) : RuntimeException(message)
+
+/**
+ * Renders validation [violations] as one report. [source] names where the content came from
+ * (a file path) and is left out when the caller has nothing to name — the core never knows it.
+ */
+public fun arbigentValidationReport(violations: List<String>, source: String? = null): String =
+  "Invalid project configuration" + (source?.let { " in $it" } ?: "") + ":\n" +
+    violations.joinToString("\n") { "- $it" }
 
 /**
  * Resolves `{{inputs.name}}` placeholders with values bound at the call site (`with:` + declared defaults).
@@ -43,9 +58,7 @@ public fun ArbigentProjectFileContent.validateProject() {
   val errors = ArbigentScenarioResolver.diagnoseDependencies(scenarioContents).map { it.message } +
     reusableScenarioErrors()
   if (errors.isNotEmpty()) {
-    throw ArbigentProjectValidationException(
-      "Invalid project configuration:\n" + errors.joinToString("\n") { "- $it" }
-    )
+    throw ArbigentProjectValidationException(arbigentValidationReport(errors), errors)
   }
 }
 
@@ -159,8 +172,9 @@ private fun ArbigentProjectFileContent.reusableScenarioErrors(): List<String> {
     }
   }
 
-  val duplicateReusableIds = reusableScenarios.groupBy { it.id }.filterValues { it.size > 1 }.keys
-  duplicateReusableIds.forEach { errors += "reusableScenarios: duplicate id '$it'" }
+  reusableScenarios.groupBy { it.id }.filterValues { it.size > 1 }.forEach { (id, declarations) ->
+    errors += "reusableScenarios '$id': duplicate id (declared ${declarations.size} times)"
+  }
 
   scenarioContents.forEach { validateNode(it, isReusable = false) }
   reusableScenarios.forEach { validateNode(it, isReusable = true) }
@@ -170,7 +184,10 @@ private fun ArbigentProjectFileContent.reusableScenarioErrors(): List<String> {
   fun visit(id: String, path: List<String>) {
     when (visitState[id]) {
       0 -> {
-        errors += "reusableScenarios: cyclic reference detected: ${(path + id).joinToString(" -> ")}"
+        // Same shape as ArbigentScenarioDiagnostic.CyclicReusable: attributed to the cycle's start.
+        val cycle = (path + id).dropWhile { it != id }
+        errors += "reusableScenarios '$id': cyclic reusable reference: " +
+          cycle.joinToString(" -> ")
         return
       }
       1 -> return

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReusableScenarios.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReusableScenarios.kt
@@ -35,10 +35,21 @@ public object ReusableInputsResolver {
 }
 
 /**
- * Load-time validation of reusable scenarios. Throws [ArbigentProjectValidationException]
- * with all violations joined, so the user can fix everything in one pass.
+ * Load-time validation of a project file. Throws [ArbigentProjectValidationException] with all
+ * violations joined, so the user can fix everything in one pass. Covers the reusable-scenario
+ * rules and the `dependency` graph (duplicate scenario ids, dangling and cyclic references).
  */
-public fun ArbigentProjectFileContent.validateReusableScenarios() {
+public fun ArbigentProjectFileContent.validateProject() {
+  val errors = ArbigentScenarioResolver.diagnoseDependencies(scenarioContents).map { it.message } +
+    reusableScenarioErrors()
+  if (errors.isNotEmpty()) {
+    throw ArbigentProjectValidationException(
+      "Invalid project configuration:\n" + errors.joinToString("\n") { "- $it" }
+    )
+  }
+}
+
+private fun ArbigentProjectFileContent.reusableScenarioErrors(): List<String> {
   val errors = mutableListOf<String>()
   val reusableById = reusableScenarios.associateBy { it.id }
 
@@ -174,11 +185,7 @@ public fun ArbigentProjectFileContent.validateReusableScenarios() {
   }
   reusableScenarios.forEach { visit(it.id, emptyList()) }
 
-  if (errors.isNotEmpty()) {
-    throw ArbigentProjectValidationException(
-      "Invalid reusable scenario configuration:\n" + errors.joinToString("\n") { "- $it" }
-    )
-  }
+  return errors
 }
 
 private val RESERVED_ID_CHARS = listOf("/", "#", "@")

--- a/arbigent-core/src/test/java/ReusableScenariosTest.kt
+++ b/arbigent-core/src/test/java/ReusableScenariosTest.kt
@@ -573,7 +573,7 @@ class ReusableScenariosTest {
   @Test
   fun duplicateReusableIdsFailAtLoad() {
     assertValidationError(
-      "duplicate id 'part'",
+      "reusableScenarios 'part': duplicate id (declared 2 times)",
       """
       scenarios:
       - id: "caller"

--- a/arbigent-core/src/test/java/ScenarioResolutionCharacterizationTest.kt
+++ b/arbigent-core/src/test/java/ScenarioResolutionCharacterizationTest.kt
@@ -39,7 +39,7 @@ class ScenarioResolutionCharacterizationTest {
   @Test
   fun danglingDependencyFailsAtLoad() {
     assertValidationError(
-      "Scenario 'a' depends on unknown scenario 'missing'.",
+      "scenarios 'a': dependency 'missing' is not defined in scenarios",
       """
       scenarios:
       - id: "a"
@@ -119,7 +119,7 @@ class ScenarioResolutionCharacterizationTest {
   @Test
   fun cyclicDependencyFailsAtLoadWithThePath() {
     assertValidationError(
-      "Cyclic scenario dependency detected: a -> c -> b -> a",
+      "scenarios 'a': cyclic dependency: a -> c -> b -> a",
       """
       scenarios:
       - id: "a"
@@ -138,7 +138,7 @@ class ScenarioResolutionCharacterizationTest {
   @Test
   fun selfDependencyFailsAtLoad() {
     assertValidationError(
-      "Cyclic scenario dependency detected: selfie -> selfie",
+      "scenarios 'selfie': cyclic dependency: selfie -> selfie",
       """
       scenarios:
       - id: "selfie"
@@ -151,7 +151,7 @@ class ScenarioResolutionCharacterizationTest {
   @Test
   fun duplicateScenarioIdFailsAtLoad() {
     assertValidationError(
-      "scenarios: duplicate id 'a'",
+      "scenarios 'a': duplicate id (declared 2 times)",
       """
       scenarios:
       - id: "a"
@@ -187,9 +187,9 @@ class ScenarioResolutionCharacterizationTest {
       )
     }
     val message = exception.message!!
-    assertTrue(message.contains("scenarios: duplicate id 'dup'"), message)
-    assertTrue(message.contains("Scenario 'orphan' depends on unknown scenario 'missing'."), message)
-    assertTrue(message.contains("Cyclic scenario dependency detected: loop-a -> loop-b -> loop-a"), message)
+    assertTrue(message.contains("scenarios 'dup': duplicate id (declared 2 times)"), message)
+    assertTrue(message.contains("scenarios 'orphan': dependency 'missing' is not defined in scenarios"), message)
+    assertTrue(message.contains("scenarios 'loop-a': cyclic dependency: loop-a -> loop-b -> loop-a"), message)
     // Reusable violations are reported in the same pass, not one run later.
     assertTrue(message.contains("uses 'nowhere' is not defined in reusableScenarios"), message)
   }
@@ -214,7 +214,7 @@ class ScenarioResolutionCharacterizationTest {
     }
     assertEquals(
       1,
-      exception.message!!.lines().count { it.contains("Cyclic scenario dependency detected") },
+      exception.message!!.lines().count { it.contains("cyclic dependency:") },
       exception.message
     )
   }
@@ -237,7 +237,7 @@ class ScenarioResolutionCharacterizationTest {
         aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache(),
       )
     }
-    assertEquals("Scenario 'a' depends on unknown scenario 'missing'.", failure.message)
+    assertEquals("scenarios 'a': dependency 'missing' is not defined in scenarios", failure.message)
   }
 
   /**
@@ -336,7 +336,7 @@ class ScenarioResolutionCharacterizationTest {
       buildTasks(listOf(ArbigentScenarioContent(id = "a", uses = "nowhere")))
     }
     assertEquals(
-      "Reusable scenario 'nowhere' referenced from 'a' is not defined in reusableScenarios",
+      "scenarios 'a': uses 'nowhere' is not defined in reusableScenarios",
       failure.message
     )
   }
@@ -353,7 +353,7 @@ class ScenarioResolutionCharacterizationTest {
       )
     }
     assertEquals(
-      "Cyclic reusable scenario reference detected: first -> second -> first",
+      "reusableScenarios 'first': cyclic reusable reference: first -> second -> first",
       failure.message
     )
   }

--- a/arbigent-core/src/test/java/ScenarioResolutionCharacterizationTest.kt
+++ b/arbigent-core/src/test/java/ScenarioResolutionCharacterizationTest.kt
@@ -4,11 +4,12 @@ import io.github.takahirom.arbigent.*
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
 
 /**
- * Records how each caller of the scenario-resolution logic reacts to broken `dependency` graphs
- * today. The four callers deliberately disagree, so this test pins the current behavior down
- * before the resolution logic is unified; it must keep passing across the refactoring.
+ * Pins down how scenario resolution reacts to broken `dependency` graphs. A broken graph is now
+ * rejected at load time with every violation listed at once; the tests that used to record each
+ * caller's own divergent reaction were rewritten accordingly.
  */
 class ScenarioResolutionCharacterizationTest {
   private fun load(yaml: String): ArbigentProjectFileContent = ArbigentProjectSerializer().load(yaml)
@@ -16,7 +17,7 @@ class ScenarioResolutionCharacterizationTest {
   private fun ArbigentProjectFileContent.scenario(id: String) =
     scenarioContents.first { it.id == id }
 
-  private fun ArbigentProjectFileContent.taskIdsOf(id: String): List<String> =
+  private fun ArbigentProjectFileContent.tasksOf(id: String) =
     scenarioContents.createArbigentScenario(
       projectSettings = settings,
       scenario = scenario(id),
@@ -25,82 +26,27 @@ class ScenarioResolutionCharacterizationTest {
       aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache(),
       fixedScenarios = fixedScenarios,
       reusableScenarios = reusableScenarios,
-    ).agentTasks.map { it.scenarioId }
+    ).agentTasks
 
-  private val danglingDependency = """
-    scenarios:
-    - id: "a"
-      goal: "A"
-      dependency: "missing"
-    """
-
-  private val cyclicDependency = """
-    scenarios:
-    - id: "a"
-      goal: "A"
-      dependency: "c"
-    - id: "b"
-      goal: "B"
-      dependency: "a"
-    - id: "c"
-      goal: "C"
-      dependency: "b"
-    """
-
-  private val duplicateScenarioIds = """
-    scenarios:
-    - id: "a"
-      goal: "first"
-    - id: "a"
-      goal: "second"
-    """
-
-  @Test
-  fun brokenDependenciesLoadWithoutValidationError() {
-    // `dependency` is not validated at load time; only reusable scenarios are.
-    load(danglingDependency)
-    load(cyclicDependency)
-    load(duplicateScenarioIds)
+  private fun assertValidationError(expectedMessagePart: String, yaml: String) {
+    val exception = assertFailsWith<ArbigentProjectValidationException> { load(yaml) }
+    assertTrue(
+      exception.message!!.contains(expectedMessagePart),
+      "Expected message to contain '$expectedMessagePart' but was: ${exception.message}"
+    )
   }
 
   @Test
-  fun runtimeThrowsNoSuchElementOnDanglingDependency() {
-    val project = load(danglingDependency)
-    val failure = assertFailsWith<NoSuchElementException> { project.taskIdsOf("a") }
-    assertEquals("Collection contains no element matching the predicate.", failure.message)
-  }
-
-  @Test
-  fun runtimeSilentlyTruncatesCyclicDependency() {
-    // No error: the `visited` set cuts the cycle and the remaining tasks are emitted.
-    val project = load(cyclicDependency)
-    assertEquals(listOf("b", "c", "a"), project.taskIdsOf("a"))
-    assertEquals(listOf("c", "a", "b"), project.taskIdsOf("b"))
-    assertEquals(listOf("a", "b", "c"), project.taskIdsOf("c"))
-  }
-
-  @Test
-  fun runtimeResolvesDuplicateScenarioIdToTheFirstDeclaration() {
-    val project = load(
+  fun danglingDependencyFailsAtLoad() {
+    assertValidationError(
+      "Scenario 'a' depends on unknown scenario 'missing'.",
       """
       scenarios:
-      - id: "dep"
-        goal: "first"
-      - id: "dep"
-        goal: "second"
       - id: "a"
         goal: "A"
-        dependency: "dep"
+        dependency: "missing"
       """
     )
-    val goals = project.scenarioContents.createArbigentScenario(
-      projectSettings = project.settings,
-      scenario = project.scenario("a"),
-      aiFactory = { FakeAi() },
-      deviceFactory = { FakeDevice() },
-      aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache(),
-    ).agentTasks.map { it.goal }
-    assertEquals(listOf("first", "A"), goals)
   }
 
   /**
@@ -171,28 +117,149 @@ class ScenarioResolutionCharacterizationTest {
   }
 
   @Test
-  fun graphSilentlyDropsDanglingDependencyEdge() {
-    val graph = ArbigentScenarioGraph.from(load(danglingDependency))
-    assertEquals(listOf("a"), graph.nodes.map { it.title })
-    assertEquals(emptyList(), graph.edges)
+  fun cyclicDependencyFailsAtLoadWithThePath() {
+    assertValidationError(
+      "Cyclic scenario dependency detected: a -> c -> b -> a",
+      """
+      scenarios:
+      - id: "a"
+        goal: "A"
+        dependency: "c"
+      - id: "b"
+        goal: "B"
+        dependency: "a"
+      - id: "c"
+        goal: "C"
+        dependency: "b"
+      """
+    )
   }
 
   @Test
-  fun graphKeepsCyclicDependencyEdges() {
-    val graph = ArbigentScenarioGraph.from(load(cyclicDependency))
+  fun selfDependencyFailsAtLoad() {
+    assertValidationError(
+      "Cyclic scenario dependency detected: selfie -> selfie",
+      """
+      scenarios:
+      - id: "selfie"
+        goal: "Loop"
+        dependency: "selfie"
+      """
+    )
+  }
+
+  @Test
+  fun duplicateScenarioIdFailsAtLoad() {
+    assertValidationError(
+      "scenarios: duplicate id 'a'",
+      """
+      scenarios:
+      - id: "a"
+        goal: "first"
+      - id: "a"
+        goal: "second"
+      """
+    )
+  }
+
+  @Test
+  fun allViolationsAreReportedInOnePass() {
+    val exception = assertFailsWith<ArbigentProjectValidationException> {
+      load(
+        """
+        scenarios:
+        - id: "dup"
+          goal: "first"
+        - id: "dup"
+          goal: "second"
+        - id: "orphan"
+          goal: "O"
+          dependency: "missing"
+        - id: "loop-a"
+          goal: "A"
+          dependency: "loop-b"
+        - id: "loop-b"
+          goal: "B"
+          dependency: "loop-a"
+        - id: "bad-call"
+          uses: "nowhere"
+        """
+      )
+    }
+    val message = exception.message!!
+    assertTrue(message.contains("scenarios: duplicate id 'dup'"), message)
+    assertTrue(message.contains("Scenario 'orphan' depends on unknown scenario 'missing'."), message)
+    assertTrue(message.contains("Cyclic scenario dependency detected: loop-a -> loop-b -> loop-a"), message)
+    // Reusable violations are reported in the same pass, not one run later.
+    assertTrue(message.contains("uses 'nowhere' is not defined in reusableScenarios"), message)
+  }
+
+  @Test
+  fun aCycleSharedBySeveralScenariosIsReportedOnce() {
+    val exception = assertFailsWith<ArbigentProjectValidationException> {
+      load(
+        """
+        scenarios:
+        - id: "a"
+          goal: "A"
+          dependency: "b"
+        - id: "b"
+          goal: "B"
+          dependency: "a"
+        - id: "c"
+          goal: "C"
+          dependency: "a"
+        """
+      )
+    }
     assertEquals(
-      listOf(
-        "scenario:c" to "scenario:a",
-        "scenario:a" to "scenario:b",
-        "scenario:b" to "scenario:c",
-      ),
-      graph.edges.map { it.fromKey to it.toKey }
+      1,
+      exception.message!!.lines().count { it.contains("Cyclic scenario dependency detected") },
+      exception.message
     )
   }
 
   /**
+   * Content built in memory never went through load-time validation, so the runtime repeats the
+   * check instead of running a half-resolved chain.
+   */
+  @Test
+  fun runtimeRejectsInMemoryContentWithADanglingDependency() {
+    val scenarios = listOf(
+      ArbigentScenarioContent(id = "a", goal = "A", dependencyId = "missing"),
+    )
+    val failure = assertFailsWith<ArbigentProjectValidationException> {
+      scenarios.createArbigentScenario(
+        projectSettings = ArbigentProjectSettings(),
+        scenario = scenarios.single(),
+        aiFactory = { FakeAi() },
+        deviceFactory = { FakeDevice() },
+        aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache(),
+      )
+    }
+    assertEquals("Scenario 'a' depends on unknown scenario 'missing'.", failure.message)
+  }
+
+  /**
+   * The graph renders whatever content it is handed — the UI draws it while the project is still
+   * being edited — so a dangling reference only loses its edge.
+   */
+  @Test
+  fun graphStillRendersInMemoryContentWithADanglingDependency() {
+    val graph = ArbigentScenarioGraph.from(
+      ArbigentProjectFileContent(
+        scenarioContents = listOf(
+          ArbigentScenarioContent(id = "a", goal = "A", dependencyId = "missing"),
+        )
+      )
+    )
+    assertEquals(listOf("a"), graph.nodes.map { it.title })
+    assertEquals(emptyList(), graph.edges)
+  }
+
+  /**
    * The UI tree ordering: roots first, dependents indented under them. A scenario pointing at
-   * something outside the list (the UI's shape of a dangling dependency) is shown as a root.
+   * something outside the list is shown as a root.
    */
   @Test
   fun dependencyForestTreatsMissingAndSelfDependenciesAsRoots() {
@@ -323,14 +390,7 @@ class ScenarioResolutionCharacterizationTest {
         goal: "Checkout"
       """
     )
-    val tasks = project.scenarioContents.createArbigentScenario(
-      projectSettings = project.settings,
-      scenario = project.scenario("buy"),
-      aiFactory = { FakeAi() },
-      deviceFactory = { FakeDevice() },
-      aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache(),
-      reusableScenarios = project.reusableScenarios,
-    ).agentTasks
+    val tasks = project.tasksOf("buy")
     assertEquals(listOf("setup", "buy", "buy"), tasks.map { it.scenarioId })
     assertEquals(listOf("Setup", "Log in as paid", "Checkout"), tasks.map { it.goal })
     assertEquals(

--- a/arbigent-core/src/test/java/ScenarioResolutionCharacterizationTest.kt
+++ b/arbigent-core/src/test/java/ScenarioResolutionCharacterizationTest.kt
@@ -116,6 +116,84 @@ class ScenarioResolutionCharacterizationTest {
     assertEquals(listOf("dup-first", "x", "dup-second"), goals)
   }
 
+  /**
+   * A violation must name a declaration the user can open. The resolver walks from the target, so
+   * it can enter a cycle from outside it and reach a nested call through composites; neither the
+   * lead-in nor a breadcrumb label is addressable, so both are trimmed away before attributing.
+   */
+  @Test
+  fun runtimeAttributesACycleEnteredFromOutsideToTheCycleItself() {
+    val a = ArbigentScenarioContent(id = "a", goal = "A", dependencyId = "b")
+    val b = ArbigentScenarioContent(id = "b", goal = "B", dependencyId = "a")
+    val tail = ArbigentScenarioContent(id = "tail", goal = "T", dependencyId = "a")
+    val scenarios = listOf(a, b, tail)
+
+    val failure = assertFailsWith<ArbigentProjectValidationException> {
+      scenarios.createArbigentScenario(
+        projectSettings = ArbigentProjectSettings(),
+        scenario = tail,
+        aiFactory = { FakeAi() },
+        deviceFactory = { FakeDevice() },
+        aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache(),
+      )
+    }
+    // Same attribution load-time validation produces for this project, not `scenarios 'tail'`.
+    assertEquals("scenarios 'a': cyclic dependency: a -> b -> a", failure.message)
+  }
+
+  @Test
+  fun runtimeAttributesAnUndefinedNestedCallToTheReusableThatMakesIt() {
+    val scenarios = listOf(ArbigentScenarioContent(id = "caller", uses = "outer"))
+    val reusableScenarios = listOf(
+      ArbigentScenarioContent(
+        id = "outer",
+        steps = listOf(ArbigentScenarioContent.ReusableStep(uses = "nowhere")),
+        inputs = mapOf("user" to ArbigentScenarioContent.ReusableInput(default = "paid")),
+      )
+    )
+
+    val failure = assertFailsWith<ArbigentProjectValidationException> {
+      scenarios.createArbigentScenario(
+        projectSettings = ArbigentProjectSettings(),
+        scenario = scenarios.single(),
+        aiFactory = { FakeAi() },
+        deviceFactory = { FakeDevice() },
+        aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache(),
+        reusableScenarios = reusableScenarios,
+      )
+    }
+    // Not `scenarios 'outer (user=paid)'` — that breadcrumb label is not a declaration.
+    assertEquals(
+      "reusableScenarios 'outer': uses 'nowhere' is not defined in reusableScenarios",
+      failure.message
+    )
+  }
+
+  @Test
+  fun runtimeAttributesAReusableCycleEnteredFromOutsideToTheCycleItself() {
+    val scenarios = listOf(ArbigentScenarioContent(id = "caller", uses = "entry"))
+    val reusableScenarios = listOf(
+      ArbigentScenarioContent(id = "entry", steps = listOf(ArbigentScenarioContent.ReusableStep(uses = "y"))),
+      ArbigentScenarioContent(id = "y", steps = listOf(ArbigentScenarioContent.ReusableStep(uses = "z"))),
+      ArbigentScenarioContent(id = "z", steps = listOf(ArbigentScenarioContent.ReusableStep(uses = "y"))),
+    )
+
+    val failure = assertFailsWith<ArbigentProjectValidationException> {
+      scenarios.createArbigentScenario(
+        projectSettings = ArbigentProjectSettings(),
+        scenario = scenarios.single(),
+        aiFactory = { FakeAi() },
+        deviceFactory = { FakeDevice() },
+        aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache(),
+        reusableScenarios = reusableScenarios,
+      )
+    }
+    assertEquals(
+      "reusableScenarios 'y': cyclic reusable reference: y -> z -> y",
+      failure.message
+    )
+  }
+
   @Test
   fun cyclicDependencyFailsAtLoadWithThePath() {
     assertValidationError(

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -557,7 +557,16 @@ class ArbigentAppStateHolder(
     if (file == null) {
       return
     }
-    val projectFile = ArbigentProjectSerializer().load(file)
+    // The core reports the violations but not which file they came from; name it here.
+    val projectFile = try {
+      ArbigentProjectSerializer().load(file)
+    } catch (e: ArbigentProjectValidationException) {
+      if (e.violations.isEmpty()) throw e
+      throw ArbigentProjectValidationException(
+        arbigentValidationReport(e.violations, source = file.absolutePath),
+        e.violations,
+      )
+    }
     val scenarios = projectFile.scenarioContents
     val arbigentScenarioStateHolders = scenarios.map { scenarioContent ->
       ArbigentScenarioStateHolder(

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -178,7 +178,7 @@ class ArbigentAppStateHolder(
         scenarioContents = allScenarioStateHoldersStateFlow.value.map { it.createArbigentScenarioContent() },
         reusableScenarios = prospectiveReusables,
         fixedScenarios = _fixedScenariosFlow.value,
-      ).validateReusableScenarios()
+      ).validateProject()
     }.exceptionOrNull()?.message
   }
 
@@ -542,7 +542,7 @@ class ArbigentAppStateHolder(
     }
     val content = getCurrentProjectFileContent()
     // Never write a project file that would fail to load; surface the problem instead.
-    runCatching { content.validateReusableScenarios() }.exceptionOrNull()?.let { e ->
+    runCatching { content.validateProject() }.exceptionOrNull()?.let { e ->
       showErrorDialog(e)
       return
     }


### PR DESCRIPTION
Stacked on #405 (review that one first — it is the behavior-preserving refactoring this builds on).

`dependency` had no validation at all. #405 put the resolution walk in one place and made it report broken references as diagnostics; this PR feeds those diagnostics into load-time validation, so `dependency` is checked the same way reusable scenarios already are: **every violation reported at once, at load, with `ArbigentProjectValidationException`.**

## Behavior changes (user-visible)

`validateReusableScenarios()` is now `validateProject()` and covers both rule sets. Newly rejected at load: **dangling `dependency`**, **cyclic `dependency`**, **duplicate ids in `scenarios`** (`reusableScenarios` already rejected duplicates).

```
$ arbigent graph --project-file=broken.yaml
Invalid project configuration in /path/to/broken.yaml:
- scenarios 'dup': duplicate id (declared 2 times)
- scenarios 'orphan': dependency 'missing' is not defined in scenarios
- scenarios 'loop-a': cyclic dependency: loop-a -> loop-b -> loop-a
- scenarios 'caller': uses 'nowhere' is not defined in reusableScenarios
```

Every line follows the shape the reusable rules already used — `<section> '<id>': <what is wrong>`,
no trailing period — so dependency and reusable violations read as one list. A cycle is attributed
to the scenario the cycle starts at, so each line points at something the user can go edit.

Per caller, for a broken project:

| | before | after |
|---|---|---|
| `arbigent run` — dangling | `NoSuchElementException` stack trace | the message above, exit 1 |
| `arbigent run` — cycle | ran a silently truncated task chain | the message above, exit 1 |
| `arbigent graph` / `scenarios` / `tags` | rendered/listed the broken project (dependency edge silently dropped) | the message above, exit 1 |
| `arbigent instruction` | one `CliktError` for the first problem found | the message above (all problems), exit 1 |
| UI project load | loaded, dangling dependency shown as a root | load fails with the message |

Two smaller consequences:

- The exception header changed from `Invalid reusable scenario configuration:` to `Invalid project configuration in <path>:`, since it now carries both kinds of violation. `ArbigentProjectValidationException` gained a `violations: List<String>` field and core exposes `arbigentValidationReport(violations, source)`; the path is supplied by whoever loaded the file (CLI `asCliktError`, UI `loadProjectContents`) so **core never learns about file paths**.
- Two pre-existing reusable messages were reshaped to match the new dependency ones: `reusableScenarios: duplicate id 'x'` → `reusableScenarios 'x': duplicate id (declared 2 times)`, and `reusableScenarios: cyclic reference detected: a -> b -> a` → `reusableScenarios 'a': cyclic reusable reference: a -> b -> a`. Every other individual message is unchanged.
- CLI commands now report a load-time validation failure as a plain message instead of an uncaught exception (new `loadArbigentProjectFileContent` / `asCliktError` in `CommonOptions.kt`). This also applies to the pre-existing reusable-scenario errors, which used to print a stack trace.

A valid project is completely unaffected — verified by diffing `arbigent graph` and `arbigent instruction` output for all 7 projects under `sample-test/src/main/resources/projects/` against the pre-#405 build: byte-identical.

## Where the checks live

`ArbigentScenarioResolver.diagnoseDependencies(scenarios)` walks the whole project and returns diagnostics in a stable order — duplicate ids, dangling references in declaration order, then each cycle once (three-color walk, so a cycle reachable from several scenarios is not reported repeatedly). `validateProject()` joins those with the reusable-scenario errors into one exception.

`createArbigentScenario` still checks the diagnostics itself and now throws `ArbigentProjectValidationException` for a dangling *or* cyclic dependency instead of `NoSuchElementException` / silently truncating. That path is only reachable for content built in memory (the UI editor), which never went through the loader.

`ArbigentScenarioGraph.from` deliberately keeps rendering whatever it is handed, dangling edges and all — the UI draws it for a project that is still being edited. The CLI can no longer reach that state because loading fails first.

## Tests changed

`ScenarioResolutionCharacterizationTest` recorded the four callers' old divergent reactions. Six of its tests encoded behavior this PR intentionally changes and were rewritten:

| removed | replaced by |
|---|---|
| `brokenDependenciesLoadWithoutValidationError` | `danglingDependencyFailsAtLoad`, `cyclicDependencyFailsAtLoadWithThePath`, `selfDependencyFailsAtLoad`, `duplicateScenarioIdFailsAtLoad` |
| `runtimeThrowsNoSuchElementOnDanglingDependency` | `runtimeRejectsInMemoryContentWithADanglingDependency` (typed exception, in-memory content) |
| `runtimeSilentlyTruncatesCyclicDependency` | `cyclicDependencyFailsAtLoadWithThePath` |
| `runtimeResolvesDuplicateScenarioIdToTheFirstDeclaration` | `duplicateScenarioIdFailsAtLoad` — the ambiguity is now an error instead of a silent first-wins pick |
| `graphSilentlyDropsDanglingDependencyEdge` | `graphStillRendersInMemoryContentWithADanglingDependency` (same assertion, in-memory content since the YAML no longer loads) |
| `graphKeepsCyclicDependencyEdges` | dropped — unreachable from a loaded project |

Added: `allViolationsAreReportedInOnePass` (dependency + reusable violations in a single message) and `aCycleSharedBySeveralScenariosIsReportedOnce`.

Two more assertions were updated for the message reformatting:

- `ReusableScenariosTest.duplicateReusableIdsFailAtLoad`: `"duplicate id 'part'"` → `"reusableScenarios 'part': duplicate id (declared 2 times)"`.
- `InstructionCommandTest`: the two cycle tests match `"cyclic dependency:"` instead of `"Cyclic scenario dependency detected"`, and the dangling test now also asserts the report names the project file.

No other test needed changing.

`./gradlew :arbigent-core:test :arbigent-cli:test :arbigent-ui:test installDist` passes.

Verified against a real 25-scenario project (24 `dependency` uses, 7 `uses`/`steps`, reusable scenarios): `graph` (77 lines), `scenarios` (58 lines) and `instruction` for all 25 ids (989 lines) are identical to `origin/main` once log timestamps are stripped.
