### PR TITLE
Fix Unknown key errors from KeyPress by resolving aliases and listing supported keys

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/AgentCommands.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/AgentCommands.kt
@@ -647,7 +647,7 @@ public data class KeyPressAgentAction(val keyName: String) : ArbigentAgentAction
         AgentActionType.Argument(
           name = "text",
           type = "string",
-          description = "The name of the key to press. Must be one of: ${supportedKeyNames().joinToString(", ")}"
+          description = "The name of the key to press (e.g., ENTER, TAB, BACKSPACE, ESCAPE, BACK, HOME)"
         )
       )
   }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/AgentCommands.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/AgentCommands.kt
@@ -601,7 +601,7 @@ public data class KeyPressAgentAction(val keyName: String) : ArbigentAgentAction
   override fun runDeviceAction(runInput: ArbigentAgentAction.RunInput) {
     val code = resolveKeyCode(keyName)
       ?: throw MaestroException.InvalidCommand(
-        message = "Unknown key: $keyName. Supported keys: ${supportedKeyNames().joinToString(", ")}"
+        message = "Unknown key: $keyName. Supported keys (canonical names): ${supportedKeyNames().joinToString(", ")}"
       )
     runInput.device.executeActions(
       actions = listOf(
@@ -621,7 +621,6 @@ public data class KeyPressAgentAction(val keyName: String) : ArbigentAgentAction
     private val keyAliases: Map<String, KeyCode> = mapOf(
       "DEL" to KeyCode.BACKSPACE,
       "DELETE" to KeyCode.BACKSPACE,
-      "FORWARD_DEL" to KeyCode.BACKSPACE,
       "ESC" to KeyCode.ESCAPE,
       "DPAD_UP" to KeyCode.REMOTE_UP,
       "DPAD_DOWN" to KeyCode.REMOTE_DOWN,
@@ -632,7 +631,12 @@ public data class KeyPressAgentAction(val keyName: String) : ArbigentAgentAction
     )
 
     public fun resolveKeyCode(keyName: String): KeyCode? {
-      val normalized = keyName.trim().removePrefix("KEYCODE_")
+      val trimmed = keyName.trim()
+      val normalized = if (trimmed.startsWith("KEYCODE_", ignoreCase = true)) {
+        trimmed.substring("KEYCODE_".length)
+      } else {
+        trimmed
+      }
       return KeyCode.getByName(normalized)
         ?: KeyCode.entries.firstOrNull { it.name.equals(normalized.replace(' ', '_'), ignoreCase = true) }
         ?: keyAliases[normalized.replace(' ', '_').uppercase()]

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/AgentCommands.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/AgentCommands.kt
@@ -599,8 +599,10 @@ public data class KeyPressAgentAction(val keyName: String) : ArbigentAgentAction
   }
 
   override fun runDeviceAction(runInput: ArbigentAgentAction.RunInput) {
-    val code = KeyCode.getByName(keyName)
-      ?: throw MaestroException.InvalidCommand(message = "Unknown key: $keyName")
+    val code = resolveKeyCode(keyName)
+      ?: throw MaestroException.InvalidCommand(
+        message = "Unknown key: $keyName. Supported keys: ${supportedKeyNames().joinToString(", ")}"
+      )
     runInput.device.executeActions(
       actions = listOf(
         MaestroCommand(
@@ -615,6 +617,29 @@ public data class KeyPressAgentAction(val keyName: String) : ArbigentAgentAction
   public companion object : AgentActionType {
     override val actionName: String = "KeyPress"
 
+    // AI models often emit Android KeyEvent style names that Maestro doesn't know.
+    private val keyAliases: Map<String, KeyCode> = mapOf(
+      "DEL" to KeyCode.BACKSPACE,
+      "DELETE" to KeyCode.BACKSPACE,
+      "FORWARD_DEL" to KeyCode.BACKSPACE,
+      "ESC" to KeyCode.ESCAPE,
+      "DPAD_UP" to KeyCode.REMOTE_UP,
+      "DPAD_DOWN" to KeyCode.REMOTE_DOWN,
+      "DPAD_LEFT" to KeyCode.REMOTE_LEFT,
+      "DPAD_RIGHT" to KeyCode.REMOTE_RIGHT,
+      "DPAD_CENTER" to KeyCode.REMOTE_CENTER,
+      "MENU" to KeyCode.REMOTE_MENU,
+    )
+
+    public fun resolveKeyCode(keyName: String): KeyCode? {
+      val normalized = keyName.trim().removePrefix("KEYCODE_")
+      return KeyCode.getByName(normalized)
+        ?: KeyCode.entries.firstOrNull { it.name.equals(normalized.replace(' ', '_'), ignoreCase = true) }
+        ?: keyAliases[normalized.replace(' ', '_').uppercase()]
+    }
+
+    public fun supportedKeyNames(): List<String> = KeyCode.entries.map { it.name }
+
     override fun actionDescription(): String = "Press a specific key on the device"
 
     override fun arguments(): List<AgentActionType.Argument> =
@@ -622,7 +647,7 @@ public data class KeyPressAgentAction(val keyName: String) : ArbigentAgentAction
         AgentActionType.Argument(
           name = "text",
           type = "string",
-          description = "The name of the key to press (e.g., ENTER, TAB, etc.)"
+          description = "The name of the key to press. Must be one of: ${supportedKeyNames().joinToString(", ")}"
         )
       )
   }

--- a/arbigent-core/src/test/java/KeyPressAgentActionTest.kt
+++ b/arbigent-core/src/test/java/KeyPressAgentActionTest.kt
@@ -30,6 +30,18 @@ class KeyPressAgentActionTest {
   }
 
   @Test
+  fun `strips keycode prefix case insensitively`() {
+    assertEquals(KeyCode.BACKSPACE, KeyPressAgentAction.resolveKeyCode("keycode_del"))
+    assertEquals(KeyCode.REMOTE_UP, KeyPressAgentAction.resolveKeyCode("KeyCode_Dpad_Up"))
+  }
+
+  @Test
+  fun `rejects forward delete because maestro has no forward-delete key`() {
+    assertNull(KeyPressAgentAction.resolveKeyCode("FORWARD_DEL"))
+    assertNull(KeyPressAgentAction.resolveKeyCode("KEYCODE_FORWARD_DEL"))
+  }
+
+  @Test
   fun `trims whitespace`() {
     assertEquals(KeyCode.TAB, KeyPressAgentAction.resolveKeyCode(" TAB "))
   }

--- a/arbigent-core/src/test/java/KeyPressAgentActionTest.kt
+++ b/arbigent-core/src/test/java/KeyPressAgentActionTest.kt
@@ -1,0 +1,42 @@
+import io.github.takahirom.arbigent.KeyPressAgentAction
+import maestro.KeyCode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class KeyPressAgentActionTest {
+  @Test
+  fun `resolves maestro description names`() {
+    assertEquals(KeyCode.ENTER, KeyPressAgentAction.resolveKeyCode("Enter"))
+    assertEquals(KeyCode.BACKSPACE, KeyPressAgentAction.resolveKeyCode("backspace"))
+    assertEquals(KeyCode.REMOTE_UP, KeyPressAgentAction.resolveKeyCode("Remote Dpad Up"))
+  }
+
+  @Test
+  fun `resolves enum names`() {
+    assertEquals(KeyCode.VOLUME_UP, KeyPressAgentAction.resolveKeyCode("VOLUME_UP"))
+    assertEquals(KeyCode.REMOTE_CENTER, KeyPressAgentAction.resolveKeyCode("REMOTE_CENTER"))
+    assertEquals(KeyCode.REMOTE_PLAY_PAUSE, KeyPressAgentAction.resolveKeyCode("remote_play_pause"))
+  }
+
+  @Test
+  fun `resolves android keyevent style aliases`() {
+    assertEquals(KeyCode.BACKSPACE, KeyPressAgentAction.resolveKeyCode("DEL"))
+    assertEquals(KeyCode.BACKSPACE, KeyPressAgentAction.resolveKeyCode("DELETE"))
+    assertEquals(KeyCode.BACKSPACE, KeyPressAgentAction.resolveKeyCode("KEYCODE_DEL"))
+    assertEquals(KeyCode.ESCAPE, KeyPressAgentAction.resolveKeyCode("ESC"))
+    assertEquals(KeyCode.REMOTE_CENTER, KeyPressAgentAction.resolveKeyCode("DPAD_CENTER"))
+    assertEquals(KeyCode.REMOTE_UP, KeyPressAgentAction.resolveKeyCode("KEYCODE_DPAD_UP"))
+  }
+
+  @Test
+  fun `trims whitespace`() {
+    assertEquals(KeyCode.TAB, KeyPressAgentAction.resolveKeyCode(" TAB "))
+  }
+
+  @Test
+  fun `returns null for unknown keys`() {
+    assertNull(KeyPressAgentAction.resolveKeyCode("F13"))
+    assertNull(KeyPressAgentAction.resolveKeyCode(""))
+  }
+}


### PR DESCRIPTION
## Problem

When the AI emits an Android-KeyEvent-style key name such as `DEL` in a `KeyPress` action (e.g. while trying to correct text it just typed into a search field), Maestro's `KeyCode.getByName` fails because it only matches enum *descriptions* (`"Backspace"`, `"Remote Dpad Up"`, ...). The action throws:

```
maestro.MaestroException$InvalidCommand: Unknown key: DEL
```

The exception is converted into step feedback, but the feedback doesn't tell the AI which keys are valid, so retries tend to fail again and burn through `maxStep`, failing the scenario.

## Fix

- Add `KeyPressAgentAction.resolveKeyCode()` which resolves, in order: Maestro description names (existing behavior), `KeyCode` enum names (`VOLUME_UP`, `REMOTE_CENTER`, ...), and common Android KeyEvent aliases (`DEL`/`DELETE`/`KEYCODE_DEL` → `BACKSPACE`, `ESC` → `ESCAPE`, `DPAD_*` → `REMOTE_*`, etc.).
- Include the full list of supported key names in the `Unknown key` error message, so the failure feedback lets the AI retry with a valid key instead of guessing. The list is intentionally kept out of the always-sent argument description (it would add ~410 chars to every decision request); the description only shows a few common examples.

## Testing

- Added `KeyPressAgentActionTest` covering description names, enum names, aliases, whitespace, and unknown keys.
- `./gradlew :arbigent-core:test --tests KeyPressAgentActionTest` passes.