### PR TITLE
Fix report export failing after a replayed run

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
@@ -109,7 +109,9 @@ internal class ArbigentReplayDecisionInterceptor(
         cacheKey = decisionInput.cacheKey,
         timestamp = TimeProvider.get().currentTimeMillis(),
         screenshotFilePath = decisionInput.screenshotFilePath,
-        apiCallJsonLFilePath = decisionInput.apiCallJsonLFilePath,
+        // No AI call was made, so nothing wrote a JSONL for this step. Carrying the path anyway
+        // would name an artifact that does not exist, and the report copies every path it is given.
+        apiCallJsonLFilePath = null,
         stepSource = ArbigentStepSource.Replay,
       ),
     )

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
@@ -89,6 +89,17 @@ internal class ArbigentReplayDecisionInterceptor(
     // re-locate it so the action survives a reordered list, and its absence is real divergence.
     // Elements with no identifying attributes at all (common for TV cards driven by D-pad index)
     // are replayed as recorded — the image assertions and the fallback are what keep replay honest.
+    // A recorded index means nothing on a shorter element list, and the actions that carry one
+    // index into it directly. Catching it here turns a stray IndexOutOfBoundsException thrown
+    // mid-action into ordinary divergence, before anything has been tapped.
+    recordedAction.recordedElementIndex()?.let { index ->
+      if (index !in decisionInput.elements.elements.indices) {
+        throw ReplayDivergenceException(
+          "step ${replayIndex + 1} targets element $index but the current screen has " +
+            "${decisionInput.elements.elements.size}",
+        )
+      }
+    }
     val identity = recorded.decisionOutput.step.targetElement
     val reboundAction = if (identity != null) {
       val currentElement = identity.findMatch(decisionInput.elements)
@@ -212,6 +223,12 @@ private fun ArbigentAgentAction.targetElement(elements: ArbigentElementList): Ar
   // Coordinate actions explicitly target content outside the UI hierarchy and therefore cannot
   // be replayed safely in replay mode.
   is ClickAtCoordinates -> null
+  else -> null
+}
+
+private fun ArbigentAgentAction.recordedElementIndex(): Int? = when (this) {
+  is ClickWithIndex -> index
+  is DpadAutoFocusWithIndexAgentAction -> index
   else -> null
 }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReportHtml.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReportHtml.kt
@@ -73,7 +73,10 @@ public class ArbigentHtmlReport {
                     step.copy(
                       screenshotFilePath = newScreenshotFile.absolutePath
                     ).let {
-                      step.apiCallJsonPath?.let { apiCallJsonPath ->
+                      // A recorded path can outlive the file it names: an AI-decision cache entry
+                      // survives the result directory it was written in. Exporting a report must
+                      // not fail over a missing artifact.
+                      step.apiCallJsonPath?.takeIf { File(it).isFile }?.let { apiCallJsonPath ->
                         val jsonlFile = File(apiCallJsonPath)
                         val newJsonlFile = File(jsonlsDir, jsonlFile.name)
                         jsonlFile.copyTo(newJsonlFile, overwrite = true)

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReportHtml.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReportHtml.kt
@@ -74,16 +74,19 @@ public class ArbigentHtmlReport {
                       screenshotFilePath = newScreenshotFile.absolutePath
                     ).let {
                       // A recorded path can outlive the file it names: an AI-decision cache entry
-                      // survives the result directory it was written in. Exporting a report must
-                      // not fail over a missing artifact.
-                      step.apiCallJsonPath?.takeIf { File(it).isFile }?.let { apiCallJsonPath ->
-                        val jsonlFile = File(apiCallJsonPath)
+                      // survives the result directory it was written in. Exporting must neither
+                      // fail over the missing artifact nor keep pointing at it, since the export
+                      // would then carry a dead link and a local path it never packaged.
+                      val jsonlFile = step.apiCallJsonPath?.let { path -> File(path) }
+                      if (jsonlFile != null && jsonlFile.isFile) {
                         val newJsonlFile = File(jsonlsDir, jsonlFile.name)
                         jsonlFile.copyTo(newJsonlFile, overwrite = true)
                         it.copy(
                           apiCallJsonPath = newJsonlFile.absolutePath
                         )
-                      } ?: it
+                      } else {
+                        it.copy(apiCallJsonPath = null)
+                      }
                     }
                   }
                 )

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentHtmlReportTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentHtmlReportTest.kt
@@ -138,10 +138,15 @@ class ArbigentHtmlReportRobot(private val tempFolder: TemporaryFolder) {
     }
 
     fun assertReportExistsWithoutJsonl(): ArbigentHtmlReportRobot {
-        assertTrue(File(outputDir, "report.html").exists(), "Report should be written")
+        val reportFile = File(outputDir, "report.html")
+        assertTrue(reportFile.exists(), "Report should be written")
         assertTrue(
             !File(outputDir, "jsonls/never-written.jsonl").exists(),
             "A JSONL that was never written must not be copied"
+        )
+        assertTrue(
+            !reportFile.readText().contains("never-written.jsonl"),
+            "The export must not point at a JSONL it did not package"
         )
         return this
     }

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentHtmlReportTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentHtmlReportTest.kt
@@ -47,6 +47,16 @@ class ArbigentHtmlReportTest(private val behavior: DescribedBehavior<ArbigentHtm
                             assertReportFileExists()
                         }
                     }
+                    describe("with a replayed step whose JSONL was never written") {
+                        doIt {
+                            createScreenshotFile()
+                            generateReportWithMissingJsonl()
+                        }
+                        itShould("export without failing") {
+                            capture(it)
+                            assertReportExistsWithoutJsonl()
+                        }
+                    }
                     describe("with existing annotated files") {
                         doIt {
                             createScreenshotFile()
@@ -113,6 +123,26 @@ class ArbigentHtmlReportRobot(private val tempFolder: TemporaryFolder) {
         result = createTestProjectExecutionResult(step)
         outputDir = tempFolder.newFolder("output")
         ArbigentHtmlReport().saveReportHtml(outputDir.absolutePath, result)
+        return this
+    }
+
+    fun generateReportWithMissingJsonl(): ArbigentHtmlReportRobot {
+        val step = createTestStep().copy(
+            apiCallJsonPath = File(tempFolder.root, "never-written.jsonl").absolutePath,
+            stepSource = ArbigentStepSource.Replay,
+        )
+        result = createTestProjectExecutionResult(step)
+        outputDir = tempFolder.newFolder("output-missing-jsonl")
+        ArbigentHtmlReport().saveReportHtml(outputDir.absolutePath, result)
+        return this
+    }
+
+    fun assertReportExistsWithoutJsonl(): ArbigentHtmlReportRobot {
+        assertTrue(File(outputDir, "report.html").exists(), "Report should be written")
+        assertTrue(
+            !File(outputDir, "jsonls/never-written.jsonl").exists(),
+            "A JSONL that was never written must not be copied"
+        )
         return this
     }
 

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
@@ -9,8 +9,10 @@ import java.io.File
 import java.nio.file.Files
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertTrue
 
 class ArbigentReplayTraceTest {
   @Test
@@ -181,6 +183,66 @@ class ArbigentReplayTraceTest {
       "A failed normal attempt must purge the layout cache as before",
     )
   }
+
+  /**
+   * The actions that carry a recorded index read the element list directly, so an index that no
+   * longer exists would surface as an IndexOutOfBoundsException from inside the action, after the
+   * screen had already been touched. Replay must see it as divergence first.
+   */
+  @Test
+  fun `an index beyond the current screen is divergence, not an exception from the action`() = runTest {
+    val action = ClickWithIndex(16)
+    val trace = ArbigentReplayTrace(
+      version = "1.2.3",
+      scenarioId = "scenario",
+      taskIndex = 0,
+      taskIdentity = "scenario",
+      goalHash = "hash",
+      steps = listOf(
+        ArbigentReplayTraceStep(
+          decisionOutput = ArbigentAi.DecisionOutput(
+            agentActions = listOf(action),
+            step = ArbigentContextHolder.Step(
+              stepId = "step-1",
+              agentAction = action,
+              cacheKey = "cache-key",
+              screenshotFilePath = "screenshot.png",
+            ),
+          ),
+        ),
+      ),
+    )
+    val interceptor = ArbigentReplayDecisionInterceptor(trace)
+    val onlyOneElement = ArbigentElementList(
+      listOf(element(text = "Only", resourceId = "only", accessibilityId = "Only")),
+      screenWidth = 100,
+    )
+
+    val exception = assertFailsWith<ReplayDivergenceException> {
+      interceptor.intercept(decisionInput(onlyOneElement)) { error("Should not reach the AI") }
+    }
+    assertTrue(
+      exception.message.contains("targets element 16"),
+      "Expected the reason to name the missing index, got: ${exception.message}",
+    )
+  }
+
+  private fun decisionInput(elements: ArbigentElementList): ArbigentAi.DecisionInput =
+    ArbigentAi.DecisionInput(
+      stepId = "step",
+      contextHolder = ArbigentContextHolder("goal", 1),
+      formFactor = ArbigentScenarioDeviceFormFactor.Mobile,
+      uiTreeStrings = io.github.takahirom.arbigent.result.ArbigentUiTreeStrings("", ""),
+      focusedTreeString = null,
+      agentActionTypes = defaultAgentActionTypesForVisualMode(),
+      screenshotFilePath = "screenshot.png",
+      requestUuid = "uuid",
+      apiCallJsonLFilePath = "call.jsonl",
+      elements = elements,
+      prompt = ArbigentPrompt(),
+      cacheKey = "cache-key",
+      aiOptions = null,
+    )
 
   private fun executeInput(attemptMode: ArbigentAttemptMode): ArbigentAgent.ExecuteInput {
     val device = FakeDevice()


### PR DESCRIPTION
# What

A replayed step no longer records an `apiCallJsonLFilePath`, and the HTML report no longer fails
when a recorded path names a file that is not there.

# Why

Replay makes no AI call, so nothing writes the JSONL for that step — but the step still carried the
path the AI call would have used. `ReportHtml` copies every non-null `apiCallJsonPath` with
`copyTo`, which throws when the source is missing.

The CLI passes `needCopy = false` and so never hit this, but the desktop UI saves a report with
copying enabled, so exporting a project after a successful replay threw `NoSuchFileException`.

Both halves are worth fixing. Carrying a path to an artifact that does not exist is dishonest in the
result model, and the copy should not fail over a missing artifact regardless: an AI-decision cache
entry can outlive the result directory it was originally written in, so a cache-hit step can name a
path that is gone for the same reason.

## Verification

`./gradlew installDist` and the full test suite pass. A new report case exports a result whose
replayed step names a JSONL that was never written; it was checked with a negative control —
removing the guard reproduces `NoSuchFileException`.

Found by a `codex exec review` pass over the 0.79.0 delta.
