### PR TITLE
Keep scenarios in a dependency cycle in the ordered list

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
@@ -240,9 +240,10 @@ public object ArbigentScenarioResolver {
    * state holders (which have no stable id) by identity — `ArbigentScenarioStateHolder` does not
    * override `equals`.
    *
-   * Items that only reach each other form no root, so a dependency cycle is omitted from the
-   * result entirely. That is what the UI has always done; see
-   * `mutualDependencyCycleIsOmittedFromTheForest`.
+   * Every item appears exactly once. Items that only reach each other form no root, so the first
+   * member of such a cycle is surfaced as a root and the rest follow as its dependents — the
+   * cycle itself is reported separately by [diagnoseDependencies], and dropping the items here
+   * would delete them from a project the UI saves.
    */
   public fun <T> dependencyForestWithDepth(
     items: List<T>,
@@ -261,11 +262,32 @@ public object ArbigentScenarioResolver {
     }
 
     val result = mutableListOf<Pair<T, Int>>()
+    val placed = mutableSetOf<T>()
     fun walk(item: T, depth: Int) {
+      // A cycle would otherwise recurse forever once traversal enters it. Outside a cycle each
+      // item has a single dependency, so it can be reached only once and this never fires.
+      if (!placed.add(item)) return
       result.add(item to depth)
       dependents[item]?.forEach { walk(it, depth + 1) }
     }
     roots.forEach { walk(it, 0) }
+    // Items that only reach each other form no root. Enter each such group at the cycle itself
+    // rather than at whichever member happens to be declared first: seeding from an ordinary
+    // dependent of the cycle would strand it at depth 0, contradicting "roots first, then their
+    // dependents". Walking up the dependency chain always lands on a cycle member, because the
+    // only way the walk can stop is by revisiting something it already stepped through.
+    val itemSet = items.toSet()
+    items.forEach { item ->
+      if (item in placed) return@forEach
+      var seed = item
+      val steppedThrough = mutableSetOf<T>()
+      while (steppedThrough.add(seed)) {
+        val parent = dependencyOf(seed) ?: break
+        if (parent !in itemSet || parent in placed) break
+        seed = parent
+      }
+      walk(seed, 0)
+    }
     return result
   }
 }

--- a/arbigent-core/src/test/java/ScenarioResolutionCharacterizationTest.kt
+++ b/arbigent-core/src/test/java/ScenarioResolutionCharacterizationTest.kt
@@ -361,19 +361,13 @@ class ScenarioResolutionCharacterizationTest {
   }
 
   /**
-   * A mutual cycle gives every item a dependency inside the list, so no root exists and the
-   * whole cycle drops out of the ordering. The UI has always behaved this way: the pre-refactor
-   * `sortedScenarioAndDepth` built the same roots/dependents split, and its
-   * `if (v.isEmpty()) roots.add(k)` branch was unreachable because `getOrPut` always inserted a
-   * non-empty list.
-   *
-   * This matters beyond ordering, because `getCurrentProjectFileContent()` serializes
-   * `sortedScenariosAndDepthsStateFlow`, so scenarios in a cycle are dropped when the project is
-   * saved. That is a pre-existing bug rather than something this refactoring introduces, and it
-   * is pinned here so a fix has to change this test deliberately.
+   * A mutual cycle gives every item a dependency inside the list, so it has no root. The first
+   * member is surfaced as a root instead of dropping the group, because
+   * `getCurrentProjectFileContent()` serializes this ordering and a dropped scenario is a
+   * scenario deleted from the saved project.
    */
   @Test
-  fun mutualDependencyCycleIsOmittedFromTheForest() {
+  fun mutualDependencyCycleKeepsEveryItemWithTheFirstAsRoot() {
     class Item(val name: String, var dependency: Item? = null)
 
     val a = Item("a")
@@ -385,7 +379,53 @@ class ScenarioResolutionCharacterizationTest {
       it.dependency
     }
 
-    assertEquals(listOf("unrelated" to 0), ordered.map { (item, depth) -> item.name to depth })
+    // Genuine roots keep their order and come first; the cycle is appended rather than dropped.
+    assertEquals(
+      listOf("unrelated" to 0, "a" to 0, "b" to 1),
+      ordered.map { (item, depth) -> item.name to depth }
+    )
+  }
+
+  /**
+   * A dependent of a cycle stays a dependent even when it is declared before the cycle. Entering
+   * the group at the first unplaced item would emit `trailing` as a root and then be unable to
+   * attach it under `a`, so the fallback walks up to a cycle member first.
+   */
+  @Test
+  fun aDependentDeclaredBeforeTheCycleItPointsIntoIsNotShownAsARoot() {
+    class Item(val name: String, var dependency: Item? = null)
+
+    val a = Item("a")
+    val b = Item("b", a)
+    a.dependency = b
+    val trailing = Item("trailing", a)
+
+    val ordered = ArbigentScenarioResolver.dependencyForestWithDepth(listOf(trailing, a, b)) {
+      it.dependency
+    }
+
+    assertEquals(0, ordered.single { it.first.name == "a" }.second)
+    assertEquals(1, ordered.single { it.first.name == "trailing" }.second)
+    assertEquals(1, ordered.single { it.first.name == "b" }.second)
+    assertEquals(3, ordered.size)
+  }
+
+  /** A scenario hanging off a cycle must survive too, and must not be visited twice. */
+  @Test
+  fun aDependentOfACycleIsListedOnce() {
+    class Item(val name: String, var dependency: Item? = null)
+
+    val a = Item("a")
+    val b = Item("b", a)
+    a.dependency = b
+    val trailing = Item("trailing", a)
+
+    val ordered = ArbigentScenarioResolver.dependencyForestWithDepth(listOf(a, b, trailing)) {
+      it.dependency
+    }
+
+    assertEquals(listOf("a", "b", "trailing"), ordered.map { it.first.name }.sorted())
+    assertEquals(3, ordered.size)
   }
 
   /**

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -30,6 +30,9 @@ class ArbigentAppStateHolder(
   // by the UI composition root (Main). internal so editor dialogs that build their own holders
   // (e.g. the reusable-scenario editor) can keep them on the same dispatcher.
   internal val dispatcher: CoroutineDispatcher,
+  // How a recoverable failure reaches the user. Defaults to the Swing error dialog; tests replace
+  // it so asserting on a rejected save does not open a modal window.
+  private val onRecoverableError: (Throwable) -> Unit = { showErrorDialog(it) },
 ) {
   private val _fixedScenariosFlow = MutableStateFlow<List<FixedScenario>>(emptyList())
   val fixedScenariosFlow: StateFlow<List<FixedScenario>> = _fixedScenariosFlow.asStateFlow()
@@ -508,7 +511,17 @@ class ArbigentAppStateHolder(
   private var lastSavedYaml: String? = getCurrentContentAsYaml()
 
   private fun getCurrentProjectFileContent(): ArbigentProjectFileContent {
-    val sortedScenarios = sortedScenariosAndDepthsStateFlow.value.map { it.first }
+    // Ordering is recomputed here rather than read from `sortedScenariosAndDepthsStateFlow`:
+    // that flow is `WhileSubscribed`, so its value is the empty initial value until the UI first
+    // collects it and goes stale whenever collection stops — saving from either state would
+    // write a project with scenarios missing.
+    //
+    // The ordering decides the order scenarios are written in, but it must never decide *which*
+    // scenarios are written. Anything it does not place is appended in declaration order, so
+    // saving stays lossless even if the ordering regresses.
+    val ordered = sortedScenariosAndDepths().map { it.first }
+    val placed = ordered.toSet()
+    val sortedScenarios = ordered + allScenarioStateHoldersStateFlow.value.filterNot { it in placed }
     return ArbigentProjectFileContent(
       settings = ArbigentProjectSettings(
         prompt = promptFlow.value,
@@ -543,7 +556,7 @@ class ArbigentAppStateHolder(
     val content = getCurrentProjectFileContent()
     // Never write a project file that would fail to load; surface the problem instead.
     runCatching { content.validateProject() }.exceptionOrNull()?.let { e ->
-      showErrorDialog(e)
+      onRecoverableError(e)
       return
     }
     arbigentProjectSerializer.save(

--- a/arbigent-ui/src/test/kotlin/ScenarioOrderingUiTest.kt
+++ b/arbigent-ui/src/test/kotlin/ScenarioOrderingUiTest.kt
@@ -1,0 +1,124 @@
+package io.github.takahirom.arbigent.ui
+
+import io.github.takahirom.arbigent.ArbigentProjectSerializer
+import io.github.takahirom.arbigent.ArbigentTagManager
+import kotlinx.coroutines.Dispatchers
+import org.junit.Before
+import org.junit.Test
+import java.io.File
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * `getCurrentProjectFileContent()` writes scenarios in the order `sortedScenariosAndDepths()`
+ * produces, appending anything that ordering does not place. These tests cover both halves: the
+ * ordering keeps every scenario (a cycle used to drop out of it entirely), and the save path
+ * stays lossless regardless of what the ordering returns.
+ */
+class ScenarioOrderingUiTest {
+
+  @Before
+  fun setup() {
+    globalKeyStoreFactory = TestKeyStoreFactory()
+  }
+
+  /** Errors the app surfaced, captured instead of opening the Swing dialog. */
+  private val errors = mutableListOf<Throwable>()
+
+  private fun appWith(vararg ids: String): Pair<ArbigentAppStateHolder, Map<String, ArbigentScenarioStateHolder>> {
+    val app = ArbigentAppStateHolder(
+      aiFactory = { FakeAi() },
+      dispatcher = Dispatchers.Unconfined,
+      onRecoverableError = { errors += it },
+    )
+    val holders = ids.associateWith { id ->
+      ArbigentScenarioStateHolder(
+        id = id,
+        tagManager = ArbigentTagManager(),
+        dispatcher = Dispatchers.Unconfined,
+      ).also { app.addScenarioStateHolder(it) }
+    }
+    return app to holders
+  }
+
+  @Test
+  fun `scenarios in a dependency cycle are still ordered`() {
+    val (app, holders) = appWith("a", "b", "unrelated")
+    holders.getValue("a").dependencyScenarioStateHolderStateFlow.value = holders.getValue("b")
+    holders.getValue("b").dependencyScenarioStateHolderStateFlow.value = holders.getValue("a")
+
+    val ordered = app.sortedScenariosAndDepths()
+
+    // Genuine roots keep their order and come first; the cycle is appended rather than dropped.
+    assertEquals(listOf("unrelated" to 0, "a" to 0, "b" to 1), ordered.map { it.first.id to it.second })
+  }
+
+  @Test
+  fun `a scenario depending on a cycle is listed exactly once`() {
+    val (app, holders) = appWith("a", "b", "trailing")
+    holders.getValue("a").dependencyScenarioStateHolderStateFlow.value = holders.getValue("b")
+    holders.getValue("b").dependencyScenarioStateHolderStateFlow.value = holders.getValue("a")
+    holders.getValue("trailing").dependencyScenarioStateHolderStateFlow.value = holders.getValue("a")
+
+    val ordered = app.sortedScenariosAndDepths().map { it.first.id }
+
+    assertEquals(listOf("a", "b", "trailing"), ordered.sorted())
+  }
+
+  /**
+   * The save path must never write a project that is missing scenarios. With a cycle present,
+   * validation rejects the save outright; without one, every scenario reaches the file.
+   */
+  @Test
+  fun `saving a project with a dependency cycle writes nothing rather than dropping scenarios`() {
+    val (app, holders) = appWith("a", "b", "unrelated")
+    holders.getValue("a").dependencyScenarioStateHolderStateFlow.value = holders.getValue("b")
+    holders.getValue("b").dependencyScenarioStateHolderStateFlow.value = holders.getValue("a")
+    val file = File.createTempFile("arbigent-cycle", ".yml").also { it.delete() }
+
+    app.saveProjectContents(file)
+
+    assertFalse(file.exists(), "a project with a cyclic dependency must not be written")
+    assertEquals(1, errors.size, "the rejected save must be reported once")
+    assertTrue(
+      errors.single().message!!.contains("scenarios 'a': cyclic dependency: a -> b -> a"),
+      errors.single().message
+    )
+    file.delete()
+  }
+
+  /**
+   * Nothing collects `sortedScenariosAndDepthsStateFlow` here, which is the state the app is in
+   * before the scenario list is first composed and whenever collection stops. Saving must still
+   * write every scenario, so the ordering is recomputed rather than read from that flow.
+   */
+  @Test
+  fun `saving an ordinary project writes every scenario without an active collector`() {
+    // Declared dependent-first, so dependency order and declaration order disagree: reading the
+    // uncollected flow would fall back to declaration order and be caught here.
+    val (app, holders) = appWith("child", "root", "loose")
+    holders.getValue("child").dependencyScenarioStateHolderStateFlow.value = holders.getValue("root")
+    val file = File.createTempFile("arbigent-ok", ".yml")
+
+    app.saveProjectContents(file)
+
+    val written = ArbigentProjectSerializer().load(file).scenarioContents.map { it.id }
+    assertEquals(listOf("root", "child", "loose"), written)
+    file.delete()
+  }
+
+  @Test
+  fun `an ordinary dependency chain keeps roots first and dependents indented`() {
+    val (app, holders) = appWith("root", "child", "grandChild")
+    holders.getValue("child").dependencyScenarioStateHolderStateFlow.value = holders.getValue("root")
+    holders.getValue("grandChild").dependencyScenarioStateHolderStateFlow.value = holders.getValue("child")
+
+    val ordered = app.sortedScenariosAndDepths()
+
+    assertEquals(
+      listOf("root" to 0, "child" to 1, "grandChild" to 2),
+      ordered.map { it.first.id to it.second }
+    )
+  }
+}


### PR DESCRIPTION
Stacked on #406.

## Problem

`dependencyForestWithDepth` walks only from roots. Items that only reach each other form no root, so a mutual `dependency` cycle produced an **empty** result for those items.

This is pre-existing — the pre-refactor `sortedScenarioAndDepth` built the same roots/dependents split, and its `if (v.isEmpty()) roots.add(k)` line was unreachable because `getOrPut` always inserted a non-empty list. #405 preserved it deliberately and pinned it in a test; this PR is the deliberate change.

It is not only a display issue. `getCurrentProjectFileContent()` serializes `sortedScenariosAndDepths()`, so **scenarios in a cycle were silently deleted from the project on save**. `saveProjectContents` does validate, but it validates the already-filtered content, so the cycle was gone before validation could see it.

## Change

After the root traversal, sweep the remaining items and surface each as a root, with a `placed` guard so a cycle cannot recurse forever. Outside a cycle every item has a single dependency and is reachable once, so the guard never fires and ordinary ordering is untouched.

Genuine roots keep their order and come first; cycle members are appended rather than dropped. With #406 in place, saving a cyclic project now fails with `scenarios 'a': cyclic dependency: a -> b -> a` instead of quietly dropping scenarios.

## Tests

- `ScenarioResolutionCharacterizationTest`: `mutualDependencyCycleKeepsEveryItemWithTheFirstAsRoot` (replaces the pin added in #405), `aDependentOfACycleIsListedOnce`.
- New `ScenarioOrderingUiTest` drives `ArbigentAppStateHolder.sortedScenariosAndDepths()` — the function `getCurrentProjectFileContent()` serializes — for a cycle, a scenario hanging off a cycle, and an ordinary chain.

## Verification

`:arbigent-core:test :arbigent-cli:test :arbigent-ui:test` all green. `graph` / `scenarios` / `instruction` (989 lines) on a real 25-scenario project are byte-identical to `origin/main`.

Found by CodeRabbit on #405.