### PR TITLE
Start image assertion history at the previous screenshot

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -911,13 +911,19 @@ public interface ArbigentStepInterceptor : ArbigentInterceptor {
  * starts at the immediately preceding screenshot. Skipping that first entry both delayed a
  * two-image assertion until the third step of a task and then compared non-adjacent screenshots.
  * An assertion about what changed between images cannot pass while it is handed only one.
+ *
+ * A step can be recorded against the screen the assertion is about before the assertion runs — a
+ * stuck screen or a failed screenshot both leave one behind — so the screenshot being judged is
+ * dropped from the history rather than handed over a second time as its own predecessor.
  */
 internal fun assertionScreenshotFilePaths(
   currentScreenshotFilePath: String,
   previousScreenshotFilePaths: List<String>,
   historyCount: Int,
 ): List<String> = listOf(currentScreenshotFilePath) +
-  previousScreenshotFilePaths.take((historyCount - 1).coerceAtLeast(0))
+  previousScreenshotFilePaths
+    .filterNot { it == currentScreenshotFilePath }
+    .take((historyCount - 1).coerceAtLeast(0))
 
 public fun defaultAgentActionTypesForVisualMode(): List<AgentActionType> {
   return listOf(

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -804,17 +804,14 @@ public fun AgentConfigBuilder(
       ): ArbigentAi.ImageAssertionOutput {
         val output = chain.proceed(
           imageAssertionInput.copy(
-            screenshotFilePaths = (1..imageAssertions.historyCount).mapNotNull { index ->
-              val path: String? = if (index == 1) {
-                imageAssertionInput.screenshotFilePaths.first()
-              } else {
-                imageAssertionInput.arbigentContextHolder.steps().reversed()
-                  .map { it.screenshotFilePath }
-                  .distinct()
-                  .getOrNull(index - 1)
-              }
-              path
-            },
+            screenshotFilePaths = assertionScreenshotFilePaths(
+              currentScreenshotFilePath = imageAssertionInput.screenshotFilePaths.first(),
+              previousScreenshotFilePaths = imageAssertionInput.arbigentContextHolder.steps()
+                .reversed()
+                .map { it.screenshotFilePath }
+                .distinct(),
+              historyCount = imageAssertions.historyCount,
+            ),
             assertions = imageAssertionInput.assertions + imageAssertions
           )
         )
@@ -905,6 +902,22 @@ public interface ArbigentStepInterceptor : ArbigentInterceptor {
   }
 }
 
+
+/**
+ * Screenshots handed to an image assertion: the one being judged, followed by up to
+ * [historyCount] - 1 earlier ones, newest first.
+ *
+ * An assertion runs before its own step is recorded, so [previousScreenshotFilePaths] already
+ * starts at the immediately preceding screenshot. Skipping that first entry both delayed a
+ * two-image assertion until the third step of a task and then compared non-adjacent screenshots.
+ * An assertion about what changed between images cannot pass while it is handed only one.
+ */
+internal fun assertionScreenshotFilePaths(
+  currentScreenshotFilePath: String,
+  previousScreenshotFilePaths: List<String>,
+  historyCount: Int,
+): List<String> = listOf(currentScreenshotFilePath) +
+  previousScreenshotFilePaths.take((historyCount - 1).coerceAtLeast(0))
 
 public fun defaultAgentActionTypesForVisualMode(): List<AgentActionType> {
   return listOf(

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/AssertionScreenshotHistoryTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/AssertionScreenshotHistoryTest.kt
@@ -1,0 +1,54 @@
+package io.github.takahirom.arbigent
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AssertionScreenshotHistoryTest {
+  @Test
+  fun `the history starts at the screenshot immediately before the one being judged`() {
+    assertEquals(
+      listOf("s3", "s2"),
+      assertionScreenshotFilePaths(
+        currentScreenshotFilePath = "s3",
+        previousScreenshotFilePaths = listOf("s2", "s1"),
+        historyCount = 2,
+      ),
+    )
+  }
+
+  @Test
+  fun `the second step of a task already has a previous screenshot to compare`() {
+    assertEquals(
+      listOf("s2", "s1"),
+      assertionScreenshotFilePaths(
+        currentScreenshotFilePath = "s2",
+        previousScreenshotFilePaths = listOf("s1"),
+        historyCount = 2,
+      ),
+    )
+  }
+
+  @Test
+  fun `the first step of a task has nothing to compare against`() {
+    assertEquals(
+      listOf("s1"),
+      assertionScreenshotFilePaths(
+        currentScreenshotFilePath = "s1",
+        previousScreenshotFilePaths = emptyList(),
+        historyCount = 2,
+      ),
+    )
+  }
+
+  @Test
+  fun `a history count of one asks about the current screenshot alone`() {
+    assertEquals(
+      listOf("s3"),
+      assertionScreenshotFilePaths(
+        currentScreenshotFilePath = "s3",
+        previousScreenshotFilePaths = listOf("s2", "s1"),
+        historyCount = 1,
+      ),
+    )
+  }
+}

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/AssertionScreenshotHistoryTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/AssertionScreenshotHistoryTest.kt
@@ -28,6 +28,23 @@ class AssertionScreenshotHistoryTest {
     )
   }
 
+  /**
+   * A stuck screen, or a screenshot that could not be taken, records a step against the screen the
+   * assertion is about before the assertion runs. Handing that screenshot over as its own
+   * predecessor would leave the assertion comparing an image with itself.
+   */
+  @Test
+  fun `a step already recorded against the current screenshot does not fill the history`() {
+    assertEquals(
+      listOf("s2", "s1"),
+      assertionScreenshotFilePaths(
+        currentScreenshotFilePath = "s2",
+        previousScreenshotFilePaths = listOf("s2", "s1"),
+        historyCount = 2,
+      ),
+    )
+  }
+
   @Test
   fun `the first step of a task has nothing to compare against`() {
     assertEquals(


### PR DESCRIPTION
# What

`imageAssertionHistoryCount` now includes the screenshot immediately preceding the one being judged. The selection moved into `assertionScreenshotFilePaths`, which is covered by unit tests.

# Why

An image assertion runs before its own step is recorded, so the step history already starts at the previous screenshot. Indexing it from the second entry meant:

- with `imageAssertionHistoryCount: 2`, an assertion received two screenshots only from the **third** step of a task; the first and second steps silently got one
- once two were passed, they were the current screenshot and the one before last, skipping the screenshot in between

An assertion phrased as "the images differ" cannot pass while it is handed a single image, so this reads as a failed assertion rather than as missing input. It costs a scenario retry every time it happens, and on a task that reaches its goal in one or two steps it happens on every run.