### PR TITLE
Record the device events Arbigent sends as replayable data

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -248,7 +248,17 @@ public class MaestroDevice(
   }
 
   @Volatile private var connection: Connection =
-    Connection(maestro, Orchestra(maestro = maestro), onClose)
+    Connection(maestro, newOrchestra(maestro), onClose)
+
+  // Every Orchestra this device runs commands through reports each command back here as soon as
+  // Maestro finishes it, so a flow of several commands (repeated key presses) that fails half way
+  // still leaves the commands that were actually sent in the event log. A command Maestro rejected
+  // (an element it could not find, which the agent then retries with a looser selector) never
+  // completes and so never reaches the log.
+  private fun newOrchestra(maestro: Maestro): Orchestra = Orchestra(
+    maestro = maestro,
+    onCommandComplete = { _, command -> recordDeviceEvents(command) },
+  )
 
   // Volatile read of the live connection so callers keep using `maestro`/`orchestra` unchanged.
   private val maestro: Maestro get() = connection.maestro
@@ -273,15 +283,11 @@ public class MaestroDevice(
     deviceEventListeners.remove(listener)
   }
 
-  private fun recordDeviceEvents(actions: List<MaestroCommand>) {
+  private fun recordDeviceEvents(command: MaestroCommand) {
     if (deviceEventListeners.isEmpty()) return
     runCatching {
       val deviceInfo = maestro.cachedDeviceInfo
-      actions.forEach { command ->
-        emitDeviceEvents(
-          command.toArbigentDeviceEvents(deviceInfo.widthPixels, deviceInfo.heightPixels)
-        )
-      }
+      emitDeviceEvents(command.toArbigentDeviceEvents(deviceInfo.widthPixels, deviceInfo.heightPixels))
     }.onFailure { arbigentDebugLog("Failed to record device events: ${it.message}") }
   }
 
@@ -326,13 +332,8 @@ public class MaestroDevice(
           val file = resolveScreenshotFile(screenshotsDir, screenshot.path)
           maestro.takeScreenshot(file.sink(), false)
         } else {
-          val result = orchestra.runFlow(actions)
-          // Recorded after the flow, and only when Maestro reports it succeeded, so a command it
-          // rejected (an element it could not find, which the agent then retries with a looser
-          // selector) or gave up on never reaches the log.
-          if (result.success) {
-            recordDeviceEvents(actions)
-          }
+          // Device events are recorded per command by the Orchestra callback (see newOrchestra).
+          orchestra.runFlow(actions)
         }
       }
     }
@@ -804,7 +805,10 @@ public class MaestroDevice(
 
         // Adopt the new device's whole Connection (maestro + orchestra + its onClose, which owns the
         // new iproxy) in one volatile swap. The old connection was already torn down above.
-        this.connection = newDevice.connection
+        // The new device's own Orchestra would report commands to that throwaway instance, so this
+        // device builds its own around the adopted maestro to keep recording after the swap.
+        val adopted = newDevice.connection
+        this.connection = Connection(adopted.maestro, newOrchestra(adopted.maestro), adopted.onClose)
 
         // Reset counter on successful reconnection
         reconnectAttempts = 0

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -326,8 +326,10 @@ public class MaestroDevice(
           val file = resolveScreenshotFile(screenshotsDir, screenshot.path)
           maestro.takeScreenshot(file.sink(), false)
         } else {
-          recordDeviceEvents(actions)
           orchestra.runFlow(actions)
+          // Recorded after the flow so a command Maestro rejected (an element it could not find,
+          // which the agent then retries with a looser selector) never reaches the log.
+          recordDeviceEvents(actions)
         }
       }
     }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -11,6 +11,7 @@ import maestro.orchestra.MaestroCommand
 import maestro.orchestra.Orchestra
 import okio.sink
 import java.io.File
+import java.util.concurrent.CopyOnWriteArrayList
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.pow
 import kotlin.system.measureTimeMillis
@@ -61,6 +62,20 @@ public interface ArbigentDevice {
   public fun elements(): ArbigentElementList
   public fun waitForAppToSettle(appId: String? = null)
   public fun os(): ArbigentDeviceOs
+
+  /**
+   * Observes the low-level interactions this device performs, for recording replay scripts.
+   *
+   * Devices that cannot report their interactions keep the no-op defaults, so listening is always
+   * safe to ask for and simply records nothing.
+   */
+  @ArbigentInternalApi
+  public fun addDeviceEventListener(listener: ArbigentDeviceEventListener) {
+  }
+
+  @ArbigentInternalApi
+  public fun removeDeviceEventListener(listener: ArbigentDeviceEventListener) {
+  }
 }
 
 public data class ArbigentElement(
@@ -98,7 +113,12 @@ public data class ArbigentElement(
 
 public data class ArbigentElementList(
   val elements: List<ArbigentElement>,
-  val screenWidth: Int
+  val screenWidth: Int,
+  /**
+   * Screen height in the same coordinate space as [ArbigentElement] bounds. Defaults to 0 when the
+   * device did not report it.
+   */
+  val screenHeight: Int = 0
 ) {
 
   public fun getPromptTexts(): String {
@@ -193,7 +213,8 @@ public data class ArbigentElementList(
 
       return ArbigentElementList(
         elements = elements,
-        screenWidth = (deviceInfo.widthGrid)
+        screenWidth = (deviceInfo.widthGrid),
+        screenHeight = (deviceInfo.heightGrid)
       )
     }
   }
@@ -233,8 +254,45 @@ public class MaestroDevice(
   private val maestro: Maestro get() = connection.maestro
   private val orchestra: Orchestra get() = connection.orchestra
 
+  // Copy-on-write because listeners are attached and detached by the scenario executor on its own
+  // coroutine while commands are being sent from the agent's, and a recording device must never be
+  // the reason a run fails.
+  private val deviceEventListeners = CopyOnWriteArrayList<ArbigentDeviceEventListener>()
+
   init {
     arbigentInfoLog("MaestroDevice created: screenshotsDir:${screenshotsDir.absolutePath}")
+  }
+
+  @ArbigentInternalApi
+  override fun addDeviceEventListener(listener: ArbigentDeviceEventListener) {
+    deviceEventListeners.addIfAbsent(listener)
+  }
+
+  @ArbigentInternalApi
+  override fun removeDeviceEventListener(listener: ArbigentDeviceEventListener) {
+    deviceEventListeners.remove(listener)
+  }
+
+  private fun recordDeviceEvents(actions: List<MaestroCommand>) {
+    if (deviceEventListeners.isEmpty()) return
+    runCatching {
+      val deviceInfo = maestro.cachedDeviceInfo
+      actions.forEach { command ->
+        emitDeviceEvents(
+          command.toArbigentDeviceEvents(deviceInfo.widthPixels, deviceInfo.heightPixels)
+        )
+      }
+    }.onFailure { arbigentDebugLog("Failed to record device events: ${it.message}") }
+  }
+
+  private fun emitDeviceEvents(events: List<ArbigentDeviceEvent>) {
+    if (deviceEventListeners.isEmpty()) return
+    events.forEach { event ->
+      deviceEventListeners.forEach { listener ->
+        runCatching { listener.onDeviceEvent(event) }
+          .onFailure { arbigentDebugLog("Device event listener failed: ${it.message}") }
+      }
+    }
   }
 
   override fun deviceName(): String {
@@ -268,6 +326,7 @@ public class MaestroDevice(
           val file = resolveScreenshotFile(screenshotsDir, screenshot.path)
           maestro.takeScreenshot(file.sink(), false)
         } else {
+          recordDeviceEvents(actions)
           orchestra.runFlow(actions)
         }
       }
@@ -292,7 +351,11 @@ public class MaestroDevice(
         Thread.sleep(1000)
       }
     }
-    return ArbigentElementList(emptyList(), maestro.cachedDeviceInfo.widthPixels)
+    return ArbigentElementList(
+      emptyList(),
+      maestro.cachedDeviceInfo.widthPixels,
+      maestro.cachedDeviceInfo.heightPixels
+    )
   }
 
 
@@ -557,6 +620,12 @@ public class MaestroDevice(
       val direction = directionCandidates.random()
       arbigentDebugLog("directionCandidates: $directionCandidates \ndirection: $direction")
       runBlocking {
+        // Recorded here rather than in executeActions because the focus walk drives maestro
+        // directly: these presses are the only device interaction a D-pad focus action performs,
+        // and a replay that skipped them would never move the focus at all.
+        emitDeviceEvents(
+          listOf(arbigentKeyPressEvent(direction))
+        )
         maestro.pressKey(direction)
         maestro.waitForAnimationToEnd("100")
       }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -326,10 +326,13 @@ public class MaestroDevice(
           val file = resolveScreenshotFile(screenshotsDir, screenshot.path)
           maestro.takeScreenshot(file.sink(), false)
         } else {
-          orchestra.runFlow(actions)
-          // Recorded after the flow so a command Maestro rejected (an element it could not find,
-          // which the agent then retries with a looser selector) never reaches the log.
-          recordDeviceEvents(actions)
+          val result = orchestra.runFlow(actions)
+          // Recorded after the flow, and only when Maestro reports it succeeded, so a command it
+          // rejected (an element it could not find, which the agent then retries with a looser
+          // selector) or gave up on never reaches the log.
+          if (result.success) {
+            recordDeviceEvents(actions)
+          }
         }
       }
     }
@@ -622,13 +625,14 @@ public class MaestroDevice(
       val direction = directionCandidates.random()
       arbigentDebugLog("directionCandidates: $directionCandidates \ndirection: $direction")
       runBlocking {
+        maestro.pressKey(direction)
         // Recorded here rather than in executeActions because the focus walk drives maestro
         // directly: these presses are the only device interaction a D-pad focus action performs,
-        // and a replay that skipped them would never move the focus at all.
+        // and a replay that skipped them would never move the focus at all. Recorded after the
+        // press so one the device refused is not replayed either.
         emitDeviceEvents(
           listOf(arbigentKeyPressEvent(direction))
         )
-        maestro.pressKey(direction)
         maestro.waitForAnimationToEnd("100")
       }
     }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -287,7 +287,11 @@ public class MaestroDevice(
     if (deviceEventListeners.isEmpty()) return
     runCatching {
       val deviceInfo = maestro.cachedDeviceInfo
-      emitDeviceEvents(command.toArbigentDeviceEvents(deviceInfo.widthPixels, deviceInfo.heightPixels))
+      // Grid units, not pixels: this is the space Maestro's own drivers do their coordinate work in
+      // (the iOS driver reads widthGrid/heightGrid), and the space ArbigentElementList reports, so
+      // recording in it keeps the events, the recorded screen size and the element bounds
+      // comparable. On Android the two are the same number.
+      emitDeviceEvents(command.toArbigentDeviceEvents(deviceInfo.widthGrid, deviceInfo.heightGrid))
     }.onFailure { arbigentDebugLog("Failed to record device events: ${it.message}") }
   }
 
@@ -359,8 +363,9 @@ public class MaestroDevice(
     }
     return ArbigentElementList(
       emptyList(),
-      maestro.cachedDeviceInfo.widthPixels,
-      maestro.cachedDeviceInfo.heightPixels
+      // Grid units, like the list [ArbigentElementList.from] builds when the hierarchy can be read.
+      maestro.cachedDeviceInfo.widthGrid,
+      maestro.cachedDeviceInfo.heightGrid
     )
   }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -291,7 +291,7 @@ public class MaestroDevice(
       // (the iOS driver reads widthGrid/heightGrid), and the space ArbigentElementList reports, so
       // recording in it keeps the events, the recorded screen size and the element bounds
       // comparable. On Android the two are the same number.
-      emitDeviceEvents(command.toArbigentDeviceEvents(deviceInfo.widthGrid, deviceInfo.heightGrid))
+      emitDeviceEvents(command.toArbigentDeviceEvents(deviceInfo.widthGrid, deviceInfo.heightGrid, os()))
     }.onFailure { arbigentDebugLog("Failed to record device events: ${it.message}") }
   }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
@@ -30,6 +30,21 @@ public sealed interface ArbigentDeviceEvent {
     override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
   ) : ArbigentDeviceEvent
 
+  /**
+   * A tap on an element Maestro located by text or resource id at the time. The selector is kept
+   * so a replay can find the element again in the current hierarchy and press its center, since the
+   * pixel it landed on in the recorded run is only right while the layout has not moved. [index] is
+   * the zero-based position among the matches, as Maestro counts them.
+   */
+  @Serializable
+  @SerialName("tap_element")
+  public data class TapElement(
+    val textRegex: String? = null,
+    val idRegex: String? = null,
+    val index: Int = 0,
+    override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
+  ) : ArbigentDeviceEvent
+
   /** [keyName] is an Android `KEYCODE_*` name, ready for `adb shell input keyevent`. */
   @Serializable
   @SerialName("key_press")
@@ -61,12 +76,16 @@ public sealed interface ArbigentDeviceEvent {
    * replay can pass each one through the matching `am start` flag. An app that reads a launch extra
    * to decide what to show (a test-only entry point, a first-run flow) starts somewhere else without
    * them, and every later step then diverges.
+   *
+   * [stopApp] mirrors Maestro's default of force-stopping the app before starting it, so a replay
+   * starts a fresh process the way the recorded run did instead of resuming whatever was left.
    */
   @Serializable
   @SerialName("launch_app")
   public data class LaunchApp(
     val appId: String,
     val clearState: Boolean = false,
+    val stopApp: Boolean = true,
     val launchArguments: Map<String, JsonPrimitive> = emptyMap(),
     override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
   ) : ArbigentDeviceEvent
@@ -146,14 +165,21 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
   tapOnPoint?.let { command ->
     return listOf(ArbigentDeviceEvent.Tap(command.x, command.y, timestamp))
   }
-  // Element-relative taps depend on the view hierarchy Maestro saw at the time, which the replay
-  // script cannot reconstruct. The recorded step target tells the reader what to press instead.
+  // Element taps are how the agent clicks by text or id, so they are the common case on phones.
+  // Only a selector with something a hierarchy dump can be searched for is replayable.
   tapOnElement?.let { command ->
-    val selector = listOfNotNull(
-      command.selector.textRegex?.let { "text=$it" },
-      command.selector.idRegex?.let { "id=$it" },
-    ).joinToString(" ").ifEmpty { "element" }
-    return listOf(ArbigentDeviceEvent.Unsupported("tapOn $selector", timestamp))
+    val selector = command.selector
+    if (selector.textRegex == null && selector.idRegex == null) {
+      return listOf(ArbigentDeviceEvent.Unsupported("tapOn $selector", timestamp))
+    }
+    return listOf(
+      ArbigentDeviceEvent.TapElement(
+        textRegex = selector.textRegex,
+        idRegex = selector.idRegex,
+        index = selector.index?.toIntOrNull() ?: 0,
+        timestamp = timestamp,
+      )
+    )
   }
   backPressCommand?.let { return listOf(ArbigentDeviceEvent.KeyPress("KEYCODE_BACK", timestamp)) }
   pressKeyCommand?.let { command ->
@@ -171,6 +197,8 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
       ArbigentDeviceEvent.LaunchApp(
         appId = command.appId,
         clearState = command.clearState == true,
+        // Maestro treats a missing stopApp as true.
+        stopApp = command.stopApp != false,
         launchArguments = command.launchArguments.orEmpty().mapValues { (_, value) -> value.toJsonPrimitive() },
         timestamp = timestamp,
       )

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
@@ -5,7 +5,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonPrimitive
 import maestro.KeyCode
 import maestro.SwipeDirection
+import maestro.orchestra.ElementSelector
 import maestro.orchestra.MaestroCommand
+import maestro.orchestra.TapOnElementCommand
 
 /**
  * A single low-level interaction Arbigent sent to the device, recorded at the point where the
@@ -151,6 +153,9 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
   timestamp: Long = TimeProvider.get().currentTimeMillis(),
 ): List<ArbigentDeviceEvent> {
   tapOnPointV2Command?.let { command ->
+    if (command.longPress == true || command.repeat != null) {
+      return listOf(ArbigentDeviceEvent.Unsupported("tapOnPointV2 ${command.point} (longPress/repeat)", timestamp))
+    }
     val point = command.point
     // Arbigent always issues absolute points; a percentage point would need the driver's own
     // resolution rules, so it is recorded as a divergence instead of guessed at.
@@ -171,6 +176,15 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
     val selector = command.selector
     if (selector.textRegex == null && selector.idRegex == null) {
       return listOf(ArbigentDeviceEvent.Unsupported("tapOn $selector", timestamp))
+    }
+    // A plain tap on the first element matching text/id/index is all the replay can reproduce.
+    // Anything that changes which element is hit or how (a long press, a repeated tap, a tap at a
+    // relative point, a selector narrowed by position, traits or state) is recorded as a
+    // divergence rather than silently downgraded to a different interaction.
+    if (command.longPress == true || command.repeat != null || command.relativePoint != null ||
+      selector.hasConstraintsBeyondTextIdIndex()
+    ) {
+      return listOf(ArbigentDeviceEvent.Unsupported("tapOn $selector (${command.describeExtras()})", timestamp))
     }
     return listOf(
       ArbigentDeviceEvent.TapElement(
@@ -205,13 +219,19 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
     )
   }
   stopAppCommand?.let { return listOf(ArbigentDeviceEvent.StopApp(it.appId, timestamp)) }
-  killAppCommand?.let { return listOf(ArbigentDeviceEvent.StopApp(it.appId, timestamp)) }
+  // killApp asks the driver to kill the process without clearing tasks, which `am force-stop`
+  // does not reproduce exactly, so it is left to the AI fallback.
+  killAppCommand?.let { return listOf(ArbigentDeviceEvent.Unsupported("killApp ${it.appId}", timestamp)) }
   clearStateCommand?.let { return listOf(ArbigentDeviceEvent.ClearState(it.appId, timestamp)) }
   openLinkCommand?.let { return listOf(ArbigentDeviceEvent.OpenLink(it.link, timestamp)) }
   scrollCommand?.let {
     return listOf(swipeEvent(SwipeDirection.UP, SCROLL_DURATION_MS, screenWidth, screenHeight, timestamp))
   }
   swipeCommand?.let { command ->
+    // A swipe that starts on an element depends on where that element is at replay time.
+    if (command.elementSelector != null) {
+      return listOf(ArbigentDeviceEvent.Unsupported("swipe from element ${command.elementSelector}", timestamp))
+    }
     val start = command.startPoint
     val end = command.endPoint
     if (start != null && end != null) {
@@ -357,3 +377,16 @@ private fun Any.toJsonPrimitive(): JsonPrimitive = when (this) {
   is Number -> JsonPrimitive(this)
   else -> JsonPrimitive(toString())
 }
+
+/** True when the selector narrows the match by anything other than text, id and index. */
+private fun ElementSelector.hasConstraintsBeyondTextIdIndex(): Boolean =
+  size != null || below != null || above != null || leftOf != null || rightOf != null ||
+    containsChild != null || containsDescendants != null || childOf != null || traits != null ||
+    enabled != null || selected != null || checked != null || focused != null || css != null
+
+private fun TapOnElementCommand.describeExtras(): String = buildList {
+  if (longPress == true) add("longPress")
+  if (repeat != null) add("repeat")
+  if (relativePoint != null) add("relativePoint")
+  if (selector.hasConstraintsBeyondTextIdIndex()) add("constrained selector")
+}.joinToString(", ")

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
@@ -1,0 +1,331 @@
+package io.github.takahirom.arbigent
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonPrimitive
+import maestro.KeyCode
+import maestro.SwipeDirection
+import maestro.orchestra.MaestroCommand
+
+/**
+ * A single low-level interaction Arbigent sent to the device, recorded at the point where the
+ * device layer hands it to Maestro.
+ *
+ * The point of recording here rather than at the agent-action layer is fidelity: one agent action
+ * can expand into several device commands (a D-pad focus walk is many key presses), and only the
+ * device layer knows what was really sent. Each event is expressed in terms an `adb` user can
+ * reproduce, so a replay script needs no Arbigent and no Maestro.
+ */
+@ArbigentInternalApi
+@Serializable
+public sealed interface ArbigentDeviceEvent {
+  /** Epoch milliseconds, from [TimeProvider], so tests can pin it. */
+  public val timestamp: Long
+
+  @Serializable
+  @SerialName("tap")
+  public data class Tap(
+    val x: Int,
+    val y: Int,
+    override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
+  ) : ArbigentDeviceEvent
+
+  /** [keyName] is an Android `KEYCODE_*` name, ready for `adb shell input keyevent`. */
+  @Serializable
+  @SerialName("key_press")
+  public data class KeyPress(
+    val keyName: String,
+    override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
+  ) : ArbigentDeviceEvent
+
+  @Serializable
+  @SerialName("input_text")
+  public data class InputText(
+    val text: String,
+    override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
+  ) : ArbigentDeviceEvent
+
+  @Serializable
+  @SerialName("swipe")
+  public data class Swipe(
+    val startX: Int,
+    val startY: Int,
+    val endX: Int,
+    val endY: Int,
+    val durationMs: Long,
+    override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
+  ) : ArbigentDeviceEvent
+
+  /**
+   * [launchArguments] are the intent extras the app was started with, typed as JSON primitives so a
+   * replay can pass each one through the matching `am start` flag. An app that reads a launch extra
+   * to decide what to show (a test-only entry point, a first-run flow) starts somewhere else without
+   * them, and every later step then diverges.
+   */
+  @Serializable
+  @SerialName("launch_app")
+  public data class LaunchApp(
+    val appId: String,
+    val clearState: Boolean = false,
+    val launchArguments: Map<String, JsonPrimitive> = emptyMap(),
+    override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
+  ) : ArbigentDeviceEvent
+
+  @Serializable
+  @SerialName("stop_app")
+  public data class StopApp(
+    val appId: String,
+    override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
+  ) : ArbigentDeviceEvent
+
+  @Serializable
+  @SerialName("clear_state")
+  public data class ClearState(
+    val appId: String,
+    override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
+  ) : ArbigentDeviceEvent
+
+  @Serializable
+  @SerialName("wait")
+  public data class Wait(
+    val millis: Long,
+    override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
+  ) : ArbigentDeviceEvent
+
+  @Serializable
+  @SerialName("open_link")
+  public data class OpenLink(
+    val url: String,
+    override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
+  ) : ArbigentDeviceEvent
+
+  /**
+   * A command that has no faithful `adb` equivalent. Recorded rather than dropped so a replay stops
+   * at the point where it would silently diverge instead of carrying on against a wrong screen.
+   */
+  @Serializable
+  @SerialName("unsupported")
+  public data class Unsupported(
+    val command: String,
+    override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
+  ) : ArbigentDeviceEvent
+}
+
+/** Receives every [ArbigentDeviceEvent] a device emits, on the thread that sent the command. */
+@ArbigentInternalApi
+public fun interface ArbigentDeviceEventListener {
+  public fun onDeviceEvent(event: ArbigentDeviceEvent)
+}
+
+/**
+ * Translates one Maestro command into the device events it will actually perform.
+ *
+ * Gestures Maestro expresses relative to the screen (scroll, directional swipe) are resolved into
+ * absolute pixels here using [screenWidth]/[screenHeight], because the replay script only has
+ * `adb shell input swipe`, which takes pixels. The fractions mirror Maestro's own AndroidDriver
+ * (verified against the pinned Maestro release), so a replayed swipe covers the same distance the
+ * recorded run did.
+ */
+internal fun MaestroCommand.toArbigentDeviceEvents(
+  screenWidth: Int,
+  screenHeight: Int,
+  timestamp: Long = TimeProvider.get().currentTimeMillis(),
+): List<ArbigentDeviceEvent> {
+  tapOnPointV2Command?.let { command ->
+    val point = command.point
+    // Arbigent always issues absolute points; a percentage point would need the driver's own
+    // resolution rules, so it is recorded as a divergence instead of guessed at.
+    if (point.contains('%')) return listOf(ArbigentDeviceEvent.Unsupported("tapOnPointV2 $point", timestamp))
+    val x = point.substringBefore(',').trim().toIntOrNull()
+    val y = point.substringAfter(',', "").trim().toIntOrNull()
+    if (x == null || y == null) {
+      return listOf(ArbigentDeviceEvent.Unsupported("tapOnPointV2 $point", timestamp))
+    }
+    return listOf(ArbigentDeviceEvent.Tap(x, y, timestamp))
+  }
+  tapOnPoint?.let { command ->
+    return listOf(ArbigentDeviceEvent.Tap(command.x, command.y, timestamp))
+  }
+  // Element-relative taps depend on the view hierarchy Maestro saw at the time, which the replay
+  // script cannot reconstruct. The recorded step target tells the reader what to press instead.
+  tapOnElement?.let { command ->
+    val selector = listOfNotNull(
+      command.selector.textRegex?.let { "text=$it" },
+      command.selector.idRegex?.let { "id=$it" },
+    ).joinToString(" ").ifEmpty { "element" }
+    return listOf(ArbigentDeviceEvent.Unsupported("tapOn $selector", timestamp))
+  }
+  backPressCommand?.let { return listOf(ArbigentDeviceEvent.KeyPress("KEYCODE_BACK", timestamp)) }
+  pressKeyCommand?.let { command ->
+    val keyName = command.code.toAndroidKeyName()
+      ?: return listOf(ArbigentDeviceEvent.Unsupported("pressKey ${command.code}", timestamp))
+    return listOf(ArbigentDeviceEvent.KeyPress(keyName, timestamp))
+  }
+  inputTextCommand?.let { return listOf(ArbigentDeviceEvent.InputText(it.text, timestamp)) }
+  eraseTextCommand?.let { command ->
+    val count = command.charactersToErase ?: DEFAULT_CHARACTERS_TO_ERASE
+    return List(count) { ArbigentDeviceEvent.KeyPress("KEYCODE_DEL", timestamp) }
+  }
+  launchAppCommand?.let { command ->
+    return listOf(
+      ArbigentDeviceEvent.LaunchApp(
+        appId = command.appId,
+        clearState = command.clearState == true,
+        launchArguments = command.launchArguments.orEmpty().mapValues { (_, value) -> value.toJsonPrimitive() },
+        timestamp = timestamp,
+      )
+    )
+  }
+  stopAppCommand?.let { return listOf(ArbigentDeviceEvent.StopApp(it.appId, timestamp)) }
+  killAppCommand?.let { return listOf(ArbigentDeviceEvent.StopApp(it.appId, timestamp)) }
+  clearStateCommand?.let { return listOf(ArbigentDeviceEvent.ClearState(it.appId, timestamp)) }
+  openLinkCommand?.let { return listOf(ArbigentDeviceEvent.OpenLink(it.link, timestamp)) }
+  scrollCommand?.let {
+    return listOf(swipeEvent(SwipeDirection.UP, SCROLL_DURATION_MS, screenWidth, screenHeight, timestamp))
+  }
+  swipeCommand?.let { command ->
+    val start = command.startPoint
+    val end = command.endPoint
+    if (start != null && end != null) {
+      return listOf(
+        ArbigentDeviceEvent.Swipe(start.x, start.y, end.x, end.y, command.duration, timestamp)
+      )
+    }
+    val startRelative = command.startRelative
+    val endRelative = command.endRelative
+    if (startRelative != null && endRelative != null) {
+      val startPoint = parseRelativePoint(startRelative, screenWidth, screenHeight)
+      val endPoint = parseRelativePoint(endRelative, screenWidth, screenHeight)
+      if (startPoint == null || endPoint == null) {
+        return listOf(
+          ArbigentDeviceEvent.Unsupported("swipe $startRelative -> $endRelative", timestamp)
+        )
+      }
+      return listOf(
+        ArbigentDeviceEvent.Swipe(
+          startPoint.first, startPoint.second, endPoint.first, endPoint.second,
+          command.duration, timestamp,
+        )
+      )
+    }
+    val direction = command.direction
+      ?: return listOf(ArbigentDeviceEvent.Unsupported("swipe $command", timestamp))
+    return listOf(swipeEvent(direction, command.duration, screenWidth, screenHeight, timestamp))
+  }
+  waitForAnimationToEndCommand?.let { command ->
+    val millis = command.timeout?.toLongOrNull() ?: DEFAULT_ANIMATION_WAIT_MS
+    return listOf(ArbigentDeviceEvent.Wait(millis, timestamp))
+  }
+  // Screenshots are Arbigent's own observation of the device, not something a replay has to redo.
+  takeScreenshotCommand?.let { return emptyList() }
+  hideKeyboardCommand?.let { return listOf(ArbigentDeviceEvent.Unsupported("hideKeyboard", timestamp)) }
+  return listOf(ArbigentDeviceEvent.Unsupported(describeUnknown(), timestamp))
+}
+
+private const val DEFAULT_CHARACTERS_TO_ERASE = 50
+
+/** Maestro's own default when `waitForAnimationToEnd` carries no timeout. */
+private const val DEFAULT_ANIMATION_WAIT_MS = 5000L
+
+/** Maestro's AndroidDriver scrolls with a fixed-duration directional swipe. */
+private const val SCROLL_DURATION_MS = 400L
+
+private fun MaestroCommand.describeUnknown(): String =
+  runCatching { description() }.getOrNull() ?: toString()
+
+/**
+ * The start and end points Maestro's AndroidDriver uses for each swipe direction, as fractions of
+ * the screen. Taken from the pinned Maestro release rather than assumed, because a swipe that
+ * starts in the wrong half scrolls the wrong list.
+ */
+private fun swipeEvent(
+  direction: SwipeDirection,
+  durationMs: Long,
+  screenWidth: Int,
+  screenHeight: Int,
+  timestamp: Long,
+): ArbigentDeviceEvent {
+  val fractions = when (direction) {
+    SwipeDirection.UP -> listOf(0.5f, 0.5f, 0.5f, 0.1f)
+    SwipeDirection.DOWN -> listOf(0.5f, 0.2f, 0.5f, 0.9f)
+    SwipeDirection.RIGHT -> listOf(0.1f, 0.5f, 0.9f, 0.5f)
+    SwipeDirection.LEFT -> listOf(0.9f, 0.5f, 0.1f, 0.5f)
+  }
+  return ArbigentDeviceEvent.Swipe(
+    startX = (screenWidth * fractions[0]).toInt(),
+    startY = (screenHeight * fractions[1]).toInt(),
+    endX = (screenWidth * fractions[2]).toInt(),
+    endY = (screenHeight * fractions[3]).toInt(),
+    durationMs = durationMs,
+    timestamp = timestamp,
+  )
+}
+
+private fun parseRelativePoint(
+  relative: String,
+  screenWidth: Int,
+  screenHeight: Int,
+): Pair<Int, Int>? {
+  val parts = relative.split(",")
+  if (parts.size != 2) return null
+  val xPercent = parts[0].trim().removeSuffix("%").toFloatOrNull() ?: return null
+  val yPercent = parts[1].trim().removeSuffix("%").toFloatOrNull() ?: return null
+  return (screenWidth * xPercent / 100f).toInt() to (screenHeight * yPercent / 100f).toInt()
+}
+
+/**
+ * The event a single Maestro key press performs. Used by the D-pad focus walk, which presses keys
+ * through Maestro directly instead of going through a [MaestroCommand].
+ */
+internal fun arbigentKeyPressEvent(
+  code: KeyCode,
+  timestamp: Long = TimeProvider.get().currentTimeMillis(),
+): ArbigentDeviceEvent = code.toAndroidKeyName()
+  ?.let { ArbigentDeviceEvent.KeyPress(it, timestamp) }
+  ?: ArbigentDeviceEvent.Unsupported("pressKey $code", timestamp)
+
+/** Android `KEYCODE_*` name for a Maestro key, or null when Android has no equivalent. */
+private fun KeyCode.toAndroidKeyName(): String? = when (this) {
+  KeyCode.ENTER -> "KEYCODE_ENTER"
+  KeyCode.BACKSPACE -> "KEYCODE_DEL"
+  KeyCode.BACK -> "KEYCODE_BACK"
+  KeyCode.HOME -> "KEYCODE_HOME"
+  KeyCode.LOCK -> "KEYCODE_POWER"
+  KeyCode.POWER -> "KEYCODE_POWER"
+  KeyCode.VOLUME_UP -> "KEYCODE_VOLUME_UP"
+  KeyCode.VOLUME_DOWN -> "KEYCODE_VOLUME_DOWN"
+  KeyCode.ESCAPE -> "KEYCODE_ESCAPE"
+  KeyCode.TAB -> "KEYCODE_TAB"
+  KeyCode.REMOTE_UP -> "KEYCODE_DPAD_UP"
+  KeyCode.REMOTE_DOWN -> "KEYCODE_DPAD_DOWN"
+  KeyCode.REMOTE_LEFT -> "KEYCODE_DPAD_LEFT"
+  KeyCode.REMOTE_RIGHT -> "KEYCODE_DPAD_RIGHT"
+  KeyCode.REMOTE_CENTER -> "KEYCODE_DPAD_CENTER"
+  KeyCode.REMOTE_PLAY_PAUSE -> "KEYCODE_MEDIA_PLAY_PAUSE"
+  KeyCode.REMOTE_STOP -> "KEYCODE_MEDIA_STOP"
+  KeyCode.REMOTE_NEXT -> "KEYCODE_MEDIA_NEXT"
+  KeyCode.REMOTE_PREVIOUS -> "KEYCODE_MEDIA_PREVIOUS"
+  KeyCode.REMOTE_REWIND -> "KEYCODE_MEDIA_REWIND"
+  KeyCode.REMOTE_FAST_FORWARD -> "KEYCODE_MEDIA_FAST_FORWARD"
+  KeyCode.REMOTE_SYSTEM_NAVIGATION_UP -> "KEYCODE_SYSTEM_NAVIGATION_UP"
+  KeyCode.REMOTE_SYSTEM_NAVIGATION_DOWN -> "KEYCODE_SYSTEM_NAVIGATION_DOWN"
+  KeyCode.REMOTE_BUTTON_A -> "KEYCODE_BUTTON_A"
+  KeyCode.REMOTE_BUTTON_B -> "KEYCODE_BUTTON_B"
+  KeyCode.REMOTE_MENU -> "KEYCODE_MENU"
+  KeyCode.TV_INPUT -> "KEYCODE_TV_INPUT"
+  KeyCode.TV_INPUT_HDMI_1 -> "KEYCODE_TV_INPUT_HDMI_1"
+  KeyCode.TV_INPUT_HDMI_2 -> "KEYCODE_TV_INPUT_HDMI_2"
+  KeyCode.TV_INPUT_HDMI_3 -> "KEYCODE_TV_INPUT_HDMI_3"
+  else -> null
+}
+
+/**
+ * Maestro types launch arguments loosely as `Any`; the runner needs the kind to pick an `am start`
+ * flag (`--ez`, `--ei`, `--ef`, `--es`), so booleans and numbers keep their JSON type and everything
+ * else travels as text.
+ */
+private fun Any.toJsonPrimitive(): JsonPrimitive = when (this) {
+  is Boolean -> JsonPrimitive(this)
+  is Number -> JsonPrimitive(this)
+  else -> JsonPrimitive(toString())
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
@@ -262,7 +262,7 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
     // The web driver scrolls the document with JavaScript rather than with a gesture, so a swipe
     // does not stand in for it: a page that swallows touch gestures does not move at all.
     if (os.isWeb()) return listOf(ArbigentDeviceEvent.Unsupported("scroll on web", timestamp))
-    return listOf(scrollEvent(screenWidth, screenHeight, timestamp))
+    return listOf(scrollEvent(screenWidth, screenHeight, os, timestamp))
   }
   swipeCommand?.let { command ->
     // A swipe that starts on an element depends on where that element is at replay time.
@@ -314,19 +314,32 @@ private const val DEFAULT_ANIMATION_WAIT_MS = 5000L
 
 /** Maestro's drivers scroll with a fixed-duration directional swipe. */
 private const val SCROLL_DURATION_MS = 400L
+private const val IOS_SCROLL_DURATION_MS = 333L
 
 private fun MaestroCommand.describeUnknown(): String =
   runCatching { description() }.getOrNull() ?: toString()
 
 /**
- * The Android and iOS drivers scroll with the same gesture: `AndroidDriver.scrollVertical` delegates
- * to its own upward swipe and `IOSDriver.scrollVertical` uses these fractions directly, so scrolling
- * stays the same across those two even though an upward *swipe* does not. The web driver is the
- * exception -- it scrolls with JavaScript -- which is why a web scroll is recorded as unsupported
- * rather than sent through here.
+ * The Android and iOS drivers scroll over the same fractions of the screen: `AndroidDriver
+ * .scrollVertical` delegates to its own upward swipe and `IOSDriver.scrollVertical` uses these
+ * fractions directly, so scrolling stays the same across those two even though an upward *swipe*
+ * does not. Only the duration differs -- the pinned Maestro scrolls in 400 ms on Android and 333 ms
+ * on iOS -- and a scroll sent over the wrong duration travels a different distance. The web driver
+ * is the exception -- it scrolls with JavaScript -- which is why a web scroll is recorded as
+ * unsupported rather than sent through here.
  */
-private fun scrollEvent(screenWidth: Int, screenHeight: Int, timestamp: Long): ArbigentDeviceEvent =
-  swipeEvent(listOf(0.5f, 0.5f, 0.5f, 0.1f), SCROLL_DURATION_MS, screenWidth, screenHeight, timestamp)
+private fun scrollEvent(
+  screenWidth: Int,
+  screenHeight: Int,
+  os: ArbigentDeviceOs,
+  timestamp: Long,
+): ArbigentDeviceEvent = swipeEvent(
+  listOf(0.5f, 0.5f, 0.5f, 0.1f),
+  if (os.isIos()) IOS_SCROLL_DURATION_MS else SCROLL_DURATION_MS,
+  screenWidth,
+  screenHeight,
+  timestamp,
+)
 
 /**
  * The start and end points the driver for [os] uses for each swipe direction, as fractions of the

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
@@ -47,7 +47,10 @@ public sealed interface ArbigentDeviceEvent {
     override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
   ) : ArbigentDeviceEvent
 
-  /** [keyName] is an Android `KEYCODE_*` name, ready for `adb shell input keyevent`. */
+  /**
+   * [keyName] is a Maestro `KeyCode` name such as `BACK`, `BACKSPACE` or `REMOTE_UP`.
+   * `KeyPressAgentAction.resolveKeyCode` turns it back into a `KeyCode` on replay.
+   */
   @Serializable
   @SerialName("key_press")
   public data class KeyPress(
@@ -195,16 +198,14 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
       )
     )
   }
-  backPressCommand?.let { return listOf(ArbigentDeviceEvent.KeyPress("KEYCODE_BACK", timestamp)) }
+  backPressCommand?.let { return listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp)) }
   pressKeyCommand?.let { command ->
-    val keyName = command.code.toAndroidKeyName()
-      ?: return listOf(ArbigentDeviceEvent.Unsupported("pressKey ${command.code}", timestamp))
-    return listOf(ArbigentDeviceEvent.KeyPress(keyName, timestamp))
+    return listOf(ArbigentDeviceEvent.KeyPress(command.code.name, timestamp))
   }
   inputTextCommand?.let { return listOf(ArbigentDeviceEvent.InputText(it.text, timestamp)) }
   eraseTextCommand?.let { command ->
     val count = command.charactersToErase ?: DEFAULT_CHARACTERS_TO_ERASE
-    return List(count) { ArbigentDeviceEvent.KeyPress("KEYCODE_DEL", timestamp) }
+    return List(count) { ArbigentDeviceEvent.KeyPress(KeyCode.BACKSPACE.name, timestamp) }
   }
   launchAppCommand?.let { command ->
     return listOf(
@@ -328,44 +329,8 @@ private fun parseRelativePoint(
 internal fun arbigentKeyPressEvent(
   code: KeyCode,
   timestamp: Long = TimeProvider.get().currentTimeMillis(),
-): ArbigentDeviceEvent = code.toAndroidKeyName()
-  ?.let { ArbigentDeviceEvent.KeyPress(it, timestamp) }
-  ?: ArbigentDeviceEvent.Unsupported("pressKey $code", timestamp)
+): ArbigentDeviceEvent = ArbigentDeviceEvent.KeyPress(code.name, timestamp)
 
-/** Android `KEYCODE_*` name for a Maestro key, or null when Android has no equivalent. */
-private fun KeyCode.toAndroidKeyName(): String? = when (this) {
-  KeyCode.ENTER -> "KEYCODE_ENTER"
-  KeyCode.BACKSPACE -> "KEYCODE_DEL"
-  KeyCode.BACK -> "KEYCODE_BACK"
-  KeyCode.HOME -> "KEYCODE_HOME"
-  KeyCode.LOCK -> "KEYCODE_POWER"
-  KeyCode.POWER -> "KEYCODE_POWER"
-  KeyCode.VOLUME_UP -> "KEYCODE_VOLUME_UP"
-  KeyCode.VOLUME_DOWN -> "KEYCODE_VOLUME_DOWN"
-  KeyCode.ESCAPE -> "KEYCODE_ESCAPE"
-  KeyCode.TAB -> "KEYCODE_TAB"
-  KeyCode.REMOTE_UP -> "KEYCODE_DPAD_UP"
-  KeyCode.REMOTE_DOWN -> "KEYCODE_DPAD_DOWN"
-  KeyCode.REMOTE_LEFT -> "KEYCODE_DPAD_LEFT"
-  KeyCode.REMOTE_RIGHT -> "KEYCODE_DPAD_RIGHT"
-  KeyCode.REMOTE_CENTER -> "KEYCODE_DPAD_CENTER"
-  KeyCode.REMOTE_PLAY_PAUSE -> "KEYCODE_MEDIA_PLAY_PAUSE"
-  KeyCode.REMOTE_STOP -> "KEYCODE_MEDIA_STOP"
-  KeyCode.REMOTE_NEXT -> "KEYCODE_MEDIA_NEXT"
-  KeyCode.REMOTE_PREVIOUS -> "KEYCODE_MEDIA_PREVIOUS"
-  KeyCode.REMOTE_REWIND -> "KEYCODE_MEDIA_REWIND"
-  KeyCode.REMOTE_FAST_FORWARD -> "KEYCODE_MEDIA_FAST_FORWARD"
-  KeyCode.REMOTE_SYSTEM_NAVIGATION_UP -> "KEYCODE_SYSTEM_NAVIGATION_UP"
-  KeyCode.REMOTE_SYSTEM_NAVIGATION_DOWN -> "KEYCODE_SYSTEM_NAVIGATION_DOWN"
-  KeyCode.REMOTE_BUTTON_A -> "KEYCODE_BUTTON_A"
-  KeyCode.REMOTE_BUTTON_B -> "KEYCODE_BUTTON_B"
-  KeyCode.REMOTE_MENU -> "KEYCODE_MENU"
-  KeyCode.TV_INPUT -> "KEYCODE_TV_INPUT"
-  KeyCode.TV_INPUT_HDMI_1 -> "KEYCODE_TV_INPUT_HDMI_1"
-  KeyCode.TV_INPUT_HDMI_2 -> "KEYCODE_TV_INPUT_HDMI_2"
-  KeyCode.TV_INPUT_HDMI_3 -> "KEYCODE_TV_INPUT_HDMI_3"
-  else -> null
-}
 
 /**
  * Maestro types launch arguments loosely as `Any`; the runner needs the kind to pick an `am start`

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
@@ -24,11 +24,19 @@ public sealed interface ArbigentDeviceEvent {
   /** Epoch milliseconds, from [TimeProvider], so tests can pin it. */
   public val timestamp: Long
 
+  /**
+   * [retryIfNoChange] is Maestro's own retry on a tap: with it set the driver taps a second time
+   * when the first tap left the hierarchy unchanged. It is kept exactly as the command carried it,
+   * null included, so the replayed tap is given the same number of attempts as the recorded one.
+   * Arbigent's own taps leave it unset, but a Maestro flow used as an initializer is free to set
+   * it, and those commands go through this recorder too.
+   */
   @Serializable
   @SerialName("tap")
   public data class Tap(
     val x: Int,
     val y: Int,
+    val retryIfNoChange: Boolean? = null,
     override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
   ) : ArbigentDeviceEvent
 
@@ -46,6 +54,7 @@ public sealed interface ArbigentDeviceEvent {
     val textRegex: String? = null,
     val idRegex: String? = null,
     val index: Int? = null,
+    val retryIfNoChange: Boolean? = null,
     override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
   ) : ArbigentDeviceEvent
 
@@ -183,10 +192,10 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
     if (x == null || y == null) {
       return listOf(ArbigentDeviceEvent.Unsupported("tapOnPointV2 $point", timestamp))
     }
-    return listOf(ArbigentDeviceEvent.Tap(x, y, timestamp))
+    return listOf(ArbigentDeviceEvent.Tap(x, y, command.retryIfNoChange, timestamp))
   }
   tapOnPoint?.let { command ->
-    return listOf(ArbigentDeviceEvent.Tap(command.x, command.y, timestamp))
+    return listOf(ArbigentDeviceEvent.Tap(command.x, command.y, command.retryIfNoChange, timestamp))
   }
   // Element taps are how the agent clicks by text or id, so they are the common case on phones.
   // Only a selector with something a hierarchy dump can be searched for is replayable.
@@ -209,6 +218,7 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
         textRegex = selector.textRegex,
         idRegex = selector.idRegex,
         index = selector.index?.toDoubleOrNull()?.toInt(),
+        retryIfNoChange = command.retryIfNoChange,
         timestamp = timestamp,
       )
     )

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
@@ -145,10 +145,14 @@ public fun interface ArbigentDeviceEventListener {
  * Translates one Maestro command into the device events it will actually perform.
  *
  * Gestures Maestro expresses relative to the screen (scroll, directional swipe) are resolved into
- * absolute pixels here using [screenWidth]/[screenHeight], because the replay script only has
- * `adb shell input swipe`, which takes pixels. The fractions mirror Maestro's own AndroidDriver
+ * absolute coordinates here using [screenWidth]/[screenHeight], so that a recorded event says where
+ * it landed rather than what it was named. The fractions mirror Maestro's own AndroidDriver
  * (verified against the pinned Maestro release), so a replayed swipe covers the same distance the
  * recorded run did.
+ *
+ * [screenWidth]/[screenHeight] are grid units — the space the drivers compute coordinates in and the
+ * space [ArbigentElementList] reports bounds in — because replay scales the recorded coordinates
+ * against the screen size of whatever device it is replaying on.
  */
 internal fun MaestroCommand.toArbigentDeviceEvents(
   screenWidth: Int,

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
@@ -86,6 +86,13 @@ public sealed interface ArbigentDeviceEvent {
    *
    * [stopApp] mirrors Maestro's default of force-stopping the app before starting it, so a replay
    * starts a fresh process the way the recorded run did instead of resuming whatever was left.
+   *
+   * [permissions] and [clearKeychain] stay null when the recorded launch did not set them, because
+   * Maestro fills in its own defaults for a launch that omits them (`{all: allow}` for permissions)
+   * and a replay has to leave that to Maestro rather than freeze today's default into the log. A
+   * recorded run that did set them asked for something other than the default -- a denied
+   * permission the flow depends on, an iOS keychain reset -- and a replay that dropped it would
+   * start the app in a different state.
    */
   @Serializable
   @SerialName("launch_app")
@@ -94,6 +101,8 @@ public sealed interface ArbigentDeviceEvent {
     val clearState: Boolean = false,
     val stopApp: Boolean = true,
     val launchArguments: Map<String, JsonPrimitive> = emptyMap(),
+    val permissions: Map<String, String>? = null,
+    val clearKeychain: Boolean? = null,
     override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
   ) : ArbigentDeviceEvent
 
@@ -204,7 +213,13 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
       )
     )
   }
-  backPressCommand?.let { return listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp)) }
+  backPressCommand?.let {
+    // Android and iOS drivers press the platform back key, which a replayed key press reproduces.
+    // The web driver navigates the browser history instead and its key mapper rejects BACK
+    // outright, so recording a key press there would fail the replay at this step.
+    if (os.isWeb()) return listOf(ArbigentDeviceEvent.Unsupported("back on web", timestamp))
+    return listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp))
+  }
   pressKeyCommand?.let { command ->
     return listOf(ArbigentDeviceEvent.KeyPress(command.code.name, timestamp))
   }
@@ -221,6 +236,8 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
         // Maestro treats a missing stopApp as true.
         stopApp = command.stopApp != false,
         launchArguments = command.launchArguments.orEmpty().mapValues { (_, value) -> value.toJsonPrimitive() },
+        permissions = command.permissions,
+        clearKeychain = command.clearKeychain,
         timestamp = timestamp,
       )
     )
@@ -232,6 +249,9 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
   clearStateCommand?.let { return listOf(ArbigentDeviceEvent.ClearState(it.appId, timestamp)) }
   openLinkCommand?.let { return listOf(ArbigentDeviceEvent.OpenLink(it.link, timestamp)) }
   scrollCommand?.let {
+    // The web driver scrolls the document with JavaScript rather than with a gesture, so a swipe
+    // does not stand in for it: a page that swallows touch gestures does not move at all.
+    if (os.isWeb()) return listOf(ArbigentDeviceEvent.Unsupported("scroll on web", timestamp))
     return listOf(scrollEvent(screenWidth, screenHeight, timestamp))
   }
   swipeCommand?.let { command ->
@@ -289,9 +309,11 @@ private fun MaestroCommand.describeUnknown(): String =
   runCatching { description() }.getOrNull() ?: toString()
 
 /**
- * Both drivers scroll with the same gesture: `AndroidDriver.scrollVertical` delegates to its own
- * upward swipe and `IOSDriver.scrollVertical` uses these fractions directly, so scrolling stays
- * platform independent even though an upward *swipe* does not.
+ * The Android and iOS drivers scroll with the same gesture: `AndroidDriver.scrollVertical` delegates
+ * to its own upward swipe and `IOSDriver.scrollVertical` uses these fractions directly, so scrolling
+ * stays the same across those two even though an upward *swipe* does not. The web driver is the
+ * exception -- it scrolls with JavaScript -- which is why a web scroll is recorded as unsupported
+ * rather than sent through here.
  */
 private fun scrollEvent(screenWidth: Int, screenHeight: Int, timestamp: Long): ArbigentDeviceEvent =
   swipeEvent(listOf(0.5f, 0.5f, 0.5f, 0.1f), SCROLL_DURATION_MS, screenWidth, screenHeight, timestamp)

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDeviceEvents.kt
@@ -36,14 +36,16 @@ public sealed interface ArbigentDeviceEvent {
    * A tap on an element Maestro located by text or resource id at the time. The selector is kept
    * so a replay can find the element again in the current hierarchy and press its center, since the
    * pixel it landed on in the recorded run is only right while the layout has not moved. [index] is
-   * the zero-based position among the matches, as Maestro counts them.
+   * the zero-based position among the matches, as Maestro counts them; null means the recorded
+   * command carried no index, which is Maestro's "first clickable match" selection rather than the
+   * first match, so the two must stay distinguishable.
    */
   @Serializable
   @SerialName("tap_element")
   public data class TapElement(
     val textRegex: String? = null,
     val idRegex: String? = null,
-    val index: Int = 0,
+    val index: Int? = null,
     override val timestamp: Long = TimeProvider.get().currentTimeMillis(),
   ) : ArbigentDeviceEvent
 
@@ -146,9 +148,8 @@ public fun interface ArbigentDeviceEventListener {
  *
  * Gestures Maestro expresses relative to the screen (scroll, directional swipe) are resolved into
  * absolute coordinates here using [screenWidth]/[screenHeight], so that a recorded event says where
- * it landed rather than what it was named. The fractions mirror Maestro's own AndroidDriver
- * (verified against the pinned Maestro release), so a replayed swipe covers the same distance the
- * recorded run did.
+ * it landed rather than what it was named. The fractions are taken from the driver [os] selects in
+ * the pinned Maestro release, so a replayed swipe covers the same distance the recorded run did.
  *
  * [screenWidth]/[screenHeight] are grid units — the space the drivers compute coordinates in and the
  * space [ArbigentElementList] reports bounds in — because replay scales the recorded coordinates
@@ -157,6 +158,7 @@ public fun interface ArbigentDeviceEventListener {
 internal fun MaestroCommand.toArbigentDeviceEvents(
   screenWidth: Int,
   screenHeight: Int,
+  os: ArbigentDeviceOs,
   timestamp: Long = TimeProvider.get().currentTimeMillis(),
 ): List<ArbigentDeviceEvent> {
   tapOnPointV2Command?.let { command ->
@@ -197,7 +199,7 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
       ArbigentDeviceEvent.TapElement(
         textRegex = selector.textRegex,
         idRegex = selector.idRegex,
-        index = selector.index?.toIntOrNull() ?: 0,
+        index = selector.index?.toDoubleOrNull()?.toInt(),
         timestamp = timestamp,
       )
     )
@@ -230,7 +232,7 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
   clearStateCommand?.let { return listOf(ArbigentDeviceEvent.ClearState(it.appId, timestamp)) }
   openLinkCommand?.let { return listOf(ArbigentDeviceEvent.OpenLink(it.link, timestamp)) }
   scrollCommand?.let {
-    return listOf(swipeEvent(SwipeDirection.UP, SCROLL_DURATION_MS, screenWidth, screenHeight, timestamp))
+    return listOf(scrollEvent(screenWidth, screenHeight, timestamp))
   }
   swipeCommand?.let { command ->
     // A swipe that starts on an element depends on where that element is at replay time.
@@ -263,7 +265,7 @@ internal fun MaestroCommand.toArbigentDeviceEvents(
     }
     val direction = command.direction
       ?: return listOf(ArbigentDeviceEvent.Unsupported("swipe $command", timestamp))
-    return listOf(swipeEvent(direction, command.duration, screenWidth, screenHeight, timestamp))
+    return listOf(swipeEvent(direction, command.duration, screenWidth, screenHeight, os, timestamp))
   }
   waitForAnimationToEndCommand?.let { command ->
     val millis = command.timeout?.toLongOrNull() ?: DEFAULT_ANIMATION_WAIT_MS
@@ -280,39 +282,57 @@ private const val DEFAULT_CHARACTERS_TO_ERASE = 50
 /** Maestro's own default when `waitForAnimationToEnd` carries no timeout. */
 private const val DEFAULT_ANIMATION_WAIT_MS = 5000L
 
-/** Maestro's AndroidDriver scrolls with a fixed-duration directional swipe. */
+/** Maestro's drivers scroll with a fixed-duration directional swipe. */
 private const val SCROLL_DURATION_MS = 400L
 
 private fun MaestroCommand.describeUnknown(): String =
   runCatching { description() }.getOrNull() ?: toString()
 
 /**
- * The start and end points Maestro's AndroidDriver uses for each swipe direction, as fractions of
- * the screen. Taken from the pinned Maestro release rather than assumed, because a swipe that
- * starts in the wrong half scrolls the wrong list.
+ * Both drivers scroll with the same gesture: `AndroidDriver.scrollVertical` delegates to its own
+ * upward swipe and `IOSDriver.scrollVertical` uses these fractions directly, so scrolling stays
+ * platform independent even though an upward *swipe* does not.
+ */
+private fun scrollEvent(screenWidth: Int, screenHeight: Int, timestamp: Long): ArbigentDeviceEvent =
+  swipeEvent(listOf(0.5f, 0.5f, 0.5f, 0.1f), SCROLL_DURATION_MS, screenWidth, screenHeight, timestamp)
+
+/**
+ * The start and end points the driver for [os] uses for each swipe direction, as fractions of the
+ * screen. Taken from the pinned Maestro release rather than assumed, because a swipe that starts in
+ * the wrong half scrolls the wrong list: the iOS driver starts an upward swipe near the bottom of
+ * the screen while the Android one starts at the middle.
  */
 private fun swipeEvent(
   direction: SwipeDirection,
   durationMs: Long,
   screenWidth: Int,
   screenHeight: Int,
+  os: ArbigentDeviceOs,
   timestamp: Long,
 ): ArbigentDeviceEvent {
   val fractions = when (direction) {
-    SwipeDirection.UP -> listOf(0.5f, 0.5f, 0.5f, 0.1f)
+    SwipeDirection.UP -> if (os.isIos()) listOf(0.5f, 0.9f, 0.5f, 0.1f) else listOf(0.5f, 0.5f, 0.5f, 0.1f)
     SwipeDirection.DOWN -> listOf(0.5f, 0.2f, 0.5f, 0.9f)
     SwipeDirection.RIGHT -> listOf(0.1f, 0.5f, 0.9f, 0.5f)
     SwipeDirection.LEFT -> listOf(0.9f, 0.5f, 0.1f, 0.5f)
   }
-  return ArbigentDeviceEvent.Swipe(
-    startX = (screenWidth * fractions[0]).toInt(),
-    startY = (screenHeight * fractions[1]).toInt(),
-    endX = (screenWidth * fractions[2]).toInt(),
-    endY = (screenHeight * fractions[3]).toInt(),
-    durationMs = durationMs,
-    timestamp = timestamp,
-  )
+  return swipeEvent(fractions, durationMs, screenWidth, screenHeight, timestamp)
 }
+
+private fun swipeEvent(
+  fractions: List<Float>,
+  durationMs: Long,
+  screenWidth: Int,
+  screenHeight: Int,
+  timestamp: Long,
+): ArbigentDeviceEvent = ArbigentDeviceEvent.Swipe(
+  startX = (screenWidth * fractions[0]).toInt(),
+  startY = (screenHeight * fractions[1]).toInt(),
+  endX = (screenWidth * fractions[2]).toInt(),
+  endY = (screenHeight * fractions[3]).toInt(),
+  durationMs = durationMs,
+  timestamp = timestamp,
+)
 
 private fun parseRelativePoint(
   relative: String,

--- a/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
+++ b/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
@@ -9,11 +9,13 @@ import kotlinx.serialization.json.JsonPrimitive
 import maestro.KeyCode
 import maestro.Point
 import maestro.SwipeDirection
+import maestro.TapRepeat
 import maestro.orchestra.BackPressCommand
 import maestro.orchestra.ClearStateCommand
 import maestro.orchestra.ElementSelector
 import maestro.orchestra.EraseTextCommand
 import maestro.orchestra.InputTextCommand
+import maestro.orchestra.KillAppCommand
 import maestro.orchestra.LaunchAppCommand
 import maestro.orchestra.MaestroCommand
 import maestro.orchestra.OpenLinkCommand
@@ -193,5 +195,50 @@ class ArbigentDeviceEventsTest {
   fun `a screenshot is arbigent's own observation and is not replayed`() {
     val command = MaestroCommand(takeScreenshotCommand = TakeScreenshotCommand(path = "shot"))
     assertEquals(emptyList(), command.events())
+  }
+
+  @Test
+  fun `taps that are not a plain single tap are unsupported instead of downgraded`() {
+    val plain = TapOnElementCommand(selector = ElementSelector(textRegex = "Settings"))
+    assertTrue(plain.let { MaestroCommand(tapOnElement = it) }.events().single() is ArbigentDeviceEvent.TapElement)
+    listOf(
+      plain.copy(longPress = true),
+      plain.copy(repeat = TapRepeat(2, 100L)),
+      plain.copy(relativePoint = "50%,50%"),
+      plain.copy(selector = ElementSelector(textRegex = "Settings", below = ElementSelector(textRegex = "Account"))),
+      plain.copy(selector = ElementSelector(textRegex = "Settings", enabled = true)),
+      plain.copy(selector = ElementSelector(idRegex = "row", childOf = ElementSelector(idRegex = "list"))),
+    ).forEach { command ->
+      assertTrue(
+        MaestroCommand(tapOnElement = command).events().single() is ArbigentDeviceEvent.Unsupported,
+        "a replay can only tap the first text/id match once, so $command must fall back to the AI",
+      )
+    }
+    assertTrue(
+      MaestroCommand(tapOnPointV2Command = TapOnPointV2Command(point = "10,20", longPress = true))
+        .events().single() is ArbigentDeviceEvent.Unsupported
+    )
+    assertTrue(
+      MaestroCommand(tapOnPointV2Command = TapOnPointV2Command(point = "10,20", repeat = TapRepeat(3, 50L)))
+        .events().single() is ArbigentDeviceEvent.Unsupported
+    )
+  }
+
+  @Test
+  fun `a swipe anchored on an element is unsupported`() {
+    val command = MaestroCommand(
+      swipeCommand = SwipeCommand(
+        direction = SwipeDirection.UP,
+        elementSelector = ElementSelector(idRegex = "list"),
+        duration = 400L,
+      )
+    )
+    assertTrue(command.events().single() is ArbigentDeviceEvent.Unsupported)
+  }
+
+  @Test
+  fun `kill app is not the same as force-stop and is left to the fallback`() {
+    val events = MaestroCommand(killAppCommand = KillAppCommand(appId = "com.example.app")).events()
+    assertTrue(events.single() is ArbigentDeviceEvent.Unsupported)
   }
 }

--- a/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
+++ b/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
@@ -1,0 +1,167 @@
+package io.github.takahirom.arbigent.sample.test
+
+import io.github.takahirom.arbigent.ArbigentDeviceEvent
+import io.github.takahirom.arbigent.toArbigentDeviceEvents
+import kotlinx.serialization.json.JsonPrimitive
+import maestro.KeyCode
+import maestro.Point
+import maestro.SwipeDirection
+import maestro.orchestra.BackPressCommand
+import maestro.orchestra.ClearStateCommand
+import maestro.orchestra.EraseTextCommand
+import maestro.orchestra.InputTextCommand
+import maestro.orchestra.LaunchAppCommand
+import maestro.orchestra.MaestroCommand
+import maestro.orchestra.OpenLinkCommand
+import maestro.orchestra.PressKeyCommand
+import maestro.orchestra.ScrollCommand
+import maestro.orchestra.StopAppCommand
+import maestro.orchestra.SwipeCommand
+import maestro.orchestra.TakeScreenshotCommand
+import maestro.orchestra.TapOnPointV2Command
+import maestro.orchestra.WaitForAnimationToEndCommand
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val WIDTH = 1080
+private const val HEIGHT = 1920
+private const val TS = 42L
+
+private fun MaestroCommand.events(): List<ArbigentDeviceEvent> =
+  toArbigentDeviceEvents(WIDTH, HEIGHT, TS)
+
+class ArbigentDeviceEventsTest {
+  @Test
+  fun `tap on point becomes a tap`() {
+    val events = MaestroCommand(tapOnPointV2Command = TapOnPointV2Command(point = "120,340")).events()
+    assertEquals(listOf(ArbigentDeviceEvent.Tap(120, 340, TS)), events)
+  }
+
+  @Test
+  fun `a percentage tap point is unsupported because the driver resolves it, not us`() {
+    val events = MaestroCommand(tapOnPointV2Command = TapOnPointV2Command(point = "50%,50%")).events()
+    assertTrue(events.single() is ArbigentDeviceEvent.Unsupported)
+  }
+
+  @Test
+  fun `maestro keys become android keyevent names`() {
+    fun keyName(code: KeyCode): String {
+      val event = MaestroCommand(pressKeyCommand = PressKeyCommand(code)).events().single()
+      return (event as ArbigentDeviceEvent.KeyPress).keyName
+    }
+    assertEquals("KEYCODE_DPAD_UP", keyName(KeyCode.REMOTE_UP))
+    assertEquals("KEYCODE_DPAD_CENTER", keyName(KeyCode.REMOTE_CENTER))
+    assertEquals("KEYCODE_DEL", keyName(KeyCode.BACKSPACE))
+    assertEquals("KEYCODE_POWER", keyName(KeyCode.LOCK))
+    assertEquals("KEYCODE_MEDIA_PLAY_PAUSE", keyName(KeyCode.REMOTE_PLAY_PAUSE))
+    assertEquals("KEYCODE_MENU", keyName(KeyCode.REMOTE_MENU))
+    assertEquals("KEYCODE_ENTER", keyName(KeyCode.ENTER))
+  }
+
+  @Test
+  fun `back press becomes the back key`() {
+    val events = MaestroCommand(backPressCommand = BackPressCommand()).events()
+    assertEquals(listOf(ArbigentDeviceEvent.KeyPress("KEYCODE_BACK", TS)), events)
+  }
+
+  @Test
+  fun `input text is carried through`() {
+    val events = MaestroCommand(inputTextCommand = InputTextCommand("hello world")).events()
+    assertEquals(listOf(ArbigentDeviceEvent.InputText("hello world", TS)), events)
+  }
+
+  @Test
+  fun `erase text becomes one delete per character`() {
+    val events = MaestroCommand(eraseTextCommand = EraseTextCommand(charactersToErase = 3)).events()
+    assertEquals(List(3) { ArbigentDeviceEvent.KeyPress("KEYCODE_DEL", TS) }, events)
+  }
+
+  @Test
+  fun `app lifecycle commands map to their app ids`() {
+    assertEquals(
+      listOf(ArbigentDeviceEvent.LaunchApp("com.example.app", clearState = true, timestamp = TS)),
+      MaestroCommand(
+        launchAppCommand = LaunchAppCommand(appId = "com.example.app", clearState = true)
+      ).events(),
+    )
+    assertEquals(
+      listOf(ArbigentDeviceEvent.StopApp("com.example.app", TS)),
+      MaestroCommand(stopAppCommand = StopAppCommand(appId = "com.example.app")).events(),
+    )
+    assertEquals(
+      listOf(
+        ArbigentDeviceEvent.LaunchApp(
+          "com.example.app",
+          launchArguments = mapOf(
+            "debug_menu" to JsonPrimitive(true),
+            "retries" to JsonPrimitive(3),
+            "entry" to JsonPrimitive("settings"),
+          ),
+          timestamp = TS,
+        )
+      ),
+      MaestroCommand(
+        launchAppCommand = LaunchAppCommand(
+          appId = "com.example.app",
+          launchArguments = mapOf("debug_menu" to true, "retries" to 3, "entry" to "settings"),
+        )
+      ).events(),
+      "launch extras decide what some apps show first, so they have to survive into the log",
+    )
+    assertEquals(
+      listOf(ArbigentDeviceEvent.ClearState("com.example.app", TS)),
+      MaestroCommand(clearStateCommand = ClearStateCommand(appId = "com.example.app")).events(),
+    )
+  }
+
+  @Test
+  fun `open link carries the url`() {
+    val events = MaestroCommand(openLinkCommand = OpenLinkCommand(link = "https://example.com")).events()
+    assertEquals(listOf(ArbigentDeviceEvent.OpenLink("https://example.com", TS)), events)
+  }
+
+  @Test
+  fun `a scroll is the same upward swipe maestro performs`() {
+    val events = MaestroCommand(scrollCommand = ScrollCommand()).events()
+    assertEquals(
+      listOf(ArbigentDeviceEvent.Swipe(540, 960, 540, 192, 400L, TS)),
+      events,
+    )
+  }
+
+  @Test
+  fun `each swipe direction keeps maestro's own start and end points`() {
+    fun swipe(direction: SwipeDirection): ArbigentDeviceEvent.Swipe {
+      val command = MaestroCommand(swipeCommand = SwipeCommand(direction = direction, duration = 500L))
+      return command.events().single() as ArbigentDeviceEvent.Swipe
+    }
+    assertEquals(ArbigentDeviceEvent.Swipe(540, 960, 540, 192, 500L, TS), swipe(SwipeDirection.UP))
+    assertEquals(ArbigentDeviceEvent.Swipe(540, 384, 540, 1728, 500L, TS), swipe(SwipeDirection.DOWN))
+    assertEquals(ArbigentDeviceEvent.Swipe(108, 960, 972, 960, 500L, TS), swipe(SwipeDirection.RIGHT))
+    assertEquals(ArbigentDeviceEvent.Swipe(972, 960, 108, 960, 500L, TS), swipe(SwipeDirection.LEFT))
+  }
+
+  @Test
+  fun `an explicit swipe keeps its own points`() {
+    val command = MaestroCommand(
+      swipeCommand = SwipeCommand(startPoint = Point(10, 20), endPoint = Point(30, 40), duration = 250L)
+    )
+    assertEquals(
+      listOf(ArbigentDeviceEvent.Swipe(10, 20, 30, 40, 250L, TS)),
+      command.events(),
+    )
+  }
+
+  @Test
+  fun `waiting for an animation becomes a wait`() {
+    val command = MaestroCommand(waitForAnimationToEndCommand = WaitForAnimationToEndCommand(timeout = "100"))
+    assertEquals(listOf(ArbigentDeviceEvent.Wait(100L, TS)), command.events())
+  }
+
+  @Test
+  fun `a screenshot is arbigent's own observation and is not replayed`() {
+    val command = MaestroCommand(takeScreenshotCommand = TakeScreenshotCommand(path = "shot"))
+    assertEquals(emptyList(), command.events())
+  }
+}

--- a/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
+++ b/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
@@ -2,12 +2,16 @@ package io.github.takahirom.arbigent.sample.test
 
 import io.github.takahirom.arbigent.ArbigentDeviceEvent
 import io.github.takahirom.arbigent.toArbigentDeviceEvents
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 import kotlinx.serialization.json.JsonPrimitive
 import maestro.KeyCode
 import maestro.Point
 import maestro.SwipeDirection
 import maestro.orchestra.BackPressCommand
 import maestro.orchestra.ClearStateCommand
+import maestro.orchestra.ElementSelector
 import maestro.orchestra.EraseTextCommand
 import maestro.orchestra.InputTextCommand
 import maestro.orchestra.LaunchAppCommand
@@ -18,11 +22,9 @@ import maestro.orchestra.ScrollCommand
 import maestro.orchestra.StopAppCommand
 import maestro.orchestra.SwipeCommand
 import maestro.orchestra.TakeScreenshotCommand
+import maestro.orchestra.TapOnElementCommand
 import maestro.orchestra.TapOnPointV2Command
 import maestro.orchestra.WaitForAnimationToEndCommand
-import kotlin.test.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 private const val WIDTH = 1080
 private const val HEIGHT = 1920
@@ -36,6 +38,27 @@ class ArbigentDeviceEventsTest {
   fun `tap on point becomes a tap`() {
     val events = MaestroCommand(tapOnPointV2Command = TapOnPointV2Command(point = "120,340")).events()
     assertEquals(listOf(ArbigentDeviceEvent.Tap(120, 340, TS)), events)
+  }
+
+  @Test
+  fun `tap on an element keeps its selector so a replay can find it again`() {
+    assertEquals(
+      listOf(ArbigentDeviceEvent.TapElement(textRegex = "Settings", index = 1, timestamp = TS)),
+      MaestroCommand(
+        tapOnElement = TapOnElementCommand(selector = ElementSelector(textRegex = "Settings", index = "1"))
+      ).events(),
+    )
+    assertEquals(
+      listOf(ArbigentDeviceEvent.TapElement(idRegex = ".*button", timestamp = TS)),
+      MaestroCommand(
+        tapOnElement = TapOnElementCommand(selector = ElementSelector(idRegex = ".*button"))
+      ).events(),
+    )
+    assertTrue(
+      MaestroCommand(tapOnElement = TapOnElementCommand(selector = ElementSelector(enabled = true)))
+        .events().single() is ArbigentDeviceEvent.Unsupported,
+      "a selector with nothing to search the hierarchy for cannot be replayed",
+    )
   }
 
   @Test
@@ -83,6 +106,13 @@ class ArbigentDeviceEventsTest {
       listOf(ArbigentDeviceEvent.LaunchApp("com.example.app", clearState = true, timestamp = TS)),
       MaestroCommand(
         launchAppCommand = LaunchAppCommand(appId = "com.example.app", clearState = true)
+      ).events(),
+      "maestro force-stops before launching unless told otherwise, so stopApp defaults to true",
+    )
+    assertEquals(
+      listOf(ArbigentDeviceEvent.LaunchApp("com.example.app", stopApp = false, timestamp = TS)),
+      MaestroCommand(
+        launchAppCommand = LaunchAppCommand(appId = "com.example.app", stopApp = false)
       ).events(),
     )
     assertEquals(

--- a/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
+++ b/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
@@ -1,6 +1,7 @@
 package io.github.takahirom.arbigent.sample.test
 
 import io.github.takahirom.arbigent.ArbigentDeviceEvent
+import io.github.takahirom.arbigent.ArbigentDeviceOs
 import io.github.takahirom.arbigent.KeyPressAgentAction
 import io.github.takahirom.arbigent.toArbigentDeviceEvents
 import kotlin.test.Test
@@ -33,8 +34,8 @@ private const val WIDTH = 1080
 private const val HEIGHT = 1920
 private const val TS = 42L
 
-private fun MaestroCommand.events(): List<ArbigentDeviceEvent> =
-  toArbigentDeviceEvents(WIDTH, HEIGHT, TS)
+private fun MaestroCommand.events(os: ArbigentDeviceOs = ArbigentDeviceOs.Android): List<ArbigentDeviceEvent> =
+  toArbigentDeviceEvents(WIDTH, HEIGHT, os, TS)
 
 class ArbigentDeviceEventsTest {
   @Test
@@ -55,6 +56,13 @@ class ArbigentDeviceEventsTest {
       listOf(ArbigentDeviceEvent.TapElement(idRegex = ".*button", timestamp = TS)),
       MaestroCommand(
         tapOnElement = TapOnElementCommand(selector = ElementSelector(idRegex = ".*button"))
+      ).events(),
+    )
+    // An explicit index of 0 is not the same selection as no index at all, so it has to survive.
+    assertEquals(
+      listOf(ArbigentDeviceEvent.TapElement(textRegex = "Play", index = 0, timestamp = TS)),
+      MaestroCommand(
+        tapOnElement = TapOnElementCommand(selector = ElementSelector(textRegex = "Play", index = "0"))
       ).events(),
     )
     assertTrue(
@@ -164,24 +172,34 @@ class ArbigentDeviceEventsTest {
   }
 
   @Test
-  fun `a scroll is the same upward swipe maestro performs`() {
-    val events = MaestroCommand(scrollCommand = ScrollCommand()).events()
-    assertEquals(
-      listOf(ArbigentDeviceEvent.Swipe(540, 960, 540, 192, 400L, TS)),
-      events,
-    )
+  fun `a scroll is the same upward swipe maestro performs on both platforms`() {
+    val expected = listOf(ArbigentDeviceEvent.Swipe(540, 960, 540, 192, 400L, TS))
+    assertEquals(expected, MaestroCommand(scrollCommand = ScrollCommand()).events())
+    assertEquals(expected, MaestroCommand(scrollCommand = ScrollCommand()).events(ArbigentDeviceOs.Ios))
   }
 
   @Test
   fun `each swipe direction keeps maestro's own start and end points`() {
-    fun swipe(direction: SwipeDirection): ArbigentDeviceEvent.Swipe {
+    fun swipe(
+      direction: SwipeDirection,
+      os: ArbigentDeviceOs = ArbigentDeviceOs.Android,
+    ): ArbigentDeviceEvent.Swipe {
       val command = MaestroCommand(swipeCommand = SwipeCommand(direction = direction, duration = 500L))
-      return command.events().single() as ArbigentDeviceEvent.Swipe
+      return command.events(os).single() as ArbigentDeviceEvent.Swipe
     }
     assertEquals(ArbigentDeviceEvent.Swipe(540, 960, 540, 192, 500L, TS), swipe(SwipeDirection.UP))
     assertEquals(ArbigentDeviceEvent.Swipe(540, 384, 540, 1728, 500L, TS), swipe(SwipeDirection.DOWN))
     assertEquals(ArbigentDeviceEvent.Swipe(108, 960, 972, 960, 500L, TS), swipe(SwipeDirection.RIGHT))
     assertEquals(ArbigentDeviceEvent.Swipe(972, 960, 108, 960, 500L, TS), swipe(SwipeDirection.LEFT))
+    // Only the upward swipe differs between the drivers: iOS starts it near the bottom edge.
+    assertEquals(
+      ArbigentDeviceEvent.Swipe(540, 1728, 540, 192, 500L, TS),
+      swipe(SwipeDirection.UP, ArbigentDeviceOs.Ios),
+    )
+    assertEquals(
+      ArbigentDeviceEvent.Swipe(540, 384, 540, 1728, 500L, TS),
+      swipe(SwipeDirection.DOWN, ArbigentDeviceOs.Ios),
+    )
   }
 
   @Test

--- a/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
+++ b/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
@@ -109,6 +109,17 @@ class ArbigentDeviceEventsTest {
   }
 
   @Test
+  fun `back on web cannot be replayed as a key press`() {
+    val events = MaestroCommand(backPressCommand = BackPressCommand()).events(ArbigentDeviceOs.Web)
+    assertEquals(
+      listOf(ArbigentDeviceEvent.Unsupported("back on web", TS)),
+      events,
+      "the web driver navigates history instead and rejects the BACK key, so a key press would " +
+        "fail the replay at this step",
+    )
+  }
+
+  @Test
   fun `input text is carried through`() {
     val events = MaestroCommand(inputTextCommand = InputTextCommand("hello world")).events()
     assertEquals(listOf(ArbigentDeviceEvent.InputText("hello world", TS)), events)
@@ -166,6 +177,34 @@ class ArbigentDeviceEventsTest {
   }
 
   @Test
+  fun `a launch keeps the permissions and keychain reset it asked for`() {
+    assertEquals(
+      listOf(
+        ArbigentDeviceEvent.LaunchApp(
+          "com.example.app",
+          permissions = mapOf("all" to "deny"),
+          clearKeychain = true,
+          timestamp = TS,
+        )
+      ),
+      MaestroCommand(
+        launchAppCommand = LaunchAppCommand(
+          appId = "com.example.app",
+          permissions = mapOf("all" to "deny"),
+          clearKeychain = true,
+        )
+      ).events(),
+      "a launch that denies a permission or resets the keychain starts the app in a state a " +
+        "replay cannot reach by launching with maestro's defaults",
+    )
+    val defaults = MaestroCommand(launchAppCommand = LaunchAppCommand(appId = "com.example.app"))
+      .events()
+      .single() as ArbigentDeviceEvent.LaunchApp
+    assertEquals(null, defaults.permissions, "maestro fills in its own default for an omitted value")
+    assertEquals(null, defaults.clearKeychain)
+  }
+
+  @Test
   fun `open link carries the url`() {
     val events = MaestroCommand(openLinkCommand = OpenLinkCommand(link = "https://example.com")).events()
     assertEquals(listOf(ArbigentDeviceEvent.OpenLink("https://example.com", TS)), events)
@@ -176,6 +215,16 @@ class ArbigentDeviceEventsTest {
     val expected = listOf(ArbigentDeviceEvent.Swipe(540, 960, 540, 192, 400L, TS))
     assertEquals(expected, MaestroCommand(scrollCommand = ScrollCommand()).events())
     assertEquals(expected, MaestroCommand(scrollCommand = ScrollCommand()).events(ArbigentDeviceOs.Ios))
+  }
+
+  @Test
+  fun `a scroll on web is not the swipe the other platforms perform`() {
+    assertEquals(
+      listOf(ArbigentDeviceEvent.Unsupported("scroll on web", TS)),
+      MaestroCommand(scrollCommand = ScrollCommand()).events(ArbigentDeviceOs.Web),
+      "the web driver scrolls the document with JavaScript, so a page that swallows touch " +
+        "gestures would not move at all for a replayed swipe",
+    )
   }
 
   @Test

--- a/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
+++ b/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
@@ -1,6 +1,7 @@
 package io.github.takahirom.arbigent.sample.test
 
 import io.github.takahirom.arbigent.ArbigentDeviceEvent
+import io.github.takahirom.arbigent.KeyPressAgentAction
 import io.github.takahirom.arbigent.toArbigentDeviceEvents
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -70,24 +71,33 @@ class ArbigentDeviceEventsTest {
   }
 
   @Test
-  fun `maestro keys become android keyevent names`() {
+  fun `maestro keys are recorded under their maestro name`() {
     fun keyName(code: KeyCode): String {
       val event = MaestroCommand(pressKeyCommand = PressKeyCommand(code)).events().single()
       return (event as ArbigentDeviceEvent.KeyPress).keyName
     }
-    assertEquals("KEYCODE_DPAD_UP", keyName(KeyCode.REMOTE_UP))
-    assertEquals("KEYCODE_DPAD_CENTER", keyName(KeyCode.REMOTE_CENTER))
-    assertEquals("KEYCODE_DEL", keyName(KeyCode.BACKSPACE))
-    assertEquals("KEYCODE_POWER", keyName(KeyCode.LOCK))
-    assertEquals("KEYCODE_MEDIA_PLAY_PAUSE", keyName(KeyCode.REMOTE_PLAY_PAUSE))
-    assertEquals("KEYCODE_MENU", keyName(KeyCode.REMOTE_MENU))
-    assertEquals("KEYCODE_ENTER", keyName(KeyCode.ENTER))
+    assertEquals("REMOTE_UP", keyName(KeyCode.REMOTE_UP))
+    assertEquals("REMOTE_CENTER", keyName(KeyCode.REMOTE_CENTER))
+    assertEquals("BACKSPACE", keyName(KeyCode.BACKSPACE))
+    assertEquals("LOCK", keyName(KeyCode.LOCK))
+    assertEquals("REMOTE_PLAY_PAUSE", keyName(KeyCode.REMOTE_PLAY_PAUSE))
+    assertEquals("REMOTE_MENU", keyName(KeyCode.REMOTE_MENU))
+    assertEquals("ENTER", keyName(KeyCode.ENTER))
+  }
+
+  @Test
+  fun `every recorded key name resolves back to its key`() {
+    KeyCode.entries.forEach { code ->
+      val event = MaestroCommand(pressKeyCommand = PressKeyCommand(code)).events().single()
+      val recorded = (event as ArbigentDeviceEvent.KeyPress).keyName
+      assertEquals(code, KeyPressAgentAction.resolveKeyCode(recorded), "key $code")
+    }
   }
 
   @Test
   fun `back press becomes the back key`() {
     val events = MaestroCommand(backPressCommand = BackPressCommand()).events()
-    assertEquals(listOf(ArbigentDeviceEvent.KeyPress("KEYCODE_BACK", TS)), events)
+    assertEquals(listOf(ArbigentDeviceEvent.KeyPress("BACK", TS)), events)
   }
 
   @Test
@@ -99,7 +109,7 @@ class ArbigentDeviceEventsTest {
   @Test
   fun `erase text becomes one delete per character`() {
     val events = MaestroCommand(eraseTextCommand = EraseTextCommand(charactersToErase = 3)).events()
-    assertEquals(List(3) { ArbigentDeviceEvent.KeyPress("KEYCODE_DEL", TS) }, events)
+    assertEquals(List(3) { ArbigentDeviceEvent.KeyPress("BACKSPACE", TS) }, events)
   }
 
   @Test

--- a/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
+++ b/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
@@ -41,7 +41,7 @@ class ArbigentDeviceEventsTest {
   @Test
   fun `tap on point becomes a tap`() {
     val events = MaestroCommand(tapOnPointV2Command = TapOnPointV2Command(point = "120,340")).events()
-    assertEquals(listOf(ArbigentDeviceEvent.Tap(120, 340, TS)), events)
+    assertEquals(listOf(ArbigentDeviceEvent.Tap(120, 340, timestamp = TS)), events)
   }
 
   @Test
@@ -69,6 +69,33 @@ class ArbigentDeviceEventsTest {
       MaestroCommand(tapOnElement = TapOnElementCommand(selector = ElementSelector(enabled = true)))
         .events().single() is ArbigentDeviceEvent.Unsupported,
       "a selector with nothing to search the hierarchy for cannot be replayed",
+    )
+  }
+
+  @Test
+  fun `a tap keeps maestro's own retry so the replay gets the same attempts`() {
+    // Arbigent's taps leave retryIfNoChange unset, but a Maestro flow used as an initializer runs
+    // through this recorder, and dropping the flag would give the replayed tap one attempt where
+    // the recorded one had two.
+    assertEquals(
+      listOf(ArbigentDeviceEvent.Tap(10, 20, retryIfNoChange = true, timestamp = TS)),
+      MaestroCommand(tapOnPointV2Command = TapOnPointV2Command(point = "10,20", retryIfNoChange = true)).events(),
+    )
+    assertEquals(
+      listOf(ArbigentDeviceEvent.TapElement(textRegex = "Settings", retryIfNoChange = true, timestamp = TS)),
+      MaestroCommand(
+        tapOnElement = TapOnElementCommand(
+          selector = ElementSelector(textRegex = "Settings"),
+          retryIfNoChange = true,
+        )
+      ).events(),
+    )
+    // Unset stays unset: Maestro reads null as false, and writing false into the log would freeze
+    // today's default instead of recording that the command asked for nothing.
+    assertEquals(
+      null,
+      (MaestroCommand(tapOnPointV2Command = TapOnPointV2Command(point = "10,20")).events().single()
+        as ArbigentDeviceEvent.Tap).retryIfNoChange,
     )
   }
 

--- a/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
+++ b/arbigent-core/src/test/java/ArbigentDeviceEventsTest.kt
@@ -238,10 +238,16 @@ class ArbigentDeviceEventsTest {
   }
 
   @Test
-  fun `a scroll is the same upward swipe maestro performs on both platforms`() {
-    val expected = listOf(ArbigentDeviceEvent.Swipe(540, 960, 540, 192, 400L, TS))
-    assertEquals(expected, MaestroCommand(scrollCommand = ScrollCommand()).events())
-    assertEquals(expected, MaestroCommand(scrollCommand = ScrollCommand()).events(ArbigentDeviceOs.Ios))
+  fun `a scroll is the upward swipe maestro performs, over each platform's own duration`() {
+    assertEquals(
+      listOf(ArbigentDeviceEvent.Swipe(540, 960, 540, 192, 400L, TS)),
+      MaestroCommand(scrollCommand = ScrollCommand()).events(),
+    )
+    assertEquals(
+      listOf(ArbigentDeviceEvent.Swipe(540, 960, 540, 192, 333L, TS)),
+      MaestroCommand(scrollCommand = ScrollCommand()).events(ArbigentDeviceOs.Ios),
+      "the iOS driver scrolls in 333 ms, and the same gesture over 400 ms travels further",
+    )
   }
 
   @Test

--- a/arbigent-core/src/test/java/Fakes.kt
+++ b/arbigent-core/src/test/java/Fakes.kt
@@ -85,7 +85,8 @@ class FakeDevice : ArbigentDevice {
           isVisible = true
         )
       },
-      screenWidth = 1000
+      screenWidth = 1000,
+      screenHeight = 2000
     )
   }
 


### PR DESCRIPTION
Part 2 of the replay-scripts stack (on top of #425).

Arbigent already knows exactly what it sends to the device on each step, but that knowledge dies with the run. This adds a device-layer observer so a later PR can write it down and replay it with plain `adb`.

- `ArbigentDeviceEvent`: a serializable model of the interactions Arbigent performs (tap, element tap by text/id selector, key press, text input, swipe, app launch with its extras and stop-before-launch flag, stop, clear state, wait, open link, and an explicit `unsupported` for anything else).
- `MaestroCommand.toArbigentDeviceEvents()` maps the commands Arbigent issues onto that model, including the synthetic key presses the TV focus loop performs.
- `ArbigentDevice.addDeviceEventListener` / `removeDeviceEventListener` with no-op defaults, implemented by `MaestroDevice`. Listener failures are logged and never fail a run.
- `ArbigentElementList.screenHeight`, so the recorded geometry has a full coordinate space.

Launch arguments are kept on the event because some apps decide what to show first from their extras; dropping them replays into a different screen.

Element taps (how the agent clicks by text or id on phones) keep their selector rather than a pixel, so a replay can look the element up again. `stopApp` mirrors Maestro's default of force-stopping before launch. Events are emitted after Maestro ran the command, so a tap Maestro rejected and the agent retried with a looser selector is not logged twice.

No behavior change unless a listener is attached.

Device events are recorded per command through Orchestra's `onCommandComplete` callback (the Orchestra is built by the device so it survives a reconnect), and a focus-walk key press is recorded after `pressKey` returns. A command Maestro rejected never completes and so never reaches the log, while the commands that did run before a later one in the same flow failed (repeated key presses) are kept.

Translations that would change the interaction are recorded as `unsupported` instead of being downgraded: long-press, repeated or relative-point taps, selectors constrained by position/traits/state, swipes anchored on an element, and `killApp`.


A back press and a scroll on web are recorded as `unsupported`: the web driver navigates history and scrolls with JavaScript, so a replayed key press or swipe is a different interaction there (and its key mapper rejects `BACK` outright). A launch also keeps the `permissions` and `clearKeychain` it asked for, left null when the recording did not set them so Maestro applies its own defaults exactly as it did for the recorded launch.
