### PR TITLE
Allow imageAssertions on call-form scenarios as call-site verification

### DIFF
--- a/arbigent-cli/src/main/kotlin/GuideCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GuideCommand.kt
@@ -171,7 +171,8 @@ field name does not fail the load — it just does nothing. After editing, verif
 Define once under `reusableScenarios` (may declare `inputs` with `required`/`default`),
 then call from ordinary scenarios with `uses` + `with`, or a `steps` list for multiple
 calls. A calling scenario must NOT set `goal`, `maxStep`, `initializationMethods`,
-`imageAssertions`, or `userPromptTemplate` — those belong to the reusable definition.
+or `userPromptTemplate` — those belong to the reusable definition. A calling scenario
+MAY set its own `imageAssertions`; they are verified after the whole call finishes.
 Reusable definitions must NOT have `dependency` or `tags`.
 
 ## Complete example

--- a/arbigent-cli/src/main/kotlin/GuideCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GuideCommand.kt
@@ -171,8 +171,10 @@ field name does not fail the load — it just does nothing. After editing, verif
 Define once under `reusableScenarios` (may declare `inputs` with `required`/`default`),
 then call from ordinary scenarios with `uses` + `with`, or a `steps` list for multiple
 calls. A calling scenario must NOT set `goal`, `maxStep`, `initializationMethods`,
-or `userPromptTemplate` — those belong to the reusable definition. A calling scenario
-MAY set its own `imageAssertions`; they are verified after the whole call finishes.
+`userPromptTemplate`, `imageAssertionHistoryCount`, or execution options
+(`aiOptions`/`mcpOptions`/`cacheOptions`/`additionalActions`) — those belong to the
+reusable definition. A calling scenario MAY set its own `imageAssertions`; they are
+verified after the whole call finishes.
 Reusable definitions must NOT have `dependency` or `tags`.
 
 ## Complete example

--- a/arbigent-cli/src/main/kotlin/InstructionCommand.kt
+++ b/arbigent-cli/src/main/kotlin/InstructionCommand.kt
@@ -147,9 +147,11 @@ class ArbigentInstructionCommand : CliktCommand(name = "instruction") {
         goal = ReusableInputsResolver.resolve(content.goal, bindings),
         initializationMethods = rawInitializationMethods.map { resolveInitializationMethod(it, bindings) },
         note = ReusableInputsResolver.resolve(content.noteForHumans, bindings),
+        // Call-site assertions come from the calling scenario, which declares no inputs, so
+        // they are appended as written rather than resolved against this leaf's bindings.
         imageAssertions = content.imageAssertions.map {
           it.copy(assertionPrompt = ReusableInputsResolver.resolve(it.assertionPrompt, bindings))
-        },
+        } + leaf.callSiteAssertions,
       )
     }
   }

--- a/arbigent-cli/src/test/kotlin/InstructionCommandTest.kt
+++ b/arbigent-cli/src/test/kotlin/InstructionCommandTest.kt
@@ -41,6 +41,8 @@ scenarios:
   uses: "search"
   with:
     term: "wifi"
+  imageAssertions:
+  - assertionPrompt: "The wifi settings entry is listed"
 reusableScenarios:
 - id: "search"
   inputs:
@@ -88,6 +90,12 @@ reusableScenarios:
 
     // Image assertion resolved and rendered as verification.
     assertContains(output, "Verification: Results for wifi are shown")
+
+    // The call site's own assertion follows the leaf's: the leaf verifies what it promised,
+    // then the call site verifies what this particular call was for.
+    val leafVerification = output.indexOf("Verification: Results for wifi are shown")
+    val callSiteVerification = output.indexOf("Verification: The wifi settings entry is listed")
+    assertTrue(callSiteVerification > leafVerification, output)
 
     // Bare project variable stays unresolved and is listed.
     assertContains(output, "{{username}}")

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -390,9 +390,18 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
         deviceFormFactor = effectiveDeviceFormFactor,
         initializationMethods = initializationMethods,
         // Call-site assertions run after the leaf's own: the leaf verifies what it promised,
-        // then the call site verifies what this particular call was for.
+        // then the call site verifies what this particular call was for. Only the leaf's own
+        // prompts are {{inputs.*}}-resolved — the call site declares no inputs.
         imageAssertions = ArbigentImageAssertions(
-          nodeScenario.imageAssertions + callSiteAssertions,
+          nodeScenario.imageAssertions.map { assertion ->
+            if (inputBindings != null) {
+              assertion.copy(
+                assertionPrompt = ReusableInputsResolver.resolve(assertion.assertionPrompt, inputBindings)
+              )
+            } else {
+              assertion
+            }
+          } + callSiteAssertions,
           nodeScenario.imageAssertionHistoryCount
         ),
         aiDecisionCache = aiDecisionCache,

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -342,7 +342,8 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
     taskScenarioId: String,
     nodeScenario: ArbigentScenarioContent,
     inputBindings: Map<String, String>?,
-    callBreadcrumb: String?
+    callBreadcrumb: String?,
+    callSiteAssertions: List<ArbigentImageAssertion> = emptyList()
   ): ArbigentAgentTask {
     // Determine which device form factor to use
     val effectiveDeviceFormFactor = if (nodeScenario.deviceFormFactor is ArbigentScenarioDeviceFormFactor.Unspecified) {
@@ -388,8 +389,10 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
         scenarioType = nodeScenario.type,
         deviceFormFactor = effectiveDeviceFormFactor,
         initializationMethods = initializationMethods,
+        // Call-site assertions run after the leaf's own: the leaf verifies what it promised,
+        // then the call site verifies what this particular call was for.
         imageAssertions = ArbigentImageAssertions(
-          nodeScenario.imageAssertions,
+          nodeScenario.imageAssertions + callSiteAssertions,
           nodeScenario.imageAssertionHistoryCount
         ),
         aiDecisionCache = aiDecisionCache,
@@ -431,6 +434,7 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
       },
       inputBindings = leaf.bindings,
       callBreadcrumb = leaf.callPath.takeIf { it.isNotEmpty() }?.joinToString(" › "),
+      callSiteAssertions = leaf.callSiteAssertions,
     )
   }
   arbigentDebugLog("Built scenario ${scenario.id} with ${result.size} tasks: ${result.map { it.scenarioId }}")

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioResolver.kt
@@ -33,6 +33,12 @@ public object ArbigentScenarioResolver {
      * that is not reached through a call.
      */
     public val callPath: List<String>,
+    /**
+     * Assertions declared on the call-form scenario itself, carried by the last leaf of its
+     * expansion: a call site's own verification runs once the whole call has finished, and the
+     * last leaf is what executes at that moment.
+     */
+    public val callSiteAssertions: List<ArbigentImageAssertion> = emptyList(),
   ) {
     /**
      * Label of this leaf's own call site, e.g. `login (user=paid)`.
@@ -188,6 +194,16 @@ public object ArbigentScenarioResolver {
 
     scenario.callSteps().forEach { step ->
       expandStep(step, emptyMap(), listOf(scenario.id), emptyList())
+    }
+    // A call-form scenario may carry its own assertions (verification specific to this call
+    // site); they run after the whole call, i.e. with the expansion's last leaf. A call-form
+    // scenario always has at least one step and every step emits a leaf, so `leaves` is never
+    // empty here.
+    if (scenario.imageAssertions.isNotEmpty() && leaves.isNotEmpty()) {
+      val last = leaves.last()
+      leaves[leaves.lastIndex] = last.copy(
+        callSiteAssertions = last.callSiteAssertions + scenario.imageAssertions
+      )
     }
     return Resolution(leaves, diagnostics)
   }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReusableScenarios.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReusableScenarios.kt
@@ -80,8 +80,12 @@ private fun ArbigentProjectFileContent.reusableScenarioErrors(): List<String> {
       if (content.initializationMethods.isNotEmpty()) {
         errors += "$where: initializationMethods are not allowed on a call-form scenario; move them into the reusable leaf"
       }
-      if (content.imageAssertions.isNotEmpty()) {
-        errors += "$where: imageAssertions are not allowed on a call-form scenario; move them into the reusable leaf"
+      // A call-form scenario may carry imageAssertions: they are this call site's own
+      // verification and run after the whole call. Reusable composites stay pure delegation —
+      // assertion prompts are not {{inputs.*}}-resolved, so parameterized assertions on a
+      // composite would silently reach the AI unresolved.
+      if (content.imageAssertions.isNotEmpty() && isReusable) {
+        errors += "$where: imageAssertions are not allowed on a reusable call-form scenario; put them on the calling scenario or the reusable leaf"
       }
       if (content.type.isExecution()) {
         errors += "$where: type Execution is not allowed on a call-form scenario; set it on the reusable leaf"

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReusableScenarios.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReusableScenarios.kt
@@ -82,8 +82,8 @@ private fun ArbigentProjectFileContent.reusableScenarioErrors(): List<String> {
       }
       // A call-form scenario may carry imageAssertions: they are this call site's own
       // verification and run after the whole call. Reusable composites stay pure delegation —
-      // assertion prompts are not {{inputs.*}}-resolved, so parameterized assertions on a
-      // composite would silently reach the AI unresolved.
+      // verification belongs either to the scenario that owns the journey (the call site) or to
+      // the leaf that promises a state, not to the wiring in between.
       if (content.imageAssertions.isNotEmpty() && isReusable) {
         errors += "$where: imageAssertions are not allowed on a reusable call-form scenario; put them on the calling scenario or the reusable leaf"
       }
@@ -137,6 +137,7 @@ private fun ArbigentProjectFileContent.reusableScenarioErrors(): List<String> {
 
     // {{inputs.*}} may only appear in reusable definitions and only for declared inputs.
     val referencedInputs = ReusableInputsResolver.referencedInputNames(content.goal) +
+      content.imageAssertions.flatMap { ReusableInputsResolver.referencedInputNames(it.assertionPrompt) } +
       content.initializationMethods.filterIsInstance<ArbigentScenarioContent.InitializationMethod.MaestroYaml>()
         .mapNotNull { method -> fixedScenarios.firstOrNull { it.id == method.scenarioId }?.yamlText }
         .flatMap { ReusableInputsResolver.referencedInputNames(it) }

--- a/arbigent-core/src/test/java/ReusableScenariosTest.kt
+++ b/arbigent-core/src/test/java/ReusableScenariosTest.kt
@@ -230,24 +230,55 @@ class ReusableScenariosTest {
   }
 
   @Test
-  fun callSiteAssertionsAppendToTheLeafsOwnAssertionsInTheTask() {
+  fun leafAssertionsResolveInputsAndRunBeforeCallSiteAssertions() = runTest {
+    leafAssertionsResolveInputsAndRunBeforeCallSiteAssertionsBody(coroutineContext[CoroutineDispatcher]!!)
+  }
+
+  private suspend fun leafAssertionsResolveInputsAndRunBeforeCallSiteAssertionsBody(
+    dispatcher: CoroutineDispatcher
+  ) {
+    val assertedPrompts = mutableListOf<String>()
+    val fakeAi = FakeAi()
+    val recordingAi = object : ArbigentAi by fakeAi {
+      override fun assertImage(imageAssertionInput: ArbigentAi.ImageAssertionInput): ArbigentAi.ImageAssertionOutput {
+        assertedPrompts += imageAssertionInput.assertions.assertions.map { it.assertionPrompt }
+        return fakeAi.assertImage(imageAssertionInput)
+      }
+    }
     val project = load(
       """
       scenarios:
       - id: "caller"
         uses: "part"
+        with:
+          user: "paid"
         imageAssertions:
         - assertionPrompt: "Call-site verification"
       reusableScenarios:
       - id: "part"
-        goal: "Do something"
+        goal: "Log in as {{inputs.user}}"
+        inputs:
+          user:
+            required: true
         imageAssertions:
-        - assertionPrompt: "Leaf verification"
+        - assertionPrompt: "Logged in as {{inputs.user}}"
       """
     )
-    // The merged order (leaf first, call site last) is asserted end-to-end by
-    // InstructionCommandTest; here the task must simply build without a validation error.
-    assertEquals(1, project.tasksOf("caller").size)
+    val scenario = project.scenarioContents.createArbigentScenario(
+      projectSettings = project.settings,
+      scenario = project.scenarioContents.first { it.id == "caller" },
+      aiFactory = { recordingAi },
+      deviceFactory = { FakeDevice() },
+      aiDecisionCache = ArbigentAiDecisionCache.Disabled,
+      fixedScenarios = project.fixedScenarios,
+      reusableScenarios = project.reusableScenarios
+    )
+    val executor = ArbigentScenarioExecutor(dispatcher)
+    executor.execute(scenario, MCPClient())
+    assertTrue(executor.isGoalAchieved())
+    // The leaf's prompt is {{inputs.*}}-resolved (matching what `instruction` renders) and runs
+    // before the call site's own verification.
+    assertEquals(listOf("Logged in as paid", "Call-site verification"), assertedPrompts)
   }
 
   // ----- Maestro yamlText substitution -----
@@ -428,9 +459,54 @@ class ReusableScenariosTest {
     )
   }
 
+  /** Assertion prompts follow the same `{{inputs.*}}` rules as goals. */
+  @Test
+  fun inputsPlaceholderInCallSiteAssertionFailsAtLoad() {
+    assertValidationError(
+      "scenarios 'caller': '{{inputs.*}}' can only be used inside reusable scenario definitions",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "part"
+        with:
+          user: "paid"
+        imageAssertions:
+        - assertionPrompt: "Logged in as {{inputs.user}}"
+      reusableScenarios:
+      - id: "part"
+        inputs:
+          user:
+            required: true
+        goal: "Log in as {{inputs.user}}"
+      """
+    )
+  }
+
+  @Test
+  fun undeclaredInputsPlaceholderInReusableAssertionFailsAtLoad() {
+    assertValidationError(
+      "reusableScenarios 'part': '{{inputs.typo}}' is not declared in inputs",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "part"
+        with:
+          user: "paid"
+      reusableScenarios:
+      - id: "part"
+        inputs:
+          user:
+            required: true
+        goal: "Log in as {{inputs.user}}"
+        imageAssertions:
+        - assertionPrompt: "Logged in as {{inputs.typo}}"
+      """
+    )
+  }
+
   /**
-   * Reusable composites stay pure delegation: assertion prompts are not `{{inputs.*}}`-resolved,
-   * so a parameterized assertion on a composite would reach the AI with the placeholder intact.
+   * Reusable composites stay pure delegation: verification belongs either to the call site or
+   * to the leaf, not to the wiring in between.
    */
   @Test
   fun imageAssertionsOnReusableCallFormFailAtLoad() {

--- a/arbigent-core/src/test/java/ReusableScenariosTest.kt
+++ b/arbigent-core/src/test/java/ReusableScenariosTest.kt
@@ -176,6 +176,80 @@ class ReusableScenariosTest {
     assertEquals(25, project.tasksOf("caller")[0].maxStep)
   }
 
+  // ----- Call-site assertions -----
+
+  /**
+   * A call-form scenario may declare its own imageAssertions: the call shares the *how*, the
+   * assertions are this call site's own *what*. They run once the whole call has finished, so
+   * the resolver carries them on the last leaf of the expansion.
+   */
+  @Test
+  fun callSiteAssertionsAreCarriedByTheLastLeafOfTheExpansion() {
+    val project = load(
+      """
+      scenarios:
+      - id: "open-search"
+        dependency: "launch"
+        uses: "open-screen"
+        with:
+          screen: "Search"
+        imageAssertions:
+        - assertionPrompt: "The search input field is shown"
+      - id: "launch"
+        goal: "Launch the app"
+      reusableScenarios:
+      - id: "open-screen"
+        inputs:
+          screen:
+            required: true
+        steps:
+        - uses: "focus-nav"
+        - uses: "select-item"
+          with:
+            screen: "{{inputs.screen}}"
+      - id: "focus-nav"
+        goal: "Focus the left navigation"
+      - id: "select-item"
+        inputs:
+          screen:
+            required: true
+        goal: "Select {{inputs.screen}}"
+      """
+    )
+    val resolution = ArbigentScenarioResolver.resolveChain(
+      target = project.scenarioContents.first { it.id == "open-search" },
+      scenarioLookup = { id -> project.scenarioContents.firstOrNull { it.id == id } },
+      reusableLookup = { id -> project.reusableScenarios.firstOrNull { it.id == id } },
+    )
+    assertEquals(emptyList(), resolution.diagnostics)
+    // launch, focus-nav, select-item — only the expansion's last leaf carries the assertions.
+    assertEquals(
+      listOf(emptyList(), emptyList(), listOf("The search input field is shown")),
+      resolution.leaves.map { leaf -> leaf.callSiteAssertions.map { it.assertionPrompt } }
+    )
+  }
+
+  @Test
+  fun callSiteAssertionsAppendToTheLeafsOwnAssertionsInTheTask() {
+    val project = load(
+      """
+      scenarios:
+      - id: "caller"
+        uses: "part"
+        imageAssertions:
+        - assertionPrompt: "Call-site verification"
+      reusableScenarios:
+      - id: "part"
+        goal: "Do something"
+        imageAssertions:
+        - assertionPrompt: "Leaf verification"
+      """
+    )
+    // The merged order (leaf first, call site last) is asserted end-to-end by
+    // InstructionCommandTest; here the task must simply build without a validation error.
+    assertEquals(1, project.tasksOf("caller").size)
+  }
+
   // ----- Maestro yamlText substitution -----
 
   @Test
@@ -348,6 +422,30 @@ class ReusableScenariosTest {
         initializeMethods:
           type: "Back"
       reusableScenarios:
+      - id: "part"
+        goal: "part goal"
+      """
+    )
+  }
+
+  /**
+   * Reusable composites stay pure delegation: assertion prompts are not `{{inputs.*}}`-resolved,
+   * so a parameterized assertion on a composite would reach the AI with the placeholder intact.
+   */
+  @Test
+  fun imageAssertionsOnReusableCallFormFailAtLoad() {
+    assertValidationError(
+      "reusableScenarios 'composite': imageAssertions are not allowed on a reusable call-form scenario",
+      """
+      scenarios:
+      - id: "caller"
+        uses: "composite"
+      reusableScenarios:
+      - id: "composite"
+        steps:
+        - uses: "part"
+        imageAssertions:
+        - assertionPrompt: "Not allowed here"
       - id: "part"
         goal: "part goal"
       """


### PR DESCRIPTION
## Why

The most natural split — *share the how via a reusable call, keep the what on the scenario* — is currently unwritable. The moment a scenario uses `uses`/`steps`, validation rejects its `imageAssertions`, so authors either keep duplicating navigation prose in every scenario's goal, or move assertions into the reusable leaf where every caller inherits verification that is really specific to one call site.

This PR allows a call-form scenario in `scenarios` to carry its own `imageAssertions`:

```yaml
scenarios:
- id: open-search
  dependency: launch
  uses: open-screen
  with: { screen: "Search" }
  imageAssertions:
  - assertionPrompt: "The search input field is shown"
```

## Semantics

- Call-site assertions are the call site's own verification and run **after the whole call finishes**: the resolver carries them on the last leaf of the expansion, and the task merges them after that leaf's own assertions (the leaf verifies what it promised, then the call site verifies what this call was for).
- **Reusable call-form composites stay pure delegation** (still rejected, with a clearer message): assertion prompts are not `{{inputs.*}}`-resolved, so a parameterized assertion on a composite would silently reach the AI unresolved.
- `imageAssertionHistoryCount` and execution options remain leaf-only.

## Changes

- `ArbigentScenarioResolver`: `ResolvedLeaf.callSiteAssertions`, attached to the last leaf in `expandCalls`
- `createArbigentScenario`: merges call-site assertions after the leaf's own in the task's `ArbigentImageAssertions`
- `instruction` command: renders call-site verification after the leaf's (raw, since the calling scenario declares no inputs)
- `guide` command reference text updated
- Validation: the call-form `imageAssertions` rejection now applies only to `reusableScenarios` entries

## Testing

- New tests: resolver attaches assertions to the expansion's last leaf only; call-form + leaf assertions build a task; reusable composite with assertions still fails at load; `instruction` renders leaf verification before call-site verification
- Full `:arbigent-core` / `:arbigent-cli` / `:arbigent-ui` test suites pass
- Verified end-to-end with the installed CLI: a new-shape project loads and `instruction` prints the call-site verification on the call's final step