### PR TITLE
Hash the replay trace file name so long task identities fit

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
@@ -7,7 +7,6 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import java.io.File
 import java.security.MessageDigest
-import java.util.Base64
 
 public enum class ArbigentAttemptMode {
   Normal,
@@ -355,18 +354,21 @@ internal data class ArbigentReplayTraceKey(
 ) {
   val goalHash: String = goal.sha256()
 
-  val storageKey: String = buildString {
-    append("v")
-    append(version.toPathToken())
-    append("-scenario-")
-    append(scenarioId.toPathToken())
-    append("-task-")
-    append(taskIndex)
-    append("-")
-    append(taskIdentity.toPathToken())
-    append("-goal-")
-    append(goalHash)
-  }
+  /**
+   * File name of this trace. Every part is folded into a single hash instead of being spelled out,
+   * because [taskIdentity] is the resolved goal and hints of the task: encoding it produced names
+   * of 300 to 900 bytes for Japanese text, well past the 255 byte limit a single file name
+   * component has on ext4 and APFS, and every write failed with FileNotFoundException so no
+   * scenario could ever replay. Nothing is lost by not naming the parts: the trace file itself
+   * carries the scenario id, task index and goal hash, and reading one validates them again.
+   */
+  val storageKey: String = listOf(
+    version,
+    scenarioId,
+    taskIndex.toString(),
+    taskIdentity,
+    goalHash,
+  ).joinToString(separator = "\u0000").sha256()
 }
 
 internal class ArbigentReplayTraceStore(
@@ -417,7 +419,3 @@ internal class ArbigentReplayTraceStore(
 private fun String.sha256(): String = MessageDigest.getInstance("SHA-256")
   .digest(toByteArray())
   .joinToString("") { byte -> "%02x".format(byte) }
-
-private fun String.toPathToken(): String = Base64.getUrlEncoder()
-  .withoutPadding()
-  .encodeToString(toByteArray())

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
@@ -80,6 +80,81 @@ class ArbigentReplayTraceTest {
     assertEquals("Open the model", restored.steps.first().decisionOutput.step.memo)
   }
 
+  /**
+   * A task identity is the resolved goal and hints of the task, so it is long free text, and in
+   * Japanese it encodes to several bytes per character. Spelling it out in the file name produced
+   * names past the 255 byte limit a file name component has, and every write failed, which left
+   * replay permanently unable to find a trace.
+   */
+  @Test
+  fun `a trace for a long non-ascii task identity can be stored and read back`() {
+    val directory = Files.createTempDirectory("arbigent-replay-trace-long-name").toFile()
+    val store = ArbigentReplayTraceStore { directory }
+    val key = ArbigentReplayTraceKey(
+      version = "1.2.3",
+      // Synthetic multi-byte text: what matters here is only the encoded byte length.
+      scenarioId = "\u3042".repeat(30),
+      taskIndex = 3,
+      taskIdentity = "\u3042".repeat(400),
+      goal = "\u3042".repeat(30),
+    )
+
+    store.write(key, minimalTrace(key))
+
+    assertNotNull(store.read(key), "the trace could not be read back")
+    val fileName = directory.listFiles().orEmpty().single().name
+    assertTrue(
+      fileName.toByteArray().size <= 255,
+      "file name is ${fileName.toByteArray().size} bytes, which no common filesystem accepts",
+    )
+  }
+
+  @Test
+  fun `traces that differ only in task index do not share a file`() {
+    val directory = Files.createTempDirectory("arbigent-replay-trace-distinct").toFile()
+    val store = ArbigentReplayTraceStore { directory }
+    val first = ArbigentReplayTraceKey(
+      version = "1.2.3",
+      scenarioId = "scenario",
+      taskIndex = 0,
+      taskIdentity = "identity",
+      goal = "Goal",
+    )
+    val second = first.copy(taskIndex = 1)
+
+    store.write(first, minimalTrace(first))
+    store.write(second, minimalTrace(second))
+
+    assertEquals(2, directory.listFiles().orEmpty().size)
+    assertEquals(0, assertNotNull(store.read(first)).taskIndex)
+    assertEquals(1, assertNotNull(store.read(second)).taskIndex)
+  }
+
+  /** The smallest trace [ArbigentReplayTrace.isValidFor] accepts: one step that reaches the goal. */
+  private fun minimalTrace(key: ArbigentReplayTraceKey): ArbigentReplayTrace {
+    val action = GoalAchievedAgentAction()
+    return ArbigentReplayTrace(
+      version = key.version,
+      scenarioId = key.scenarioId,
+      taskIndex = key.taskIndex,
+      taskIdentity = key.taskIdentity,
+      goalHash = key.goalHash,
+      steps = listOf(
+        ArbigentReplayTraceStep(
+          decisionOutput = ArbigentAi.DecisionOutput(
+            agentActions = listOf(action),
+            step = ArbigentContextHolder.Step(
+              stepId = "step-1",
+              agentAction = action,
+              cacheKey = "cache-key",
+              screenshotFilePath = "screenshot.png",
+            ),
+          ),
+        ),
+      ),
+    )
+  }
+
   @Test
   fun `a trace store failure does not fail the run that just passed`() {
     val notADirectory = Files.createTempFile("arbigent-replay-trace-blocked", ".txt").toFile()


### PR DESCRIPTION
## Problem

`replayWithFallback` never replayed anything on Linux. Every trace write failed:

```
E: Failed to store replay trace v...-scenario-...-goal-...:
   java.io.FileNotFoundException: arbigent-cache/traces/....json
```

`ArbigentReplayTraceKey.storageKey` spelled out each part of the key in the file name, including
`taskIdentity.toPathToken()`. A task identity is the resolved goal and hints of the task, so it is
long free text, and base64 of non-ASCII text expands it further. Observed file name lengths in a
real run were 318, 318, 322, 338, 354, 476, 484, 524, 561, 572 and 965 bytes — a single file name
component is limited to 255 bytes on ext4 and APFS, so every one of them was rejected.

Writes are deliberately non-fatal, so nothing failed loudly: scenarios kept passing, the traces
just silently never existed, and the next run had nothing to replay.

## Fix

Fold the whole key into one SHA-256 instead of naming its parts. The trace file already stores the
scenario id, task index, task identity and goal hash, and `invalidReasonFor` checks them when a
trace is read, so the name only has to be a stable unique key. `toPathToken` had no other caller
and is removed.

## Tests

- `a trace for a long non-ascii task identity can be stored and read back` — fails before this
  change (`FileNotFoundException`), passes after, and asserts the file name stays within 255 bytes.
- `traces that differ only in task index do not share a file` — guards against the hash collapsing
  keys that must stay distinct.

`./gradlew :arbigent-core:test` is green.
