### PR TITLE
Add Anthropic prompt cache breakpoint and record cache usage

### DIFF
--- a/arbigent-ai-anthropic/src/main/java/io/github/takahirom/arbigent/AnthropicAi.kt
+++ b/arbigent-ai-anthropic/src/main/java/io/github/takahirom/arbigent/AnthropicAi.kt
@@ -332,7 +332,7 @@ public class AnthropicAi @OptIn(ArbigentInternalApi::class) constructor(
     prompt: ArbigentPrompt,
     formFactor: ArbigentScenarioDeviceFormFactor,
   ): List<AnthropicContent> {
-    return when (formFactor) {
+    val contents = when (formFactor) {
       ArbigentScenarioDeviceFormFactor.Tv -> prompt.systemPromptsForTv
       else -> prompt.systemPrompts
     }.map {
@@ -340,6 +340,17 @@ public class AnthropicAi @OptIn(ArbigentInternalApi::class) constructor(
     } + prompt.additionalSystemPrompts.map {
       AnthropicContent(type = "text", text = it)
     }
+    return contents.withCacheBreakpointOnLastBlock()
+  }
+
+  /**
+   * Anthropic caches nothing unless a block carries `cache_control`. The prefix is hashed in the
+   * order tools, system, messages, so a breakpoint on the last system block covers the tool
+   * definitions too. System and tools are the same for every step of a scenario.
+   */
+  private fun List<AnthropicContent>.withCacheBreakpointOnLastBlock(): List<AnthropicContent> {
+    if (isEmpty()) return this
+    return dropLast(1) + last().copy(cacheControl = AnthropicCacheControl.Ephemeral)
   }
 
   internal fun decisionToolChoice(aiOptions: ArbigentAiOptions?): AnthropicToolChoice {
@@ -425,7 +436,9 @@ public class AnthropicAi @OptIn(ArbigentInternalApi::class) constructor(
     val elements = decisionInput.elements
     val agentActionList = decisionInput.agentActionTypes
     arbigentInfoLog {
-      "AI usage: ${response.usage}"
+      val usage = response.usage
+      "AI usage: $usage (prompt cache: read ${usage?.cacheReadInputTokens ?: 0}, " +
+        "written ${usage?.cacheCreationInputTokens ?: 0}, uncached ${usage?.inputTokens ?: 0})"
     }
 
     return try {

--- a/arbigent-ai-anthropic/src/main/java/io/github/takahirom/arbigent/AnthropicApiEntities.kt
+++ b/arbigent-ai-anthropic/src/main/java/io/github/takahirom/arbigent/AnthropicApiEntities.kt
@@ -44,7 +44,18 @@ public data class AnthropicContent(
   val name: String? = null,
   val input: JsonObject? = null,
   @SerialName("tool_use_id") val toolUseId: String? = null,
+  /** Prompt cache breakpoint. Anthropic caches only the prefix up to a block that has one. */
+  @SerialName("cache_control") val cacheControl: AnthropicCacheControl? = null,
 )
+
+@Serializable
+public data class AnthropicCacheControl(
+  val type: String,
+) {
+  public companion object {
+    public val Ephemeral: AnthropicCacheControl = AnthropicCacheControl(type = "ephemeral")
+  }
+}
 
 @Serializable
 public data class AnthropicImageSource(
@@ -93,10 +104,16 @@ public data class AnthropicMessagesResponse(
   val usage: AnthropicUsage? = null
 )
 
+/**
+ * Anthropic counts cache reads and writes separately from [inputTokens], which holds only the
+ * uncached part, unlike OpenAI where the cached count is a subset of the prompt tokens.
+ */
 @Serializable
 public data class AnthropicUsage(
   @SerialName("input_tokens") val inputTokens: Int? = null,
-  @SerialName("output_tokens") val outputTokens: Int? = null
+  @SerialName("output_tokens") val outputTokens: Int? = null,
+  @SerialName("cache_creation_input_tokens") val cacheCreationInputTokens: Int? = null,
+  @SerialName("cache_read_input_tokens") val cacheReadInputTokens: Int? = null,
 )
 
 @Serializable

--- a/arbigent-ai-anthropic/src/test/java/AnthropicRequestConversionTest.kt
+++ b/arbigent-ai-anthropic/src/test/java/AnthropicRequestConversionTest.kt
@@ -1,6 +1,7 @@
 import io.github.takahirom.arbigent.AgentActionType
 import io.github.takahirom.arbigent.AnthropicAi
 import io.github.takahirom.arbigent.AnthropicAiRateLimitExceededException
+import io.github.takahirom.arbigent.AnthropicCacheControl
 import io.github.takahirom.arbigent.AnthropicContent
 import io.github.takahirom.arbigent.AnthropicErrorResponse
 import io.github.takahirom.arbigent.AnthropicImageSource
@@ -336,6 +337,62 @@ class AnthropicRequestConversionTest {
     )
 
     assertEquals("image/webp", message.content[0].source?.mediaType)
+  }
+
+  // --- Prompt caching ---
+
+  @Test
+  fun `buildUserMessage does not put cache_control on user content`() {
+    // The user turn changes every step (screenshot, UI tree, previous steps), so a breakpoint there
+    // would be written each step and never read back. The only breakpoint is on the system prompt.
+    val message = anthropicAi.buildUserMessage(imageBase64 = "aW1n", mimeType = "image/png", promptText = "goal")
+
+    assertTrue(message.content.all { it.cacheControl == null })
+  }
+
+  @Test
+  fun `buildSystemContents marks only the last block as a cache breakpoint`() {
+    val prompt = ArbigentPrompt(additionalSystemPrompts = listOf("Extra instruction"))
+
+    val system = anthropicAi.buildSystemContents(prompt, ArbigentScenarioDeviceFormFactor.Mobile)
+
+    assertTrue(system.size >= 2)
+    assertEquals(AnthropicCacheControl.Ephemeral, system.last().cacheControl)
+    assertTrue(system.dropLast(1).all { it.cacheControl == null })
+  }
+
+  @Test
+  fun `cache_control is serialized as an ephemeral object and omitted when absent`() {
+    val request = AnthropicMessagesRequest(
+      model = "claude-sonnet-4-5",
+      maxTokens = 1024,
+      system = anthropicAi.buildSystemContents(ArbigentPrompt(), ArbigentScenarioDeviceFormFactor.Mobile),
+      messages = listOf(AnthropicMessage(role = "user", content = listOf(AnthropicContent(type = "text", text = "hi")))),
+    )
+
+    val body = anthropicAi.buildRequestBody(request, null).jsonObject
+
+    val systemBlocks = body["system"]!!.jsonArray
+    assertEquals(
+      "ephemeral",
+      systemBlocks.last().jsonObject["cache_control"]!!.jsonObject["type"]!!.jsonPrimitive.content
+    )
+    val userBlock = body["messages"]!!.jsonArray.first().jsonObject["content"]!!.jsonArray.first().jsonObject
+    assertFalse(userBlock.containsKey("cache_control"))
+  }
+
+  @Test
+  fun `response usage keeps the cache read and write counts`() {
+    val json = Json { ignoreUnknownKeys = true }
+
+    val response = json.decodeFromString<AnthropicMessagesResponse>(
+      """{"type":"message","content":[],"usage":{"input_tokens":10,"output_tokens":3,
+         "cache_read_input_tokens":1500,"cache_creation_input_tokens":0}}"""
+    )
+
+    assertEquals(10, response.usage?.inputTokens)
+    assertEquals(1500, response.usage?.cacheReadInputTokens)
+    assertEquals(0, response.usage?.cacheCreationInputTokens)
   }
 
   // --- Tool schema conversion ---

--- a/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/ApiEntities.kt
+++ b/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/ApiEntities.kt
@@ -94,7 +94,15 @@ public data class ImageUrl(
 public data class Usage(
   @SerialName("completion_tokens") val completionTokens: Int? = null,
   @SerialName("prompt_tokens") val promptTokens: Int? = null,
-  @SerialName("total_tokens") val totalTokens: Int? = null
+  @SerialName("total_tokens") val totalTokens: Int? = null,
+  /** Prefix cache details. Absent from providers that do not report caching. */
+  @SerialName("prompt_tokens_details") val promptTokensDetails: PromptTokensDetails? = null,
+)
+
+@Serializable
+public data class PromptTokensDetails(
+  /** Part of `prompt_tokens` served from the prefix cache. */
+  @SerialName("cached_tokens") val cachedTokens: Int? = null,
 )
 
 @Serializable

--- a/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
+++ b/arbigent-ai-openai/src/main/java/io/github/takahirom/arbigent/OpenAIAi.kt
@@ -382,7 +382,8 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
     val elements = decisionInput.elements
     val agentActionList = decisionInput.agentActionTypes
     arbigentInfoLog {
-      "AI usage: ${chatCompletionResponse.usage}"
+      val usage = chatCompletionResponse.usage
+      "AI usage: $usage (prompt cache: ${usage?.promptTokensDetails?.cachedTokens ?: 0}/${usage?.promptTokens ?: 0} cached)"
     }
 
     return try {
@@ -815,7 +816,9 @@ public class OpenAIAi @OptIn(ArbigentInternalApi::class) constructor(
         Usage(
           completionTokens = it["output_tokens"]?.jsonPrimitive?.intOrNull,
           promptTokens = it["input_tokens"]?.jsonPrimitive?.intOrNull,
-          totalTokens = it["total_tokens"]?.jsonPrimitive?.intOrNull
+          totalTokens = it["total_tokens"]?.jsonPrimitive?.intOrNull,
+          promptTokensDetails = it["input_tokens_details"]?.jsonObject?.get("cached_tokens")?.jsonPrimitive?.intOrNull
+            ?.let { cached -> PromptTokensDetails(cachedTokens = cached) },
         )
       }
     )

--- a/arbigent-ai-openai/src/test/java/BuildRequestBodyTest.kt
+++ b/arbigent-ai-openai/src/test/java/BuildRequestBodyTest.kt
@@ -3,9 +3,11 @@ import io.github.takahirom.arbigent.ArbigentAiOptions
 import io.github.takahirom.arbigent.ChatCompletionRequest
 import io.github.takahirom.arbigent.ChatCompletionResponse
 import io.github.takahirom.arbigent.ChatMessage
+import io.github.takahirom.arbigent.PromptTokensDetails
 import io.github.takahirom.arbigent.FunctionDefinition
 import io.github.takahirom.arbigent.OpenAIAi
 import io.github.takahirom.arbigent.ToolDefinition
+import io.github.takahirom.arbigent.Usage
 import kotlinx.serialization.json.*
 import org.junit.Assert.*
 import org.junit.Test
@@ -437,5 +439,38 @@ class BuildRequestBodyTest {
       "tools should be JsonNull or absent when null",
       tools == null || tools == JsonNull
     )
+  }
+
+  // --- Prompt caching ---
+
+  @Test
+  fun `chat completions usage keeps cached_tokens`() {
+    val json = Json { ignoreUnknownKeys = true }
+
+    val usage = json.decodeFromString<Usage>(
+      """{"prompt_tokens":5000,"completion_tokens":20,"total_tokens":5020,
+         "prompt_tokens_details":{"cached_tokens":1449,"audio_tokens":0}}"""
+    )
+
+    assertEquals(5000, usage.promptTokens)
+    assertEquals(PromptTokensDetails(cachedTokens = 1449), usage.promptTokensDetails)
+  }
+
+  @Test
+  fun `normalizeResponsesApiResponse maps cached tokens from input_tokens_details`() {
+    val responseBody = """
+      {
+        "id": "resp_1", "created_at": 1, "model": "gpt-5.6",
+        "output": [ { "type": "message", "role": "assistant", "content": [ { "type": "output_text", "text": "hi" } ] } ],
+        "usage": { "input_tokens": 3000, "output_tokens": 10, "total_tokens": 3010,
+                   "input_tokens_details": { "cached_tokens": 2048 } }
+      }
+    """.trimIndent()
+
+    val normalized = openAiAi.normalizeResponsesApiResponse(responseBody, "gpt-5.6")
+    val response = Json { ignoreUnknownKeys = true }.decodeFromString<ChatCompletionResponse>(normalized)
+
+    assertEquals(3000, response.usage?.promptTokens)
+    assertEquals(2048, response.usage?.promptTokensDetails?.cachedTokens)
   }
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ApiUsageRecorder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ApiUsageRecorder.kt
@@ -42,6 +42,12 @@ public class ApiUsageRecord(
    * because reporting those here would mean something different.
    */
   @SerialName("cached_input_tokens") public val cachedInputTokens: Int? = null,
+  /**
+   * Anthropic style cache counts. These are billed separately from [inputTokens], which then
+   * holds only the uncached part, so they are kept apart from [cachedInputTokens].
+   */
+  @SerialName("cache_read_input_tokens") public val cacheReadInputTokens: Int? = null,
+  @SerialName("cache_creation_input_tokens") public val cacheCreationInputTokens: Int? = null,
   @SerialName("output_tokens") public val outputTokens: Int? = null,
   @SerialName("total_tokens") public val totalTokens: Int? = null,
 )
@@ -78,6 +84,8 @@ public fun parseApiUsageRecord(requestUuid: String?, responseBody: String): ApiU
     model = runCatching { root["model"]?.jsonPrimitive?.contentOrNull }.getOrNull(),
     inputTokens = int("prompt_tokens") ?: int("input_tokens"),
     cachedInputTokens = cachedInt(),
+    cacheReadInputTokens = int("cache_read_input_tokens"),
+    cacheCreationInputTokens = int("cache_creation_input_tokens"),
     outputTokens = int("completion_tokens") ?: int("output_tokens"),
     totalTokens = int("total_tokens"),
     // A usage object with no field this code knows about carries no number worth recording, and a

--- a/arbigent-core/src/test/java/ApiUsageRecorderTest.kt
+++ b/arbigent-core/src/test/java/ApiUsageRecorderTest.kt
@@ -78,8 +78,8 @@ class ApiUsageRecorderTest {
   @Test
   fun parsesAnthropicUsage() {
     // Anthropic reports input_tokens / output_tokens like the Responses API, but has no nested
-    // details object. Its cache counters are not a subset of input_tokens, so they are left out
-    // rather than reported as cached_input_tokens, which would mean something else.
+    // details object. Its cache counters are not a subset of input_tokens, so they go to their own
+    // fields rather than to cached_input_tokens, which would mean something else.
     val record = parseApiUsageRecord(
       requestUuid = null,
       responseBody = """
@@ -89,7 +89,8 @@ class ApiUsageRecorderTest {
           "usage": {
             "input_tokens": 700,
             "output_tokens": 25,
-            "cache_read_input_tokens": 400
+            "cache_read_input_tokens": 400,
+            "cache_creation_input_tokens": 120
           }
         }
       """.trimIndent()
@@ -99,6 +100,28 @@ class ApiUsageRecorderTest {
     assertEquals(700, record.inputTokens)
     assertEquals(25, record.outputTokens)
     assertNull(record.cachedInputTokens)
+    assertEquals(400, record.cacheReadInputTokens)
+    assertEquals(120, record.cacheCreationInputTokens)
+  }
+
+  @Test
+  fun leavesAnthropicCacheFieldsNullForOpenAiUsage() {
+    val record = parseApiUsageRecord(
+      requestUuid = null,
+      responseBody = """
+        {
+          "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 5,
+            "prompt_tokens_details": { "cached_tokens": 64 }
+          }
+        }
+      """.trimIndent()
+    )
+    requireNotNull(record)
+    assertEquals(64, record.cachedInputTokens)
+    assertNull(record.cacheReadInputTokens)
+    assertNull(record.cacheCreationInputTokens)
   }
 
   @Test


### PR DESCRIPTION
## Summary

- **Anthropic**: put `cache_control: {type: ephemeral}` on the last system block. Anthropic caches nothing without an explicit breakpoint; since the prefix is hashed as tools → system → messages, one breakpoint on the last system block covers the tool definitions too. System and tools are identical for every step of a scenario, so every call after the first reads them from cache.
- **Usage recording**: parse and record prompt-cache counts. OpenAI `prompt_tokens_details.cached_tokens` (Chat Completions) / `input_tokens_details.cached_tokens` (Responses API, normalized to the same field), and Anthropic `cache_read_input_tokens` / `cache_creation_input_tokens`. They show up in the `AI usage:` log line and in `usages/*.json`.

No change to prompt content or ordering.

## Measured (claude-sonnet-4.6 via OpenRouter `/api/v1/messages`, 5 decision calls)

| call | cache read | cache write | uncached input |
|---|---|---|---|
| 1 | 0 | 3522 | 2464 |
| 2–5 | 3522 | 0 | 2180–4420 |

Roughly 44–62% of input tokens per call are cache reads from the second step on. Before this change every call had read 0 / write 0.

The image assertion call does not carry the breakpoint yet (read 0 / write 0); that is a possible follow-up.

## Not included

Reordering the user message so fixed text precedes the screenshot was also tried, as an OpenAI prefix-cache optimization. On OpenAI via OpenRouter the cached prefix stopped at system + tools regardless of how much stable text was placed before the image, so that change was dropped.

## Test plan

- [x] `:arbigent-core:test`, `:arbigent-ai-openai:test`, `:arbigent-ai-anthropic:test` green
- [x] `:arbigent-ui:compileTestKotlin`, `:arbigent-cli:compileKotlin`
- [x] Live run against OpenRouter's Anthropic endpoint; request body has exactly one `cache_control`, usage numbers above