### PR TITLE
Leave dependents out of the dependency menu so cycles cannot be made

### DIFF
--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/App.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/App.kt
@@ -189,8 +189,9 @@ private fun MainScreen(
                 Text("No dependency")
               }
             )
-            appStateHolder.sortedScenariosAndDepthsStateFlow.value.map { it.first }
-              .filter { senario -> senario != scenarioStateHolderAndDepth.first }
+            // Scenarios that already depend on this one are left out: choosing one would create
+            // a dependency cycle, which the project can neither load nor save.
+            appStateHolder.selectableDependencies(scenarioStateHolderAndDepth.first)
               .forEach { scenarioStateHolder: ArbigentScenarioStateHolder ->
                 selectableItem(
                   selected = scenarioStateHolderAndDepth.first.dependencyScenarioStateHolderStateFlow.value == scenarioStateHolder,

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -718,6 +718,39 @@ class ArbigentAppStateHolder(
     return allScenarioStateHoldersStateFlow.value.count { it.id == newScenarioId }
   }
 
+  /**
+   * Scenarios that can be chosen as [scenarioStateHolder]'s dependency: every scenario except
+   * itself and the ones that already depend on it, directly or through a chain.
+   *
+   * Picking one of those would mean the two have to run after each other, which no ordering can
+   * satisfy — the project would then fail to load and refuse to save. The choice is left out of
+   * the menu instead of being rejected afterwards, so the editor cannot reach that state at all.
+   *
+   * Returned in tree order, the same order the scenario list is displayed in.
+   */
+  fun selectableDependencies(
+    scenarioStateHolder: ArbigentScenarioStateHolder,
+  ): List<ArbigentScenarioStateHolder> =
+    sortedScenariosAndDepths().map { it.first }.filter { candidate ->
+      candidate !== scenarioStateHolder && !dependsOn(candidate, scenarioStateHolder)
+    }
+
+  /** Whether [from] reaches [target] by following dependencies. */
+  private fun dependsOn(
+    from: ArbigentScenarioStateHolder,
+    target: ArbigentScenarioStateHolder,
+  ): Boolean {
+    // The stepped-through set only matters for content that already contains a cycle; the menu
+    // this backs is what stops one from being created in the first place.
+    val steppedThrough = mutableSetOf<ArbigentScenarioStateHolder>()
+    var current = from.dependencyScenarioStateHolderStateFlow.value
+    while (current != null && steppedThrough.add(current)) {
+      if (current === target) return true
+      current = current.dependencyScenarioStateHolderStateFlow.value
+    }
+    return false
+  }
+
   fun onStepFeedback(feedback: StepFeedbackEvent) {
     when (feedback) {
       is StepFeedback -> {

--- a/arbigent-ui/src/test/kotlin/DependencySelectionTest.kt
+++ b/arbigent-ui/src/test/kotlin/DependencySelectionTest.kt
@@ -1,0 +1,104 @@
+package io.github.takahirom.arbigent.ui
+
+import io.github.takahirom.arbigent.ArbigentTagManager
+import kotlinx.coroutines.Dispatchers
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertEquals
+
+/**
+ * The dependency menu is the only place the editor can build a dependency cycle, so it is where
+ * cycles are prevented rather than reported: a scenario that already depends on this one is not
+ * offered as a choice.
+ */
+class DependencySelectionTest {
+
+  @Before
+  fun setup() {
+    globalKeyStoreFactory = TestKeyStoreFactory()
+  }
+
+  private fun appWith(vararg ids: String): Pair<ArbigentAppStateHolder, Map<String, ArbigentScenarioStateHolder>> {
+    val app = ArbigentAppStateHolder(aiFactory = { FakeAi() }, dispatcher = Dispatchers.Unconfined)
+    val holders = ids.associateWith { id ->
+      ArbigentScenarioStateHolder(
+        id = id,
+        tagManager = ArbigentTagManager(),
+        dispatcher = Dispatchers.Unconfined,
+      ).also { app.addScenarioStateHolder(it) }
+    }
+    return app to holders
+  }
+
+  private fun ArbigentScenarioStateHolder.dependsOn(other: ArbigentScenarioStateHolder) {
+    dependencyScenarioStateHolderStateFlow.value = other
+  }
+
+  @Test
+  fun `a scenario cannot pick itself`() {
+    val (app, holders) = appWith("a", "b")
+
+    assertEquals(listOf("b"), app.selectableDependencies(holders.getValue("a")).map { it.id })
+  }
+
+  @Test
+  fun `a direct dependent is not offered`() {
+    val (app, holders) = appWith("root", "child")
+    holders.getValue("child").dependsOn(holders.getValue("root"))
+
+    // `child` already runs after `root`, so root cannot also run after child.
+    assertEquals(emptyList(), app.selectableDependencies(holders.getValue("root")).map { it.id })
+    assertEquals(listOf("root"), app.selectableDependencies(holders.getValue("child")).map { it.id })
+  }
+
+  @Test
+  fun `a transitive dependent is not offered`() {
+    val (app, holders) = appWith("root", "child", "grandChild", "unrelated")
+    holders.getValue("child").dependsOn(holders.getValue("root"))
+    holders.getValue("grandChild").dependsOn(holders.getValue("child"))
+
+    assertEquals(
+      listOf("unrelated"),
+      app.selectableDependencies(holders.getValue("root")).map { it.id }
+    )
+    assertEquals(
+      listOf("root", "unrelated"),
+      app.selectableDependencies(holders.getValue("child")).map { it.id }
+    )
+  }
+
+  @Test
+  fun `siblings can still depend on each other`() {
+    val (app, holders) = appWith("root", "left", "right")
+    holders.getValue("left").dependsOn(holders.getValue("root"))
+    holders.getValue("right").dependsOn(holders.getValue("root"))
+
+    // `left` does not depend on `right`, so this pairing is allowed and creates no cycle.
+    assertEquals(
+      listOf("root", "left"),
+      app.selectableDependencies(holders.getValue("right")).map { it.id }
+    )
+  }
+
+  @Test
+  fun `choices are listed in tree order without an active collector`() {
+    val (app, holders) = appWith("child", "root", "loose")
+    holders.getValue("child").dependsOn(holders.getValue("root"))
+
+    // Declared dependent-first: reading the uncollected ordering flow would fall back to
+    // declaration order and list `child` before `root`.
+    assertEquals(
+      listOf("root", "loose"),
+      app.selectableDependencies(holders.getValue("child")).map { it.id }
+    )
+  }
+
+  @Test
+  fun `scenario ids that are already taken are rejected`() {
+    val (app, _) = appWith("taken", "other")
+
+    // The id field only commits a change when this returns 0; see ScenarioFundamentalOptions.
+    assertEquals(1, app.scenarioCountById("taken"))
+    assertEquals(0, app.scenarioCountById("fresh"))
+  }
+}


### PR DESCRIPTION
Stacked on #407.

## Why

Seven defects fixed across #405-#407 shared one reachability condition: in-memory content that never went through load-time validation, i.e. what the editor holds while a project is being edited. Rather than keep hardening the code that copes with those states, this closes the entry point.

The editor had exactly one way left to build an invalid project:

- **Scenario ids** are already guarded — the id field only commits when `scenarioCountById(...) == 0` and otherwise shows "This id is already used."
- **Reusable scenarios** are already guarded — `validateReusableScenarioCandidate` runs `validateProject()` over the prospective content before accepting an edit.
- **The dependency menu was not.** It listed every scenario except the one being edited, so choosing a scenario that already depends on this one produced a cycle.

## Change

`selectableDependencies(holder)` leaves out the holder itself and everything that reaches it by following dependencies. Choosing one of those would mean the two scenarios each have to run after the other, which no ordering satisfies — the project would fail to load and refuse to save. The choice is no longer offered instead of being rejected afterwards.

The list is built from `sortedScenariosAndDepths()` rather than `sortedScenariosAndDepthsStateFlow.value`, for the same reason the save path was changed in #407: that flow is `WhileSubscribed`, so its value is empty before the UI first collects it and stale while collection is stopped.

## Tests

`DependencySelectionTest`: self, direct dependent, transitive dependent, siblings (which must stay allowed), tree ordering with no active collector, and the existing id guard. Negative controls: dropping the cycle filter fails the two dependent cases; reading the uncollected flow fails five.

## Verification

All modules green. `graph` / `scenarios` / `instruction` (989 lines) on a real 25-scenario project remain byte-identical to `origin/main`.

## Note

This does not make #407 redundant. A project can still arrive with a cycle from a hand-edited or AI-generated file, and load-time validation rejects it; #407 is what keeps such content from losing scenarios in the meantime.