### PR TITLE
Take the missing frames when assertion history is short

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -811,6 +811,7 @@ public fun AgentConfigBuilder(
                 .map { it.screenshotFilePath }
                 .distinct(),
               historyCount = imageAssertions.historyCount,
+              captureAdditionalScreenshot = imageAssertionInput.captureAdditionalScreenshot,
             ),
             assertions = imageAssertionInput.assertions + imageAssertions
           )
@@ -903,6 +904,73 @@ public interface ArbigentStepInterceptor : ArbigentInterceptor {
 }
 
 
+private fun takeScreenshot(device: ArbigentDevice, id: String) {
+  for (it in 0..2) {
+    try {
+      device.executeActions(
+        actions = listOf(
+          MaestroCommand(
+            takeScreenshotCommand = TakeScreenshotCommand(id)
+          ),
+        ),
+      )
+      break
+    } catch (e: StatusRuntimeException) {
+      arbigentDebugLog("Failed to take screenshot: $e retry:$it")
+      Thread.sleep(1000)
+    }
+  }
+}
+
+private fun convertScreenshot(
+  originalScreenshotFilePath: String,
+  id: String,
+  imageFormat: ImageFormat,
+): String {
+  if (imageFormat == ImageFormat.PNG) {
+    return originalScreenshotFilePath
+  }
+  val convertedScreenshotFilePath =
+    ArbigentFiles.screenshotsDir.absolutePath + File.separator + "$id.webp"
+  val originalFile = File(originalScreenshotFilePath)
+  val originalImage = ImageIO.read(originalFile)
+  ArbigentImageEncoder.saveImage(
+    originalImage,
+    convertedScreenshotFilePath,
+    ImageFormat.WEBP
+  )
+  originalFile.delete()
+  originalImage.flush()
+  return convertedScreenshotFilePath
+}
+
+/**
+ * Takes one more screenshot of the same screen after [ADDITIONAL_SCREENSHOT_WAIT_MILLIS], so an
+ * assertion about what changes between images has a second frame to look at. Returns null when the
+ * screenshot could not be taken; the assertion then runs on what it already has.
+ */
+private fun captureAdditionalScreenshot(
+  device: ArbigentDevice,
+  stepId: String,
+  sequence: Int,
+  imageFormat: ImageFormat,
+): String? {
+  val id = "$stepId-history-$sequence"
+  Thread.sleep(ADDITIONAL_SCREENSHOT_WAIT_MILLIS)
+  takeScreenshot(device, id)
+  val originalScreenshotFilePath =
+    ArbigentFiles.screenshotsDir.absolutePath + File.separator + "$id.png"
+  if (!File(originalScreenshotFilePath).exists()) {
+    arbigentErrorLog("Failed to take an additional screenshot for the image assertion history.")
+    return null
+  }
+  return convertScreenshot(originalScreenshotFilePath, id, imageFormat)
+}
+
+// Long enough that a playing video or an animation has moved on, short enough to add to every
+// assertion that needs it without changing how a run feels.
+private const val ADDITIONAL_SCREENSHOT_WAIT_MILLIS = 1000L
+
 /**
  * Screenshots handed to an image assertion: the one being judged, followed by up to
  * [historyCount] - 1 earlier ones, newest first.
@@ -916,8 +984,18 @@ internal fun assertionScreenshotFilePaths(
   currentScreenshotFilePath: String,
   previousScreenshotFilePaths: List<String>,
   historyCount: Int,
-): List<String> = listOf(currentScreenshotFilePath) +
-  previousScreenshotFilePaths.take((historyCount - 1).coerceAtLeast(0))
+  captureAdditionalScreenshot: (() -> String?)? = null,
+): List<String> {
+  val paths = (listOf(currentScreenshotFilePath) +
+    previousScreenshotFilePaths.take((historyCount - 1).coerceAtLeast(0))).toMutableList()
+  // The first steps of a task have no earlier screenshot to offer. Rather than judging an
+  // assertion on fewer images than it asked for, which reads as the assertion failing, take the
+  // missing frames now.
+  while (paths.size < historyCount && captureAdditionalScreenshot != null) {
+    paths += captureAdditionalScreenshot() ?: break
+  }
+  return paths
+}
 
 public fun defaultAgentActionTypesForVisualMode(): List<AgentActionType> {
   return listOf(
@@ -1184,23 +1262,7 @@ private suspend fun step(
 
   val stepId = contextHolder.generateStepId()
   val elements = device.elements()
-  for (it in 0..2) {
-    try {
-      device.executeActions(
-        actions = listOf(
-          MaestroCommand(
-            takeScreenshotCommand = TakeScreenshotCommand(
-              stepId
-            )
-          ),
-        ),
-      )
-      break
-    } catch (e: StatusRuntimeException) {
-      arbigentDebugLog("Failed to take screenshot: $e retry:$it")
-      Thread.sleep(1000)
-    }
-  }
+  takeScreenshot(device, stepId)
   val uiTreeStrings = device.viewTreeString()
   val uiTreeHash = uiTreeStrings.optimizedTreeString.hashCode().toString().replace("-", "")
   val contextHash = contextHolder.context(aiOptions).hashCode().toString().replace("-", "")
@@ -1221,22 +1283,7 @@ private suspend fun step(
     return StepResult.Failed
   }
   val imageFormat = stepInput.aiOptions?.imageFormat ?: ImageFormat.PNG
-  val screenshotFilePath = if (imageFormat == ImageFormat.PNG) {
-    originalScreenshotFilePath
-  } else {
-    val convertedScreenshotFilePath =
-      ArbigentFiles.screenshotsDir.absolutePath + File.separator + "$stepId.webp"
-    val originalFile = File(originalScreenshotFilePath)
-    val originalImage = ImageIO.read(originalFile)
-    ArbigentImageEncoder.saveImage(
-      originalImage,
-      convertedScreenshotFilePath,
-      ImageFormat.WEBP
-    )
-    originalFile.delete()
-    originalImage.flush()
-    convertedScreenshotFilePath
-  }
+  val screenshotFilePath = convertScreenshot(originalScreenshotFilePath, stepId, imageFormat)
   val requestUuid = java.util.UUID.randomUUID().toString()
   val decisionJsonlFilePath = ArbigentFiles.jsonlsDir.absolutePath + File.separator + "$requestUuid.jsonl"
   val lastStepOrNull = contextHolder.steps().lastOrNull()
@@ -1327,6 +1374,11 @@ private suspend fun step(
         ai = ai,
         arbigentContextHolder = contextHolder,
         screenshotFilePaths = listOf(screenshotFilePath),
+        captureAdditionalScreenshot = object : () -> String? {
+          private var sequence = 0
+          override fun invoke(): String? =
+            captureAdditionalScreenshot(device, stepId, ++sequence, imageFormat)
+        },
         // Added by interceptors
         assertions = ArbigentImageAssertions()
       )

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -972,8 +972,9 @@ private fun captureAdditionalScreenshot(
 private const val ADDITIONAL_SCREENSHOT_WAIT_MILLIS = 1000L
 
 /**
- * Screenshots handed to an image assertion: the one being judged, followed by up to
- * [historyCount] - 1 earlier ones, newest first.
+ * Screenshots handed to an image assertion, newest first: the one being judged, followed by up to
+ * [historyCount] - 1 earlier ones. When there are not that many, frames taken now fill the gap and
+ * lead the list, since they are newer than the one being judged.
  *
  * An assertion runs before its own step is recorded, so [previousScreenshotFilePaths] already
  * starts at the immediately preceding screenshot. Skipping that first entry both delayed a
@@ -991,10 +992,14 @@ internal fun assertionScreenshotFilePaths(
   // The first steps of a task have no earlier screenshot to offer. Rather than judging an
   // assertion on fewer images than it asked for, which reads as the assertion failing, take the
   // missing frames now.
-  while (paths.size < historyCount && captureAdditionalScreenshot != null) {
-    paths += captureAdditionalScreenshot() ?: break
+  val additionalPaths = mutableListOf<String>()
+  while (paths.size + additionalPaths.size < historyCount && captureAdditionalScreenshot != null) {
+    additionalPaths += captureAdditionalScreenshot() ?: break
   }
-  return paths
+  // Nothing labels these images for the model: their order is the only thing that says which one
+  // is the newest. A frame taken now is newer than the one being judged, so it goes in front of
+  // it, keeping the whole list newest first however it was filled.
+  return additionalPaths.reversed() + paths
 }
 
 public fun defaultAgentActionTypesForVisualMode(): List<AgentActionType> {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAi.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAi.kt
@@ -54,6 +54,16 @@ public interface ArbigentAi {
     val arbigentContextHolder: ArbigentContextHolder,
     val screenshotFilePaths: List<String>,
     val assertions: ArbigentImageAssertions,
+    /**
+     * Takes one more screenshot of the screen being judged, after a short wait, and returns its
+     * path. Null when the caller cannot take one.
+     *
+     * An assertion that asks what changed between images has nothing to answer with when the step
+     * history is too short to fill [ArbigentImageAssertions.historyCount] — the first steps of a
+     * task have no earlier screenshot at all. Judging it on fewer images than it asked for reads
+     * as a failed assertion rather than as missing input, so the frames are captured now instead.
+     */
+    val captureAdditionalScreenshot: (() -> String?)? = null,
   )
   public data class ImageAssertionOutput(
     val results: List<ImageAssertionResult>

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/AssertionScreenshotHistoryTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/AssertionScreenshotHistoryTest.kt
@@ -41,6 +41,54 @@ class AssertionScreenshotHistoryTest {
   }
 
   @Test
+  fun `a step with no history to offer takes the missing frames now`() {
+    val captured = mutableListOf<String>()
+    assertEquals(
+      listOf("s1", "extra1", "extra2"),
+      assertionScreenshotFilePaths(
+        currentScreenshotFilePath = "s1",
+        previousScreenshotFilePaths = emptyList(),
+        historyCount = 3,
+        captureAdditionalScreenshot = {
+          "extra${captured.size + 1}".also { captured += it }
+        },
+      ),
+    )
+    assertEquals(2, captured.size)
+  }
+
+  @Test
+  fun `a history that is already full takes no extra screenshot`() {
+    var captureCount = 0
+    assertEquals(
+      listOf("s3", "s2"),
+      assertionScreenshotFilePaths(
+        currentScreenshotFilePath = "s3",
+        previousScreenshotFilePaths = listOf("s2", "s1"),
+        historyCount = 2,
+        captureAdditionalScreenshot = {
+          captureCount++
+          "extra"
+        },
+      ),
+    )
+    assertEquals(0, captureCount)
+  }
+
+  @Test
+  fun `a screenshot that could not be taken leaves the assertion with what it has`() {
+    assertEquals(
+      listOf("s1"),
+      assertionScreenshotFilePaths(
+        currentScreenshotFilePath = "s1",
+        previousScreenshotFilePaths = emptyList(),
+        historyCount = 2,
+        captureAdditionalScreenshot = { null },
+      ),
+    )
+  }
+
+  @Test
   fun `a history count of one asks about the current screenshot alone`() {
     assertEquals(
       listOf("s3"),

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/AssertionScreenshotHistoryTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/AssertionScreenshotHistoryTest.kt
@@ -44,7 +44,7 @@ class AssertionScreenshotHistoryTest {
   fun `a step with no history to offer takes the missing frames now`() {
     val captured = mutableListOf<String>()
     assertEquals(
-      listOf("s1", "extra1", "extra2"),
+      listOf("extra2", "extra1", "s1"),
       assertionScreenshotFilePaths(
         currentScreenshotFilePath = "s1",
         previousScreenshotFilePaths = emptyList(),
@@ -55,6 +55,23 @@ class AssertionScreenshotHistoryTest {
       ),
     )
     assertEquals(2, captured.size)
+  }
+
+  /**
+   * Nothing tells the model which image is which, so a list that runs newest to oldest in one case
+   * and jumps around in another makes an assertion about what changed answerable only by luck.
+   */
+  @Test
+  fun `a frame taken to fill a partly filled history still leads the list`() {
+    assertEquals(
+      listOf("extra1", "s2", "s1"),
+      assertionScreenshotFilePaths(
+        currentScreenshotFilePath = "s2",
+        previousScreenshotFilePaths = listOf("s1"),
+        historyCount = 3,
+        captureAdditionalScreenshot = { "extra1" },
+      ),
+    )
   }
 
   @Test


### PR DESCRIPTION
Stacked on #421.

# What

When a task cannot supply `imageAssertionHistoryCount` screenshots from its step history, the missing frames are now captured on the spot: one screenshot per missing slot, each after a one second wait.

`step()` provides the capture as `ImageAssertionInput.captureAdditionalScreenshot`, so the interceptor decides how many frames are missing while the agent keeps deciding how a screenshot is taken and encoded. Nothing is captured when the history is already full or `imageAssertionHistoryCount` is 1, which is the default and the common path.

# Why

An assertion phrased as "the images differ" is unanswerable when it is handed a single image, and the AI reports that as the assertion failing rather than as missing input. The first steps of a task have no earlier screenshot at all, so a task that reaches its goal immediately fails such an assertion on every run — it costs a scenario retry each time, and under `replayWithFallback` it discards the whole replayed run.

Judging an assertion on fewer images than it asked for is not a safe degradation, so the frames are taken rather than silently skipped.