### PR TITLE
Wait for the recorded target before capturing a replayed step

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
@@ -61,6 +61,11 @@ internal class ArbigentReplayPacingStepInterceptor(
    * "the screen has settled on the recorded target" means without asking the AI. Elapsed time is
    * counted in poll intervals rather than read from the clock, so the loop advances with the
    * suspending [delay] instead of spinning against a clock that the caller may be controlling.
+   *
+   * The deadline is soft by design: it is checked between polls, and a poll is one blocking
+   * [ArbigentDevice.elements] read, so the wait can overrun by at most one hierarchy dump (bounded
+   * by the device's own retry policy). Interrupting a dump midway would leave Maestro's driver in an
+   * undefined state, and a step captured a few seconds late is still a correct step.
    */
   private suspend fun awaitStableTarget(
     replayIndex: Int,
@@ -97,6 +102,11 @@ internal class ArbigentReplayPacingStepInterceptor(
    * A cheap stand-in for the current screen, or null while the target is absent. Built from the
    * same element snapshot the match is looked for in, because the UI tree string is expensive
    * enough that polling it would itself slow replay down.
+   *
+   * It covers what an action resolves against: order, text (which Arbigent already reads from the
+   * descendants), resource id, bounds and visibility. A list in which the same elements are still
+   * sliding into place therefore reads as unsettled, while a repaint that changes nothing an action
+   * could see does not hold the replay up.
    */
   private fun targetSignature(
     device: ArbigentDevice,
@@ -112,7 +122,8 @@ internal class ArbigentReplayPacingStepInterceptor(
     }
     if (identity.findMatch(elements) == null) return null
     return elements.elements.joinToString(separator = "|", prefix = "${elements.elements.size}#") {
-      "${it.rawText}/${it.treeNode.attributes["resource-id"].orEmpty()}"
+      "${it.rawText}/${it.treeNode.attributes["resource-id"].orEmpty()}" +
+        "@${it.x},${it.y},${it.width},${it.height},${it.isVisible}"
     }
   }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
@@ -3,6 +3,7 @@ package io.github.takahirom.arbigent
 import io.github.takahirom.arbigent.result.ArbigentStepSource
 
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import maestro.TreeNode
@@ -19,10 +20,17 @@ internal class ReplayDivergenceException(
 ) : Exception(message)
 
 /**
- * Waits before a replayed step is captured, so the app is as far along as it was when the trace
- * was recorded. This must run before [step] reads the elements and UI tree: replay makes no AI
- * call, so without it the next screen is snapshotted before it has settled and an index-based
- * action resolves against a half-built element list.
+ * Waits before a replayed step is captured, so the screen the step is about to be resolved against
+ * is the screen the recorded action was decided on. This must run before [step] reads the elements
+ * and UI tree: replay makes no AI call, so without it the next screen is snapshotted before it has
+ * settled and an index-based action resolves against a half-built element list.
+ *
+ * The wait is on the recorded target of the step about to be replayed: poll the elements until that
+ * target is present and the element list is unchanged between two polls. The recorded interval
+ * between two trace steps is not a sleep — it includes the AI latency of the recording run, which
+ * replay does not pay — so it is used only to bound the wait, and only as the pace itself for steps
+ * that have no target to wait for (reaching the goal, back, scroll, wait, and text actions recorded
+ * without an identity).
  */
 internal class ArbigentReplayPacingStepInterceptor(
   private val trace: ArbigentReplayTrace,
@@ -38,18 +46,93 @@ internal class ArbigentReplayPacingStepInterceptor(
       .filter { step -> step.agentAction != null }
       .distinctBy { step -> step.stepId }
       .count()
-    waitOutRecordedGap(replayIndex)
+    val identity = trace.steps.getOrNull(replayIndex)?.decisionOutput?.step?.targetElement
+    if (identity != null) {
+      awaitStableTarget(replayIndex, identity, stepInput.device)
+    } else {
+      waitOutRecordedGap(replayIndex)
+    }
     previousStepStartedAtMillis = TimeProvider.get().currentTimeMillis()
     return chain.proceed(stepInput)
   }
 
+  /**
+   * Waits until [identity] is present and the element list around it stops changing, which is what
+   * "the screen has settled on the recorded target" means without asking the AI. Elapsed time is
+   * counted in poll intervals rather than read from the clock, so the loop advances with the
+   * suspending [delay] instead of spinning against a clock that the caller may be controlling.
+   */
+  private suspend fun awaitStableTarget(
+    replayIndex: Int,
+    identity: ArbigentElementIdentity,
+    device: ArbigentDevice,
+  ) {
+    val deadline = waitDeadlineMillis(replayIndex)
+    val waitedMillis = withTimeoutOrNull(deadline) {
+      var previousSignature: String? = null
+      var waited = 0L
+      while (true) {
+        val signature = targetSignature(device, identity)
+        if (signature != null && signature == previousSignature) break
+        previousSignature = signature
+        delay(POLL_INTERVAL_MILLIS)
+        waited += POLL_INTERVAL_MILLIS
+      }
+      waited
+    }
+    if (waitedMillis != null) {
+      arbigentInfoLog(
+        "Replay wait: target ${identity.description()} found and stable after ${waitedMillis}ms " +
+          "before capturing step ${replayIndex + 1}",
+      )
+    } else {
+      arbigentInfoLog(
+        "Replay wait: deadline ${deadline}ms reached while waiting for target " +
+          "${identity.description()} before capturing step ${replayIndex + 1}; capturing anyway",
+      )
+    }
+  }
+
+  /**
+   * A cheap stand-in for the current screen, or null while the target is absent. Built from the
+   * same element snapshot the match is looked for in, because the UI tree string is expensive
+   * enough that polling it would itself slow replay down.
+   */
+  private fun targetSignature(
+    device: ArbigentDevice,
+    identity: ArbigentElementIdentity,
+  ): String? {
+    val elements = try {
+      device.elements()
+    } catch (exception: Exception) {
+      // Reading the hierarchy can fail while the screen is mid-transition, which is exactly the
+      // state this waits out. Treat it as "not there yet".
+      arbigentDebugLog("Replay wait: could not read elements: $exception")
+      return null
+    }
+    if (identity.findMatch(elements) == null) return null
+    return elements.elements.joinToString(separator = "|", prefix = "${elements.elements.size}#") {
+      "${it.rawText}/${it.treeNode.attributes["resource-id"].orEmpty()}"
+    }
+  }
+
+  /** How long the wait may take: the recorded gap, never below 10 seconds nor above a minute. */
+  private fun waitDeadlineMillis(replayIndex: Int): Long {
+    val recordedGap = recordedGapMillis(replayIndex) ?: return MIN_TARGET_WAIT_MILLIS
+    return recordedGap.coerceAtMost(MAX_PACING_WAIT_MILLIS).coerceAtLeast(MIN_TARGET_WAIT_MILLIS)
+  }
+
+  private fun recordedGapMillis(replayIndex: Int): Long? {
+    val previousRecordedAt = trace.steps.getOrNull(replayIndex - 1)
+      ?.decisionOutput?.step?.timestamp ?: return null
+    val recordedAt = trace.steps.getOrNull(replayIndex)?.decisionOutput?.step?.timestamp
+      ?: return null
+    return (recordedAt - previousRecordedAt).takeIf { it > 0 }
+  }
+
   private suspend fun waitOutRecordedGap(replayIndex: Int) {
     val previousStartedAt = previousStepStartedAtMillis ?: return
-    val previousRecordedAt = trace.steps.getOrNull(replayIndex - 1)
-      ?.decisionOutput?.step?.timestamp ?: return
-    val recordedAt = trace.steps.getOrNull(replayIndex)?.decisionOutput?.step?.timestamp ?: return
-    val recordedGap = recordedAt - previousRecordedAt
-    if (recordedGap <= 0) return
+    val recordedGap = recordedGapMillis(replayIndex) ?: return
     val alreadySpent = TimeProvider.get().currentTimeMillis() - previousStartedAt
     val remaining = (recordedGap - alreadySpent).coerceAtMost(MAX_PACING_WAIT_MILLIS)
     if (remaining <= 0) return
@@ -62,6 +145,10 @@ internal class ArbigentReplayPacingStepInterceptor(
   private companion object {
     // A recorded gap can be pathological (a hiccup while recording); do not inherit it unbounded.
     const val MAX_PACING_WAIT_MILLIS = 60_000L
+
+    // A short recorded gap says the recording run was fast, not that the replayed screen will be.
+    const val MIN_TARGET_WAIT_MILLIS = 10_000L
+    const val POLL_INTERVAL_MILLIS = 500L
   }
 }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
@@ -3,7 +3,6 @@ package io.github.takahirom.arbigent
 import io.github.takahirom.arbigent.result.ArbigentStepSource
 
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import maestro.TreeNode
@@ -25,12 +24,21 @@ internal class ReplayDivergenceException(
  * and UI tree: replay makes no AI call, so without it the next screen is snapshotted before it has
  * settled and an index-based action resolves against a half-built element list.
  *
- * The wait is on the recorded target of the step about to be replayed: poll the elements until that
- * target is present and the element list is unchanged between two polls. The recorded interval
- * between two trace steps is not a sleep — it includes the AI latency of the recording run, which
- * replay does not pay — so it is used only to bound the wait, and only as the pace itself for steps
- * that have no target to wait for (reaching the goal, back, scroll, wait, and text actions recorded
- * without an identity).
+ * How long a step may wait is the interval recorded between it and the step before it, minus what
+ * replay has already spent executing the previous action. That interval is the recording run's own
+ * time from one capture to the next, so it already contains everything the app was given then,
+ * including the AI latency the recording paid and any `Wait` the AI itself decided on; replay is
+ * therefore never slower than the recording, and never faster than the app needs. A step with no
+ * recorded interval — the first step of a task, which has no predecessor in the trace — gets
+ * [MIN_WAIT_MILLIS] instead, because there is nothing to derive a budget from and a task that
+ * starts by launching an app must not be stepped on at once.
+ *
+ * Within that budget a step with a recorded target polls the elements until the target is present,
+ * and proceeds the moment it is. Waiting further for the element list to stop changing was tried
+ * and dropped: a screen with anything animating or ticking never stops changing, so the wait ran to
+ * the budget every time and a screen that was in fact ready was reported as one the target never
+ * reached. A step with no target to wait for (reaching the goal, back, scroll, wait, and text
+ * actions recorded without an identity) waits its budget out.
  */
 internal class ArbigentReplayPacingStepInterceptor(
   private val trace: ArbigentReplayTrace,
@@ -46,91 +54,30 @@ internal class ArbigentReplayPacingStepInterceptor(
       .filter { step -> step.agentAction != null }
       .distinctBy { step -> step.stepId }
       .count()
+    val budgetMillis = remainingBudgetMillis(replayIndex)
     val identity = trace.steps.getOrNull(replayIndex)?.decisionOutput?.step?.targetElement
     if (identity != null) {
-      awaitStableTarget(replayIndex, identity, stepInput.device)
+      awaitTarget(replayIndex, identity, stepInput.device, budgetMillis)
     } else {
-      waitOutRecordedGap(replayIndex)
+      waitOutBudget(replayIndex, budgetMillis)
     }
     previousStepStartedAtMillis = TimeProvider.get().currentTimeMillis()
     return chain.proceed(stepInput)
   }
 
   /**
-   * Waits until [identity] is present and the element list around it stops changing, which is what
-   * "the screen has settled on the recorded target" means without asking the AI. Elapsed time is
-   * counted in poll intervals rather than read from the clock, so the loop advances with the
-   * suspending [delay] instead of spinning against a clock that the caller may be controlling.
-   *
-   * The deadline is soft by design: it is checked between polls, and a poll is one blocking
-   * [ArbigentDevice.elements] read, so the wait can overrun by at most one hierarchy dump (bounded
-   * by the device's own retry policy). Interrupting a dump midway would leave Maestro's driver in an
-   * undefined state, and a step captured a few seconds late is still a correct step.
+   * How long this step may still wait: what is left of the recorded interval after the time replay
+   * has already spent since the previous step began. The cap is applied to the recorded interval
+   * itself, so a pathological recording does not become a minute of waiting plus whatever the
+   * previous action took.
    */
-  private suspend fun awaitStableTarget(
-    replayIndex: Int,
-    identity: ArbigentElementIdentity,
-    device: ArbigentDevice,
-  ) {
-    val deadline = waitDeadlineMillis(replayIndex)
-    val waitedMillis = withTimeoutOrNull(deadline) {
-      var previousSignature: String? = null
-      var waited = 0L
-      while (true) {
-        val signature = targetSignature(device, identity)
-        if (signature != null && signature == previousSignature) break
-        previousSignature = signature
-        delay(POLL_INTERVAL_MILLIS)
-        waited += POLL_INTERVAL_MILLIS
-      }
-      waited
-    }
-    if (waitedMillis != null) {
-      arbigentInfoLog(
-        "Replay wait: target ${identity.description()} found and stable after ${waitedMillis}ms " +
-          "before capturing step ${replayIndex + 1}",
-      )
-    } else {
-      arbigentInfoLog(
-        "Replay wait: deadline ${deadline}ms reached while waiting for target " +
-          "${identity.description()} before capturing step ${replayIndex + 1}; capturing anyway",
-      )
-    }
-  }
-
-  /**
-   * A cheap stand-in for the current screen, or null while the target is absent. Built from the
-   * same element snapshot the match is looked for in, because the UI tree string is expensive
-   * enough that polling it would itself slow replay down.
-   *
-   * It covers what an action resolves against: order, text (which Arbigent already reads from the
-   * descendants), resource id, bounds and visibility. A list in which the same elements are still
-   * sliding into place therefore reads as unsettled, while a repaint that changes nothing an action
-   * could see does not hold the replay up.
-   */
-  private fun targetSignature(
-    device: ArbigentDevice,
-    identity: ArbigentElementIdentity,
-  ): String? {
-    val elements = try {
-      device.elements()
-    } catch (exception: Exception) {
-      // Reading the hierarchy can fail while the screen is mid-transition, which is exactly the
-      // state this waits out. Treat it as "not there yet".
-      arbigentDebugLog("Replay wait: could not read elements: $exception")
-      return null
-    }
-    if (identity.findMatch(elements) == null) return null
-    return elements.elements.joinToString(separator = "|", prefix = "${elements.elements.size}#") {
-      "${it.rawText}/${it.treeNode.attributes["resource-id"].orEmpty()}" +
-        "@${it.x},${it.y},${it.width},${it.height},${it.isVisible}"
-    }
-  }
-
-  /** How long the wait may take: the recorded gap, never below 10 seconds nor above a minute. */
-  private fun waitDeadlineMillis(replayIndex: Int): Long {
-    val recordedGap = recordedGapMillis(replayIndex) ?: return MIN_TARGET_WAIT_MILLIS
-    return recordedGap.coerceAtMost(MAX_PACING_WAIT_MILLIS).coerceAtLeast(MIN_TARGET_WAIT_MILLIS)
+  private fun remainingBudgetMillis(replayIndex: Int): Long {
+    val recordedGap = recordedGapMillis(replayIndex) ?: return MIN_WAIT_MILLIS
+    val budget = recordedGap.coerceAtMost(MAX_WAIT_MILLIS)
+    // Nothing measured to subtract: this is the budget in full rather than a guess at what is left.
+    val previousStartedAt = previousStepStartedAtMillis ?: return budget
+    val alreadySpent = TimeProvider.get().currentTimeMillis() - previousStartedAt
+    return (budget - alreadySpent).coerceAtLeast(0)
   }
 
   private fun recordedGapMillis(replayIndex: Int): Long? {
@@ -141,24 +88,65 @@ internal class ArbigentReplayPacingStepInterceptor(
     return (recordedAt - previousRecordedAt).takeIf { it > 0 }
   }
 
-  private suspend fun waitOutRecordedGap(replayIndex: Int) {
-    val previousStartedAt = previousStepStartedAtMillis ?: return
-    val recordedGap = recordedGapMillis(replayIndex) ?: return
-    val alreadySpent = TimeProvider.get().currentTimeMillis() - previousStartedAt
-    val remaining = (recordedGap - alreadySpent).coerceAtMost(MAX_PACING_WAIT_MILLIS)
-    if (remaining <= 0) return
+  /**
+   * Polls until the recorded target is present, or until [budgetMillis] is spent. The screen is
+   * read once before the budget is consulted, so a step whose budget is already gone still gets the
+   * chance to find its target on a screen that is in fact ready — and a target that never appears
+   * is left for the decision interceptor to report as a divergence, which is what it is.
+   */
+  private suspend fun awaitTarget(
+    replayIndex: Int,
+    identity: ArbigentElementIdentity,
+    device: ArbigentDevice,
+    budgetMillis: Long,
+  ) {
+    var waitedMillis = 0L
+    while (true) {
+      if (isPresent(device, identity)) {
+        arbigentInfoLog(
+          "Replay wait: target ${identity.description()} found after ${waitedMillis}ms " +
+            "before capturing step ${replayIndex + 1}",
+        )
+        return
+      }
+      if (waitedMillis >= budgetMillis) break
+      val pollMillis = POLL_INTERVAL_MILLIS.coerceAtMost(budgetMillis - waitedMillis)
+      delay(pollMillis)
+      waitedMillis += pollMillis
+    }
     arbigentInfoLog(
-      "Replay pacing: waiting ${remaining}ms before capturing step ${replayIndex + 1}",
+      "Replay wait: budget ${budgetMillis}ms spent waiting for target ${identity.description()} " +
+        "before capturing step ${replayIndex + 1}; capturing anyway",
     )
-    delay(remaining)
+  }
+
+  private fun isPresent(device: ArbigentDevice, identity: ArbigentElementIdentity): Boolean {
+    val elements = try {
+      device.elements()
+    } catch (exception: Exception) {
+      // Reading the hierarchy can fail while the screen is mid-transition, which is exactly the
+      // state this waits out. Treat it as "not there yet".
+      arbigentDebugLog("Replay wait: could not read elements: $exception")
+      return false
+    }
+    return identity.findMatch(elements) != null
+  }
+
+  private suspend fun waitOutBudget(replayIndex: Int, budgetMillis: Long) {
+    if (budgetMillis <= 0) return
+    arbigentInfoLog(
+      "Replay pacing: waiting ${budgetMillis}ms before capturing step ${replayIndex + 1}",
+    )
+    delay(budgetMillis)
   }
 
   private companion object {
     // A recorded gap can be pathological (a hiccup while recording); do not inherit it unbounded.
-    const val MAX_PACING_WAIT_MILLIS = 60_000L
+    const val MAX_WAIT_MILLIS = 60_000L
 
-    // A short recorded gap says the recording run was fast, not that the replayed screen will be.
-    const val MIN_TARGET_WAIT_MILLIS = 10_000L
+    // Without a recorded interval there is nothing to derive a budget from, and the step this
+    // happens on is the one that starts a task — the launch replay must not step on.
+    const val MIN_WAIT_MILLIS = 10_000L
     const val POLL_INTERVAL_MILLIS = 500L
   }
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
@@ -102,7 +102,14 @@ internal class ArbigentReplayPacingStepInterceptor(
   ) {
     var waitedMillis = 0L
     while (true) {
-      if (isPresent(device, identity)) {
+      val readStartedAtMillis = TimeProvider.get().currentTimeMillis()
+      val present = isPresent(device, identity)
+      // Reading the hierarchy is synchronous and can take a while on a busy device. Charge it to
+      // the budget as well, or a slow read adds itself to every poll and the wait outlasts the
+      // recorded interval it is supposed to fit inside.
+      waitedMillis += (TimeProvider.get().currentTimeMillis() - readStartedAtMillis)
+        .coerceAtLeast(0)
+      if (present) {
         arbigentInfoLog(
           "Replay wait: target ${identity.description()} found after ${waitedMillis}ms " +
             "before capturing step ${replayIndex + 1}",

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
@@ -26,12 +26,13 @@ internal class ReplayDivergenceException(
  *
  * How long a step may wait is the interval recorded between it and the step before it, minus what
  * replay has already spent executing the previous action. That interval is the recording run's own
- * time from one capture to the next, so it already contains everything the app was given then,
- * including the AI latency the recording paid and any `Wait` the AI itself decided on; replay is
- * therefore never slower than the recording, and never faster than the app needs. A step with no
- * recorded interval — the first step of a task, which has no predecessor in the trace — gets
- * [MIN_WAIT_MILLIS] instead, because there is nothing to derive a budget from and a task that
- * starts by launching an app must not be stepped on at once.
+ * time from one decision to the next, so it already contains everything the app was given then,
+ * including the AI latency the recording paid and any `Wait` the AI itself decided on; within a
+ * task, replay therefore waits no longer than the recording did, and no less than the app needs.
+ * A step with no recorded interval — the first step of a task, which has no predecessor in the
+ * trace — gets [MIN_WAIT_MILLIS] instead, because there is nothing to derive a budget from and a
+ * task that starts by launching an app must not be stepped on at once; a task the recording got
+ * through faster than that does wait longer here.
  *
  * Within that budget a step with a recorded target polls the elements until the target is present,
  * and proceeds the moment it is. Waiting further for the element list to stop changing was tried
@@ -100,15 +101,16 @@ internal class ArbigentReplayPacingStepInterceptor(
     device: ArbigentDevice,
     budgetMillis: Long,
   ) {
+    // Everything between here and the return is charged to the budget, measured on the clock
+    // rather than summed from what was asked for: reading the hierarchy is synchronous and can
+    // take a while on a busy device, and a delay can resume well after the interval it requested.
+    // Adding up only the requested delays would let either one push the wait past the recorded
+    // interval it is supposed to fit inside.
+    val startedAtMillis = TimeProvider.get().currentTimeMillis()
     var waitedMillis = 0L
     while (true) {
-      val readStartedAtMillis = TimeProvider.get().currentTimeMillis()
       val present = isPresent(device, identity)
-      // Reading the hierarchy is synchronous and can take a while on a busy device. Charge it to
-      // the budget as well, or a slow read adds itself to every poll and the wait outlasts the
-      // recorded interval it is supposed to fit inside.
-      waitedMillis += (TimeProvider.get().currentTimeMillis() - readStartedAtMillis)
-        .coerceAtLeast(0)
+      waitedMillis = (TimeProvider.get().currentTimeMillis() - startedAtMillis).coerceAtLeast(0)
       if (present) {
         arbigentInfoLog(
           "Replay wait: target ${identity.description()} found after ${waitedMillis}ms " +
@@ -117,9 +119,7 @@ internal class ArbigentReplayPacingStepInterceptor(
         return
       }
       if (waitedMillis >= budgetMillis) break
-      val pollMillis = POLL_INTERVAL_MILLIS.coerceAtMost(budgetMillis - waitedMillis)
-      delay(pollMillis)
-      waitedMillis += pollMillis
+      delay(POLL_INTERVAL_MILLIS.coerceAtMost(budgetMillis - waitedMillis))
     }
     arbigentInfoLog(
       "Replay wait: budget ${budgetMillis}ms spent waiting for target ${identity.description()} " +

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
@@ -431,22 +431,46 @@ internal data class ArbigentReplayTrace(
       key: ArbigentReplayTraceKey,
       contextHolder: ArbigentContextHolder,
       precedingSteps: List<ArbigentContextHolder.Step> = emptyList(),
+      recordedTrace: ArbigentReplayTrace? = null,
     ): ArbigentReplayTrace {
+      val prefix = precedingSteps.replayable()
+      val steps = prefix + contextHolder.steps().replayable()
+      // Replayed steps carry the time the replay reached them, which is faster than the AI was. Writing
+      // that back would make the next replay's budget the pace of this one instead of the AI's, and
+      // every clean replay would tighten it further. The recorded intervals are kept instead, anchored
+      // on the last replayed step so the gap to the replacement agent's first AI decision stays the
+      // real one; anchoring on the first could leave that gap non-positive.
+      val recordedTimestamps = recordedTrace?.steps?.map { it.decisionOutput.step.timestamp }.orEmpty()
+      val replayedCount = if (recordedTrace == null) 0 else {
+        prefix.size + steps.drop(prefix.size).takeWhile { it.stepSource == ArbigentStepSource.Replay }.size
+      }
+      require(steps.take(replayedCount).all { it.stepSource == ArbigentStepSource.Replay }) {
+        "Every step in the replayed prefix must come from replay"
+      }
+      require(replayedCount <= recordedTimestamps.size) {
+        "The replayed prefix cannot be longer than its recorded trace"
+      }
+      val shift = if (replayedCount == 0) 0L else {
+        steps[replayedCount - 1].timestamp - recordedTimestamps[replayedCount - 1]
+      }
       return ArbigentReplayTrace(
         version = key.version,
         scenarioId = key.scenarioId,
         taskIndex = key.taskIndex,
         taskIdentity = key.taskIdentity,
         goalHash = key.goalHash,
-        steps = (precedingSteps.replayable() + contextHolder.steps().replayable())
-          .map { step ->
-            ArbigentReplayTraceStep(
-              decisionOutput = ArbigentAi.DecisionOutput(
-                agentActions = listOf(requireNotNull(step.agentAction)),
-                step = step,
-              ),
-            )
-          },
+        steps = steps.mapIndexed { index, step ->
+          ArbigentReplayTraceStep(
+            decisionOutput = ArbigentAi.DecisionOutput(
+              agentActions = listOf(requireNotNull(step.agentAction)),
+              step = if (index < replayedCount) {
+                step.copy(timestamp = recordedTimestamps[index] + shift)
+              } else {
+                step
+              },
+            ),
+          )
+        },
       )
     }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -358,6 +358,7 @@ public class ArbigentScenarioExecutor internal constructor(
                 key = key,
                 contextHolder = it,
                 precedingSteps = replayedPrefixes[index].orEmpty(),
+                recordedTrace = replayTraces?.get(index),
               )
             }
           val reason = if (candidate == null) {

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
@@ -156,6 +156,28 @@ class ArbigentReplayTraceTest {
     }
 
   @Test
+  fun `a target that is still moving is not treated as settled`() = runTest {
+    // Same text, same id, different place: the element is animating into position.
+    val moving = ArbigentElementList(listOf(element("target", "id", "desc", y = 100)), screenWidth = 1000)
+    val settled = ArbigentElementList(listOf(element("target", "id", "desc", y = 0)), screenWidth = 1000)
+    val device = ScriptedDevice(listOf(moving, settled, settled))
+    var proceeded = false
+
+    ArbigentReplayPacingStepInterceptor(traceWithTarget()).intercept(stepInput(device)) {
+      proceeded = true
+      ArbigentAgent.StepResult.Continue
+    }
+
+    assertTrue(proceeded)
+    assertEquals(
+      3,
+      device.elementsCallCount,
+      "a change in bounds alone must count as an unsettled screen and cost one more poll",
+    )
+    assertEquals(1000, currentTime)
+  }
+
+  @Test
   fun `a replayed step whose target never appears is captured once the deadline passes`() = runTest {
     val absent = ArbigentElementList(emptyList(), screenWidth = 1000)
     val device = ScriptedDevice(listOf(absent))
@@ -552,6 +574,7 @@ class ArbigentReplayTraceTest {
     text: String,
     resourceId: String,
     accessibilityId: String,
+    y: Int = 0,
   ): ArbigentElement = ArbigentElement(
     index = 0,
     textForAI = text,
@@ -566,7 +589,7 @@ class ArbigentReplayTraceTest {
       children = emptyList(),
     ),
     x = 0,
-    y = 0,
+    y = y,
     width = 10,
     height = 10,
     isVisible = true,

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
@@ -3,6 +3,7 @@ package io.github.takahirom.arbigent
 import io.github.takahirom.arbigent.sample.test.FakeAi
 import io.github.takahirom.arbigent.sample.test.FakeDevice
 import io.github.takahirom.arbigent.result.ArbigentScenarioDeviceFormFactor
+import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import maestro.TreeNode
 import java.io.File
@@ -129,6 +130,152 @@ class ArbigentReplayTraceTest {
     assertEquals(0, assertNotNull(store.read(first)).taskIndex)
     assertEquals(1, assertNotNull(store.read(second)).taskIndex)
   }
+
+  @Test
+  fun `a replayed step waits until its recorded target is present on two polls in a row`() =
+    runTest {
+      val absent = ArbigentElementList(emptyList(), screenWidth = 1000)
+      val present = ArbigentElementList(listOf(element("target", "id", "desc")), screenWidth = 1000)
+      val device = ScriptedDevice(listOf(absent, absent, present, present))
+      var proceeded = false
+
+      ArbigentReplayPacingStepInterceptor(traceWithTarget()).intercept(
+        stepInput(device),
+      ) {
+        proceeded = true
+        ArbigentAgent.StepResult.Continue
+      }
+
+      assertTrue(proceeded, "the step should have been captured once the target settled")
+      assertEquals(
+        4,
+        device.elementsCallCount,
+        "the target should be confirmed on two consecutive polls, no more and no less",
+      )
+      assertEquals(1500, currentTime, "each poll is one interval apart")
+    }
+
+  @Test
+  fun `a replayed step whose target never appears is captured once the deadline passes`() = runTest {
+    val absent = ArbigentElementList(emptyList(), screenWidth = 1000)
+    val device = ScriptedDevice(listOf(absent))
+    var proceeded = false
+
+    ArbigentReplayPacingStepInterceptor(traceWithTarget()).intercept(stepInput(device)) {
+      proceeded = true
+      ArbigentAgent.StepResult.Continue
+    }
+
+    assertTrue(proceeded, "a target that never appears is divergence to detect later, not here")
+    assertEquals(10_000, currentTime, "the wait should end at the ten second floor")
+    assertTrue(device.elementsCallCount >= 2, "the deadline should have been polled towards")
+  }
+
+  @Test
+  fun `a replayed step with no recorded target keeps the recorded pace`() = runTest {
+    val trace = traceWithoutTarget(firstTimestamp = 1_000, secondTimestamp = 4_000)
+    val device = ScriptedDevice(listOf(ArbigentElementList(emptyList(), screenWidth = 1000)))
+    val contextHolder = ArbigentContextHolder("goal", 10)
+    val interceptor = ArbigentReplayPacingStepInterceptor(trace)
+
+    // The first call has nothing to pace against; it is what records when replay reached step one.
+    interceptor.intercept(stepInput(device, contextHolder)) { ArbigentAgent.StepResult.Continue }
+    val action = GoalAchievedAgentAction()
+    contextHolder.addStep(
+      ArbigentContextHolder.Step(
+        stepId = "step-1",
+        agentAction = action,
+        cacheKey = "cache-key",
+        screenshotFilePath = "screenshot.png",
+      ),
+    )
+    interceptor.intercept(stepInput(device, contextHolder)) { ArbigentAgent.StepResult.Continue }
+
+    assertTrue(
+      currentTime in 2_000..3_000,
+      "the second step should have waited out the recorded gap, but waited ${currentTime}ms",
+    )
+    assertEquals(0, device.elementsCallCount, "pacing should not read the screen")
+  }
+
+  /** Hands out a scripted screen per [elements] call, repeating the last one once exhausted. */
+  private class ScriptedDevice(
+    private val screens: List<ArbigentElementList>,
+  ) : ArbigentDevice by FakeDevice() {
+    var elementsCallCount: Int = 0
+      private set
+
+    override fun elements(): ArbigentElementList {
+      val screen = screens[elementsCallCount.coerceAtMost(screens.lastIndex)]
+      elementsCallCount++
+      return screen
+    }
+  }
+
+  private fun stepInput(
+    device: ArbigentDevice,
+    contextHolder: ArbigentContextHolder = ArbigentContextHolder("goal", 10),
+  ): ArbigentAgent.StepInput = ArbigentAgent.StepInput(
+    arbigentContextHolder = contextHolder,
+    agentActionTypes = defaultAgentActionTypesForVisualMode(),
+    device = device,
+    deviceFormFactor = ArbigentScenarioDeviceFormFactor.Mobile,
+    ai = FakeAi(),
+    decisionChain = { error("Decision chain should not run") },
+    imageAssertionChain = { ArbigentAi.ImageAssertionOutput(emptyList()) },
+    executeActionChain = { ArbigentAgent.ExecuteActionsOutput() },
+    prompt = ArbigentPrompt(),
+    aiOptions = null,
+    attemptMode = ArbigentAttemptMode.ReplayWithFallback,
+  )
+
+  private fun traceWithTarget(): ArbigentReplayTrace {
+    val action = ClickWithTextAgentAction("target")
+    return trace(
+      listOf(
+        ArbigentContextHolder.Step(
+          stepId = "step-1",
+          agentAction = action,
+          cacheKey = "cache-key",
+          screenshotFilePath = "screenshot.png",
+          targetElement = ArbigentElementIdentity(text = "target"),
+        ) to action,
+      ),
+    )
+  }
+
+  private fun traceWithoutTarget(
+    firstTimestamp: Long,
+    secondTimestamp: Long,
+  ): ArbigentReplayTrace {
+    val action = GoalAchievedAgentAction()
+    return trace(
+      listOf(firstTimestamp, secondTimestamp).mapIndexed { index, timestamp ->
+        ArbigentContextHolder.Step(
+          stepId = "step-${index + 1}",
+          agentAction = action,
+          cacheKey = "cache-key",
+          screenshotFilePath = "screenshot.png",
+          timestamp = timestamp,
+        ) to action
+      },
+    )
+  }
+
+  private fun trace(
+    steps: List<Pair<ArbigentContextHolder.Step, ArbigentAgentAction>>,
+  ): ArbigentReplayTrace = ArbigentReplayTrace(
+    version = "1.2.3",
+    scenarioId = "scenario",
+    taskIndex = 0,
+    taskIdentity = "scenario",
+    goalHash = "goal-hash",
+    steps = steps.map { (step, action) ->
+      ArbigentReplayTraceStep(
+        decisionOutput = ArbigentAi.DecisionOutput(agentActions = listOf(action), step = step),
+      )
+    },
+  )
 
   /** The smallest trace [ArbigentReplayTrace.isValidFor] accepts: one step that reaches the goal. */
   private fun minimalTrace(key: ArbigentReplayTraceKey): ArbigentReplayTrace {

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
@@ -203,57 +203,67 @@ class ArbigentReplayTraceTest {
     val contextHolder = ArbigentContextHolder("goal", 10)
     val interceptor = ArbigentReplayPacingStepInterceptor(trace)
 
-    // The first call has nothing to pace against; it is what records when replay reached step one.
-    interceptor.intercept(stepInput(device, contextHolder)) { ArbigentAgent.StepResult.Continue }
-    val action = GoalAchievedAgentAction()
-    contextHolder.addStep(
-      ArbigentContextHolder.Step(
-        stepId = "step-1",
-        agentAction = action,
-        cacheKey = "cache-key",
-        screenshotFilePath = "screenshot.png",
-      ),
-    )
-    interceptor.intercept(stepInput(device, contextHolder)) { ArbigentAgent.StepResult.Continue }
+    withVirtualClock {
+      // The first call has nothing to pace against; it is what records when replay reached step one.
+      interceptor.intercept(stepInput(device, contextHolder)) { ArbigentAgent.StepResult.Continue }
+      val action = GoalAchievedAgentAction()
+      contextHolder.addStep(
+        ArbigentContextHolder.Step(
+          stepId = "step-1",
+          agentAction = action,
+          cacheKey = "cache-key",
+          screenshotFilePath = "screenshot.png",
+        ),
+      )
+      interceptor.intercept(stepInput(device, contextHolder)) { ArbigentAgent.StepResult.Continue }
 
-    assertEquals(
-      10_000L + 3_000L,
-      currentTime,
-      "the first step has no recorded interval so it waits the minimum, and the second waits out " +
-        "the 3000ms recorded between them",
-    )
-    assertEquals(0, device.elementsCallCount, "pacing should not read the screen")
+      assertEquals(
+        10_000L + 3_000L,
+        currentTime,
+        "the first step has no recorded interval so it waits the minimum, and the second waits " +
+          "out the 3000ms recorded between them",
+      )
+      assertEquals(0, device.elementsCallCount, "pacing should not read the screen")
+    }
   }
 
   @Test
   fun `a step whose budget is already spent still reads the screen once`() = runTest {
-    val present = ArbigentElementList(listOf(element("target", "id", "desc")), screenWidth = 1000)
-    val device = ScriptedDevice(listOf(present))
+    val absent = ArbigentElementList(emptyList(), screenWidth = 1000)
+    val device = ScriptedDevice(listOf(absent))
     val trace = traceWithTarget(secondTimestamp = 1_000)
     val contextHolder = ArbigentContextHolder("goal", 10)
     val interceptor = ArbigentReplayPacingStepInterceptor(trace)
+    var proceeded = false
 
-    interceptor.intercept(stepInput(device, contextHolder)) { ArbigentAgent.StepResult.Continue }
-    val action = ClickWithTextAgentAction("target")
-    contextHolder.addStep(
-      ArbigentContextHolder.Step(
-        stepId = "step-1",
-        agentAction = action,
-        cacheKey = "cache-key",
-        screenshotFilePath = "screenshot.png",
-      ),
-    )
-    // The replayed action took longer than the whole recorded interval, so nothing is left of it.
-    delay(2_000)
-    val startedAt = currentTime
-    interceptor.intercept(stepInput(device, contextHolder)) { ArbigentAgent.StepResult.Continue }
+    withVirtualClock {
+      interceptor.intercept(stepInput(device, contextHolder)) { ArbigentAgent.StepResult.Continue }
+      val action = ClickWithTextAgentAction("target")
+      contextHolder.addStep(
+        ArbigentContextHolder.Step(
+          stepId = "step-1",
+          agentAction = action,
+          cacheKey = "cache-key",
+          screenshotFilePath = "screenshot.png",
+        ),
+      )
+      // The replayed action took longer than the whole recorded interval, so nothing is left of it.
+      delay(2_000)
+      val readsBefore = device.elementsCallCount
+      val startedAt = currentTime
+      interceptor.intercept(stepInput(device, contextHolder)) {
+        proceeded = true
+        ArbigentAgent.StepResult.Continue
+      }
 
-    assertEquals(
-      startedAt,
-      currentTime,
-      "a target found on the first read must not cost the step any wait",
-    )
-    assertEquals(2, device.elementsCallCount, "each step reads the screen at least once")
+      assertTrue(proceeded, "a spent budget must not stop the step from being captured")
+      assertEquals(startedAt, currentTime, "there was nothing left of the interval to wait out")
+      assertEquals(
+        1,
+        device.elementsCallCount - readsBefore,
+        "the screen should be read exactly once: before the spent budget is consulted",
+      )
+    }
   }
 
   @Test

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
@@ -232,6 +232,33 @@ class ArbigentReplayTraceTest {
   }
 
   @Test
+  fun `a poll that resumes late is charged for the time it really took`() = runTest {
+    val absent = ArbigentElementList(emptyList(), screenWidth = 1000)
+    val device = ScriptedDevice(listOf(absent))
+    val scheduler = testScheduler
+    val previous = TimeProvider.get()
+    // The clock runs twice as fast as the scheduler: every delay resumes as late again as it asked
+    // for, the way a delay does on a loaded runtime.
+    TimeProvider.set(
+      object : TimeProvider {
+        override fun currentTimeMillis(): Long = scheduler.currentTime * 2
+      },
+    )
+    try {
+      ArbigentReplayPacingStepInterceptor(traceWithTarget()).intercept(stepInput(device)) {
+        ArbigentAgent.StepResult.Continue
+      }
+    } finally {
+      TimeProvider.set(previous)
+    }
+
+    // The 10s budget is used up after 5s of requested delays. Summing the requested delays instead
+    // would have kept polling for 10s of them, which is 20s on the clock the budget is measured on.
+    assertEquals(5_000, currentTime, "the wait should stop when the clock, not the sum of delays, reaches the budget")
+    assertEquals(11, device.elementsCallCount, "ten 500ms polls fit in the budget, plus the first read")
+  }
+
+  @Test
   fun `a replayed step with no recorded target keeps the recorded pace`() = runTest {
     val trace = traceWithoutTarget(firstTimestamp = 1_000, secondTimestamp = 4_000)
     val device = ScriptedDevice(listOf(ArbigentElementList(emptyList(), screenWidth = 1000)))

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
@@ -135,65 +135,100 @@ class ArbigentReplayTraceTest {
 
   @Test
   fun `a replayed step waits until its recorded target is present`() = runTest {
-    val absent = ArbigentElementList(emptyList(), screenWidth = 1000)
-    val present = ArbigentElementList(listOf(element("target", "id", "desc")), screenWidth = 1000)
-    val device = ScriptedDevice(listOf(absent, absent, present))
-    var proceeded = false
+    withVirtualClock {
+      val absent = ArbigentElementList(emptyList(), screenWidth = 1000)
+      val present = ArbigentElementList(listOf(element("target", "id", "desc")), screenWidth = 1000)
+      val device = ScriptedDevice(listOf(absent, absent, present))
+      var proceeded = false
 
-    ArbigentReplayPacingStepInterceptor(traceWithTarget()).intercept(
-      stepInput(device),
-    ) {
-      proceeded = true
-      ArbigentAgent.StepResult.Continue
+      ArbigentReplayPacingStepInterceptor(traceWithTarget()).intercept(
+        stepInput(device),
+      ) {
+        proceeded = true
+        ArbigentAgent.StepResult.Continue
+      }
+
+      assertTrue(proceeded, "the step should have been captured once the target appeared")
+      assertEquals(
+        3,
+        device.elementsCallCount,
+        "the wait should end on the poll that found the target, not one later",
+      )
+      assertEquals(1000, currentTime, "each poll is one interval apart")
     }
-
-    assertTrue(proceeded, "the step should have been captured once the target appeared")
-    assertEquals(
-      3,
-      device.elementsCallCount,
-      "the wait should end on the poll that found the target, not one later",
-    )
-    assertEquals(1000, currentTime, "each poll is one interval apart")
   }
 
   @Test
   fun `a target that is present but still moving is not waited on`() = runTest {
-    // Same text, same id, different place: the element is animating into position. Waiting for it
-    // to stop was deliberately dropped — a screen with anything animating or ticking never stops
-    // changing, and the recorded interval, not stability, is what bounds the wait.
-    val moving = ArbigentElementList(listOf(element("target", "id", "desc", y = 100)), screenWidth = 1000)
-    val stopped = ArbigentElementList(listOf(element("target", "id", "desc", y = 0)), screenWidth = 1000)
-    val device = ScriptedDevice(listOf(moving, stopped, stopped))
-    var proceeded = false
+    withVirtualClock {
+      // Same text, same id, different place: the element is animating into position. Waiting for it
+      // to stop was deliberately dropped — a screen with anything animating or ticking never stops
+      // changing, and the recorded interval, not stability, is what bounds the wait.
+      val moving = ArbigentElementList(listOf(element("target", "id", "desc", y = 100)), screenWidth = 1000)
+      val stopped = ArbigentElementList(listOf(element("target", "id", "desc", y = 0)), screenWidth = 1000)
+      val device = ScriptedDevice(listOf(moving, stopped, stopped))
+      var proceeded = false
 
-    ArbigentReplayPacingStepInterceptor(traceWithTarget()).intercept(stepInput(device)) {
-      proceeded = true
-      ArbigentAgent.StepResult.Continue
+      ArbigentReplayPacingStepInterceptor(traceWithTarget()).intercept(stepInput(device)) {
+        proceeded = true
+        ArbigentAgent.StepResult.Continue
+      }
+
+      assertTrue(proceeded)
+      assertEquals(1, device.elementsCallCount, "a present target is enough to capture the step")
+      assertEquals(0, currentTime)
     }
-
-    assertTrue(proceeded)
-    assertEquals(1, device.elementsCallCount, "a present target is enough to capture the step")
-    assertEquals(0, currentTime)
   }
 
   @Test
   fun `a replayed step whose target never appears is captured once the deadline passes`() = runTest {
+    withVirtualClock {
+      val absent = ArbigentElementList(emptyList(), screenWidth = 1000)
+      val device = ScriptedDevice(listOf(absent))
+      var proceeded = false
+
+      ArbigentReplayPacingStepInterceptor(traceWithTarget()).intercept(stepInput(device)) {
+        proceeded = true
+        ArbigentAgent.StepResult.Continue
+      }
+
+      assertTrue(proceeded, "a target that never appears is divergence to detect later, not here")
+      assertEquals(
+        10_000,
+        currentTime,
+        "with no recorded interval to derive a budget from, the wait should last the minimum",
+      )
+      assertTrue(device.elementsCallCount >= 2, "the budget should have been polled towards")
+    }
+  }
+
+  @Test
+  fun `a slow hierarchy read is charged to the wait budget`() = runTest {
     val absent = ArbigentElementList(emptyList(), screenWidth = 1000)
     val device = ScriptedDevice(listOf(absent))
-    var proceeded = false
-
-    ArbigentReplayPacingStepInterceptor(traceWithTarget()).intercept(stepInput(device)) {
-      proceeded = true
-      ArbigentAgent.StepResult.Continue
+    val scheduler = testScheduler
+    val previous = TimeProvider.get()
+    // Every read appears to take 200ms. Only this provider can express that: a read is synchronous,
+    // so it cannot advance the test scheduler the way `delay` does.
+    TimeProvider.set(
+      object : TimeProvider {
+        override fun currentTimeMillis(): Long =
+          scheduler.currentTime + ReadCostMillis * device.elementsCallCount
+      },
+    )
+    try {
+      ArbigentReplayPacingStepInterceptor(traceWithTarget()).intercept(stepInput(device)) {
+        ArbigentAgent.StepResult.Continue
+      }
+    } finally {
+      TimeProvider.set(previous)
     }
 
-    assertTrue(proceeded, "a target that never appears is divergence to detect later, not here")
-    assertEquals(
-      10_000,
-      currentTime,
-      "with no recorded interval to derive a budget from, the wait should last the minimum",
-    )
-    assertTrue(device.elementsCallCount >= 2, "the budget should have been polled towards")
+    // Each poll now costs 200ms of reading plus a 500ms delay, so the 10s budget buys 15 reads and
+    // 14 delays instead of 20 delays. Without charging the read the wait would have slept the whole
+    // 10s and spent 20 reads on top, overrunning the interval it is meant to fit inside by 4s.
+    assertEquals(15, device.elementsCallCount, "the read time should shorten the poll count")
+    assertEquals(7_000, currentTime, "only the delays are time the wait actually slept")
   }
 
   @Test
@@ -302,6 +337,14 @@ class ArbigentReplayTraceTest {
    * Runs [block] with the clock the interceptor measures elapsed time against driven by the test
    * scheduler, so time the test spends in [delay] counts as time the replayed action took.
    */
+  /**
+   * Runs [block] with the clock the wait measures against pointed at the test scheduler.
+   *
+   * The wait reads [TimeProvider] twice — for the time already spent since the previous step, and
+   * for how long each hierarchy read took — while `delay` moves only the virtual clock. Left on
+   * real time those two readings are a few stray milliseconds of whatever the machine was doing,
+   * which is enough to make an exact assertion on `currentTime` fail on a slow CI runner.
+   */
   private suspend fun TestScope.withVirtualClock(block: suspend () -> Unit) {
     val scheduler = testScheduler
     val previous = TimeProvider.get()
@@ -315,6 +358,10 @@ class ArbigentReplayTraceTest {
     } finally {
       TimeProvider.set(previous)
     }
+  }
+
+  private companion object {
+    private const val ReadCostMillis = 200L
   }
 
   /** Hands out a scripted screen per [elements] call, repeating the last one once exhausted. */

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
@@ -3,6 +3,7 @@ package io.github.takahirom.arbigent
 import io.github.takahirom.arbigent.sample.test.FakeAi
 import io.github.takahirom.arbigent.sample.test.FakeDevice
 import io.github.takahirom.arbigent.result.ArbigentScenarioDeviceFormFactor
+import io.github.takahirom.arbigent.result.ArbigentStepSource
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.currentTime
@@ -18,6 +19,104 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class ArbigentReplayTraceTest {
+  @Test
+  fun `fallback candidate preserves recorded prefix intervals and fresh AI intervals`() {
+    val recordedSteps = timestampedSteps(listOf(1_000, 5_000, 12_000, 21_000))
+    val recordedTrace = trace(recordedSteps.map { it to requireNotNull(it.agentAction) })
+    val replayedSteps = recordedSteps.take(3).mapIndexed { index, step ->
+      step.copy(timestamp = 100_000L + index * 100L, stepSource = ArbigentStepSource.Replay)
+    }
+    val aiSteps = timestampedSteps(listOf(102_200, 105_200)).mapIndexed { index, step ->
+      step.copy(stepId = "ai-$index")
+    }
+
+    // Both sources of replayed steps share the recording's order, even when the prefix spans them.
+    for (precedingCount in 0..replayedSteps.size) {
+      val context = ArbigentContextHolder("goal", 10).apply {
+        (replayedSteps.drop(precedingCount) + aiSteps).forEach(::addStep)
+      }
+      val candidate = ArbigentReplayTrace.candidateFrom(
+        key = candidateKey(),
+        contextHolder = context,
+        precedingSteps = replayedSteps.take(precedingCount),
+        recordedTrace = recordedTrace,
+      )
+      val writtenSteps = candidate.steps.map { it.decisionOutput.step }
+
+      assertEquals(listOf(4_000L, 7_000L, 2_000L, 3_000L), writtenSteps.map { it.timestamp }.zipWithNext { a, b -> b - a })
+      assertEquals(replayedSteps.last().timestamp, writtenSteps[2].timestamp)
+      assertEquals(aiSteps, writtenSteps.drop(3))
+      assertEquals(replayedSteps.drop(precedingCount) + aiSteps, context.steps())
+    }
+  }
+
+  @Test
+  fun `clean replay candidate preserves all recorded intervals`() {
+    val recordedSteps = timestampedSteps(listOf(1_000, 5_000, 12_000, 21_000))
+    val recordedTrace = trace(recordedSteps.map { it to requireNotNull(it.agentAction) })
+    val freshSteps = recordedSteps.mapIndexed { index, step ->
+      step.copy(timestamp = 100_000L + index * 100L, stepSource = ArbigentStepSource.Replay)
+    }
+    val context = ArbigentContextHolder("goal", 10).apply { freshSteps.forEach(::addStep) }
+
+    val candidate = ArbigentReplayTrace.candidateFrom(candidateKey(), context, recordedTrace = recordedTrace)
+    val writtenTimestamps = candidate.steps.map { it.decisionOutput.step.timestamp }
+
+    assertEquals(listOf(4_000L, 7_000L, 9_000L), writtenTimestamps.zipWithNext { a, b -> b - a })
+    assertEquals(freshSteps.last().timestamp, writtenTimestamps.last())
+    assertEquals(freshSteps, context.steps())
+  }
+
+  @Test
+  fun `normal candidate keeps its own timestamps`() {
+    val freshSteps = timestampedSteps(listOf(100_000, 102_200, 105_200))
+    val context = ArbigentContextHolder("goal", 10).apply { freshSteps.forEach(::addStep) }
+
+    val candidate = ArbigentReplayTrace.candidateFrom(candidateKey(), context)
+
+    assertEquals(freshSteps, candidate.steps.map { it.decisionOutput.step })
+  }
+
+  @Test
+  fun `candidate rejects a replayed prefix longer than the recording`() {
+    val context = ArbigentContextHolder("goal", 10).apply {
+      timestampedSteps(listOf(100_000, 100_100)).forEach {
+        addStep(it.copy(stepSource = ArbigentStepSource.Replay))
+      }
+    }
+
+    assertFailsWith<IllegalArgumentException> {
+      ArbigentReplayTrace.candidateFrom(candidateKey(), context, recordedTrace = minimalTrace(candidateKey()))
+    }
+  }
+
+  @Test
+  fun `candidate rejects a preceding step that did not come from replay`() {
+    assertFailsWith<IllegalArgumentException> {
+      ArbigentReplayTrace.candidateFrom(
+        key = candidateKey(),
+        contextHolder = ArbigentContextHolder("goal", 10),
+        precedingSteps = timestampedSteps(listOf(100_000)),
+        recordedTrace = minimalTrace(candidateKey()),
+      )
+    }
+  }
+
+  private fun candidateKey(): ArbigentReplayTraceKey = ArbigentReplayTraceKey(
+    version = "1.2.3",
+    scenarioId = "scenario",
+    taskIndex = 0,
+    taskIdentity = "scenario",
+    goal = "goal",
+  )
+
+  private fun timestampedSteps(timestamps: List<Long>): List<ArbigentContextHolder.Step> {
+    val step = minimalTrace(candidateKey()).steps.single().decisionOutput.step
+    return timestamps.mapIndexed { index, timestamp ->
+      step.copy(stepId = "step-$index", timestamp = timestamp)
+    }
+  }
+
   @Test
   fun `trace round trip preserves actions and target identity`() {
     val directory = Files.createTempDirectory("arbigent-replay-trace-test").toFile()

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
@@ -3,6 +3,8 @@ package io.github.takahirom.arbigent
 import io.github.takahirom.arbigent.sample.test.FakeAi
 import io.github.takahirom.arbigent.sample.test.FakeDevice
 import io.github.takahirom.arbigent.result.ArbigentScenarioDeviceFormFactor
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.currentTime
 import kotlinx.coroutines.test.runTest
 import maestro.TreeNode
@@ -132,35 +134,36 @@ class ArbigentReplayTraceTest {
   }
 
   @Test
-  fun `a replayed step waits until its recorded target is present on two polls in a row`() =
-    runTest {
-      val absent = ArbigentElementList(emptyList(), screenWidth = 1000)
-      val present = ArbigentElementList(listOf(element("target", "id", "desc")), screenWidth = 1000)
-      val device = ScriptedDevice(listOf(absent, absent, present, present))
-      var proceeded = false
+  fun `a replayed step waits until its recorded target is present`() = runTest {
+    val absent = ArbigentElementList(emptyList(), screenWidth = 1000)
+    val present = ArbigentElementList(listOf(element("target", "id", "desc")), screenWidth = 1000)
+    val device = ScriptedDevice(listOf(absent, absent, present))
+    var proceeded = false
 
-      ArbigentReplayPacingStepInterceptor(traceWithTarget()).intercept(
-        stepInput(device),
-      ) {
-        proceeded = true
-        ArbigentAgent.StepResult.Continue
-      }
-
-      assertTrue(proceeded, "the step should have been captured once the target settled")
-      assertEquals(
-        4,
-        device.elementsCallCount,
-        "the target should be confirmed on two consecutive polls, no more and no less",
-      )
-      assertEquals(1500, currentTime, "each poll is one interval apart")
+    ArbigentReplayPacingStepInterceptor(traceWithTarget()).intercept(
+      stepInput(device),
+    ) {
+      proceeded = true
+      ArbigentAgent.StepResult.Continue
     }
 
+    assertTrue(proceeded, "the step should have been captured once the target appeared")
+    assertEquals(
+      3,
+      device.elementsCallCount,
+      "the wait should end on the poll that found the target, not one later",
+    )
+    assertEquals(1000, currentTime, "each poll is one interval apart")
+  }
+
   @Test
-  fun `a target that is still moving is not treated as settled`() = runTest {
-    // Same text, same id, different place: the element is animating into position.
+  fun `a target that is present but still moving is not waited on`() = runTest {
+    // Same text, same id, different place: the element is animating into position. Waiting for it
+    // to stop was deliberately dropped — a screen with anything animating or ticking never stops
+    // changing, and the recorded interval, not stability, is what bounds the wait.
     val moving = ArbigentElementList(listOf(element("target", "id", "desc", y = 100)), screenWidth = 1000)
-    val settled = ArbigentElementList(listOf(element("target", "id", "desc", y = 0)), screenWidth = 1000)
-    val device = ScriptedDevice(listOf(moving, settled, settled))
+    val stopped = ArbigentElementList(listOf(element("target", "id", "desc", y = 0)), screenWidth = 1000)
+    val device = ScriptedDevice(listOf(moving, stopped, stopped))
     var proceeded = false
 
     ArbigentReplayPacingStepInterceptor(traceWithTarget()).intercept(stepInput(device)) {
@@ -169,12 +172,8 @@ class ArbigentReplayTraceTest {
     }
 
     assertTrue(proceeded)
-    assertEquals(
-      3,
-      device.elementsCallCount,
-      "a change in bounds alone must count as an unsettled screen and cost one more poll",
-    )
-    assertEquals(1000, currentTime)
+    assertEquals(1, device.elementsCallCount, "a present target is enough to capture the step")
+    assertEquals(0, currentTime)
   }
 
   @Test
@@ -189,8 +188,12 @@ class ArbigentReplayTraceTest {
     }
 
     assertTrue(proceeded, "a target that never appears is divergence to detect later, not here")
-    assertEquals(10_000, currentTime, "the wait should end at the ten second floor")
-    assertTrue(device.elementsCallCount >= 2, "the deadline should have been polled towards")
+    assertEquals(
+      10_000,
+      currentTime,
+      "with no recorded interval to derive a budget from, the wait should last the minimum",
+    )
+    assertTrue(device.elementsCallCount >= 2, "the budget should have been polled towards")
   }
 
   @Test
@@ -213,11 +216,95 @@ class ArbigentReplayTraceTest {
     )
     interceptor.intercept(stepInput(device, contextHolder)) { ArbigentAgent.StepResult.Continue }
 
-    assertTrue(
-      currentTime in 2_000..3_000,
-      "the second step should have waited out the recorded gap, but waited ${currentTime}ms",
+    assertEquals(
+      10_000L + 3_000L,
+      currentTime,
+      "the first step has no recorded interval so it waits the minimum, and the second waits out " +
+        "the 3000ms recorded between them",
     )
     assertEquals(0, device.elementsCallCount, "pacing should not read the screen")
+  }
+
+  @Test
+  fun `a step whose budget is already spent still reads the screen once`() = runTest {
+    val present = ArbigentElementList(listOf(element("target", "id", "desc")), screenWidth = 1000)
+    val device = ScriptedDevice(listOf(present))
+    val trace = traceWithTarget(secondTimestamp = 1_000)
+    val contextHolder = ArbigentContextHolder("goal", 10)
+    val interceptor = ArbigentReplayPacingStepInterceptor(trace)
+
+    interceptor.intercept(stepInput(device, contextHolder)) { ArbigentAgent.StepResult.Continue }
+    val action = ClickWithTextAgentAction("target")
+    contextHolder.addStep(
+      ArbigentContextHolder.Step(
+        stepId = "step-1",
+        agentAction = action,
+        cacheKey = "cache-key",
+        screenshotFilePath = "screenshot.png",
+      ),
+    )
+    // The replayed action took longer than the whole recorded interval, so nothing is left of it.
+    delay(2_000)
+    val startedAt = currentTime
+    interceptor.intercept(stepInput(device, contextHolder)) { ArbigentAgent.StepResult.Continue }
+
+    assertEquals(
+      startedAt,
+      currentTime,
+      "a target found on the first read must not cost the step any wait",
+    )
+    assertEquals(2, device.elementsCallCount, "each step reads the screen at least once")
+  }
+
+  @Test
+  fun `a replayed step waits out only what is left of the recorded interval`() = runTest {
+    val absent = ArbigentElementList(emptyList(), screenWidth = 1000)
+    val device = ScriptedDevice(listOf(absent))
+    val trace = traceWithoutTarget(firstTimestamp = 1_000, secondTimestamp = 6_000)
+    val contextHolder = ArbigentContextHolder("goal", 10)
+    val interceptor = ArbigentReplayPacingStepInterceptor(trace)
+
+    withVirtualClock {
+      interceptor.intercept(stepInput(device, contextHolder)) { ArbigentAgent.StepResult.Continue }
+      val action = GoalAchievedAgentAction()
+      contextHolder.addStep(
+        ArbigentContextHolder.Step(
+          stepId = "step-1",
+          agentAction = action,
+          cacheKey = "cache-key",
+          screenshotFilePath = "screenshot.png",
+        ),
+      )
+      // The replayed action itself took 2000ms, which the recorded interval already covers.
+      delay(2_000)
+      val startedAt = currentTime
+      interceptor.intercept(stepInput(device, contextHolder)) { ArbigentAgent.StepResult.Continue }
+
+      assertEquals(
+        3_000L,
+        currentTime - startedAt,
+        "the time the action itself took should be subtracted from the recorded interval",
+      )
+    }
+  }
+
+  /**
+   * Runs [block] with the clock the interceptor measures elapsed time against driven by the test
+   * scheduler, so time the test spends in [delay] counts as time the replayed action took.
+   */
+  private suspend fun TestScope.withVirtualClock(block: suspend () -> Unit) {
+    val scheduler = testScheduler
+    val previous = TimeProvider.get()
+    TimeProvider.set(
+      object : TimeProvider {
+        override fun currentTimeMillis(): Long = scheduler.currentTime
+      },
+    )
+    try {
+      block()
+    } finally {
+      TimeProvider.set(previous)
+    }
   }
 
   /** Hands out a scripted screen per [elements] call, repeating the last one once exhausted. */
@@ -251,18 +338,24 @@ class ArbigentReplayTraceTest {
     attemptMode = ArbigentAttemptMode.ReplayWithFallback,
   )
 
-  private fun traceWithTarget(): ArbigentReplayTrace {
+  /**
+   * A trace whose steps all act on the same target. With a [secondTimestamp] it has two steps
+   * recorded that far apart, so the second one has an interval to derive its budget from.
+   */
+  private fun traceWithTarget(secondTimestamp: Long? = null): ArbigentReplayTrace {
     val action = ClickWithTextAgentAction("target")
+    val timestamps = listOfNotNull(0L.takeIf { secondTimestamp != null }, secondTimestamp)
+      .ifEmpty { listOf(null) }
     return trace(
-      listOf(
+      timestamps.mapIndexed { index, timestamp ->
         ArbigentContextHolder.Step(
-          stepId = "step-1",
+          stepId = "step-${index + 1}",
           agentAction = action,
           cacheKey = "cache-key",
           screenshotFilePath = "screenshot.png",
           targetElement = ArbigentElementIdentity(text = "target"),
-        ) to action,
-      ),
+        ).let { step -> if (timestamp == null) step else step.copy(timestamp = timestamp) } to action
+      },
     )
   }
 


### PR DESCRIPTION
## Why
Replay paced each step by sleeping the interval recorded between two trace steps. That interval is the recording run's own time from one capture to the next, but replay slept it whole and only after the previous action had already finished, so the wait was the interval *plus* whatever replay had just spent — and it was never tied to whether the screen had actually reached the recorded state.

## What
`ArbigentReplayPacingStepInterceptor` now derives one budget per step and spends it in one of two ways.

- **The budget** is the recorded interval (capped at 60s) minus the time replay has already spent since the previous step began. Because the recorded interval already contains everything the app was given during recording — including the AI latency the recording paid, and any `Wait` the AI itself decided on — replay is never slower than the recording and never faster than the app needed.
- **A step with a recorded target** polls `device.elements()` (500ms) and proceeds the moment the target is present. The screen is read at least once even when the budget is already gone. On budget exhaustion the step is captured anyway; divergence detection stays in `ArbigentReplayDecisionInterceptor`.
- **A step with no target** (goal achieved, back, scroll, wait, text actions recorded without an identity) waits its budget out.
- **A step with no recorded interval** — the first step of a task, which has no predecessor in the trace — gets a 10s budget instead. This closes a hole: a *targetless* first step previously waited nothing at all (a first step with a recorded target already got the deadline), and since the interceptor is per task, every task boundary replayed such an action against whatever was on screen at that instant. A task that starts by launching an app or pressing a key was the case that showed it. The trace format carries no task-start timestamp, so there is nothing to derive a real budget from here; 10s is a floor, and it does cost ~10s per task boundary.

**Waiting for the element list to settle was tried and dropped.** Requiring two identical polls means a screen with anything animating, ticking or streaming never settles, so the wait ran to the deadline every time and a screen that was in fact ready got reported as one the target never reached.

Trace format is unchanged; existing traces remain valid.

## What gets written back

Replayed steps carry the time the replay reached them, which is shorter than the interval the AI took. Writing that back would make the next replay's budget the pace of this replay instead of the AI's, and every clean replay would tighten it further. When a trace is written after a replay — clean or after a fallback — steps that came from replay keep the recorded intervals, shifted so the last replayed step lands on the time the replay actually reached it. Steps decided by the AI keep their own timestamps, so the gap between the last replayed step and the first AI decision is the real one. Traces that were already tightened recover after one run where the AI decides the steps.

`ArbigentReplayTraceTest` covers the interval preservation for a clean replay and for a fallback at each position, and that a normal (non-replay) run is written unchanged.

## Tests
`ArbigentReplayTraceTest`: a target that appears after a few polls; target never present (captured when the budget is spent); no identity (waits the interval out); a budget already spent still reads the screen once; only what is left of the interval is waited out (with the clock the interceptor measures against driven by the test scheduler). `:arbigent-core:test` passes.


