### PR TITLE
Write a jsonl replay log for each successful scenario

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/AgentCommands.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/AgentCommands.kt
@@ -665,8 +665,13 @@ public class WaitAgentAction(private val timeMs: Int) : ArbigentAgentAction {
     return "Wait for $timeMs ms"
   }
 
+  @OptIn(ArbigentInternalApi::class)
   override fun runDeviceAction(runInput: ArbigentAgentAction.RunInput) {
     Thread.sleep(timeMs.toLong())
+    // A wait sends no command, so it is recorded here or not at all. The step is what made the
+    // next screen the one the recorded run acted on: a replay that dropped it would act on a
+    // screen still loading. Recorded after the wait so its own duration is not waited twice.
+    runInput.device.recordDeviceEvent(ArbigentDeviceEvent.Wait(timeMs.toLong()))
   }
 
   public companion object : AgentActionType {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -39,6 +39,10 @@ public class ArbigentAgent internal constructor(
   // degrade to normal execution, and the failed attempt would then purge the AI-decision cache as
   // if it were an ordinary failure. Null means normal AI-driven execution.
   private val replayTrace: ArbigentReplayTrace?,
+  // Interceptors the executor adds for this one run, on top of the scenario's own. The agent
+  // config is built when the project is loaded, so anything scoped to a single execution (the
+  // replay-script recorder) cannot come from there.
+  additionalInterceptors: List<ArbigentInterceptor> = emptyList(),
 ) {
   private val attemptMode: ArbigentAttemptMode = if (replayTrace != null) {
     ArbigentAttemptMode.ReplayWithFallback
@@ -48,7 +52,7 @@ public class ArbigentAgent internal constructor(
 
   private val ai by lazy { agentConfig.aiFactory() }
   public val device: ArbigentDevice by lazy { agentConfig.deviceFactory() }
-  private val interceptors: List<ArbigentInterceptor> = agentConfig.interceptors
+  private val interceptors: List<ArbigentInterceptor> = agentConfig.interceptors + additionalInterceptors
   private val deviceFormFactor = agentConfig.deviceFormFactor
   private val prompt = agentConfig.prompt
   private val aiOptions = agentConfig.aiOptions

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -693,6 +693,10 @@ public fun AgentConfigBuilder(
           ) {
             try {
               Thread.sleep(initializeMethod.durationMs)
+              // Recorded so `replay --with-init` waits here too: an initializer that waits does so
+              // because the app is not ready yet, and the steps after it were recorded against the
+              // screen that wait produced.
+              device.recordDeviceEvent(ArbigentDeviceEvent.Wait(initializeMethod.durationMs))
             } catch (e: Exception) {
               arbigentDebugLog("Failed to wait: $e")
             }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentDevice.kt
@@ -76,6 +76,18 @@ public interface ArbigentDevice {
   @ArbigentInternalApi
   public fun removeDeviceEventListener(listener: ArbigentDeviceEventListener) {
   }
+
+  /**
+   * Records an interaction the caller performed itself, without going through [executeActions].
+   *
+   * Waiting is the one such interaction: it changes nothing on the device but is what made the
+   * next step's screen the screen the recorded run acted on, so a replay that skipped it would
+   * act too early. A step that only waited has no Maestro command behind it and would otherwise
+   * leave no event at all.
+   */
+  @ArbigentInternalApi
+  public fun recordDeviceEvent(event: ArbigentDeviceEvent) {
+  }
 }
 
 public data class ArbigentElement(
@@ -281,6 +293,11 @@ public class MaestroDevice(
   @ArbigentInternalApi
   override fun removeDeviceEventListener(listener: ArbigentDeviceEventListener) {
     deviceEventListeners.remove(listener)
+  }
+
+  @ArbigentInternalApi
+  override fun recordDeviceEvent(event: ArbigentDeviceEvent) {
+    emitDeviceEvents(listOf(event))
   }
 
   private fun recordDeviceEvents(command: MaestroCommand) {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
@@ -180,6 +180,7 @@ public data class ArbigentScenario(
   val isLeaf: Boolean,
   val cacheOptions: ArbigentScenarioCacheOptions? = null,
   val mcpOptions: ArbigentMcpOptions? = null,
+  val replayScripts: ReplayScriptsSettings? = null,
 ) {
   public fun goal(): String? {
     return agentTasks.lastOrNull()?.goal

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -261,11 +261,26 @@ public data class ArbigentProjectSettings(
   public val mcpJson: String = DefaultMcpJson,
   public val deviceFormFactor: ArbigentScenarioDeviceFormFactor = ArbigentScenarioDeviceFormFactor.Unspecified,
   public val additionalActions: List<String>? = null,
+  public val replayScripts: ReplayScriptsSettings? = null,
 ) {
   public companion object {
     public const val DefaultMcpJson: String = "{}"
   }
 }
+
+/**
+ * Emits a replay script per scenario after a successful run: an event log of what was sent to the
+ * device, so the same screens can be reached again without the AI.
+ *
+ * Absent from the project file means the feature is off, so an existing project keeps writing
+ * nothing until it opts in.
+ */
+@Serializable
+public data class ReplayScriptsSettings(
+  public val enabled: Boolean = true,
+  /** Where to write. Relative paths resolve against the working directory. */
+  public val outputDir: String? = null,
+)
 
 @Serializable
 public data class ArbigentPrompt(
@@ -500,7 +515,8 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
     deviceFormFactor = effectiveScenarioDeviceFormFactor,
     isLeaf = this.none { it.dependencyId == scenario.id },
     cacheOptions = scenario.cacheOptions,
-    mcpOptions = scenario.mcpOptions
+    mcpOptions = scenario.mcpOptions,
+    replayScripts = projectSettings.replayScripts?.takeIf { it.enabled },
   )
 }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptRecorder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptRecorder.kt
@@ -116,6 +116,20 @@ internal class ArbigentReplayScriptRecorder : ArbigentExecuteActionsInterceptor,
     executeActionsInput: ExecuteActionsInput,
     chain: ArbigentExecuteActionsInterceptor.Chain,
   ): ExecuteActionsOutput {
+    // Recording is a side line: whatever goes wrong while describing the step, the action itself
+    // still runs. Events sent while no step is open land in the init bucket, which the runner
+    // treats as setup, so a step that failed to record loses its metadata but not its events.
+    val opened = runCatching { openStep(executeActionsInput) }
+      .onFailure { arbigentDebugLog("Replay script: could not record a step: $it") }
+      .isSuccess
+    return try {
+      chain.proceed(executeActionsInput)
+    } finally {
+      if (opened) synchronized(lock) { currentStep = null }
+    }
+  }
+
+  private fun openStep(executeActionsInput: ExecuteActionsInput) {
     val step = executeActionsInput.decisionOutput.step
     val elements = executeActionsInput.elements
     val recorded = RecordedStep(
@@ -137,11 +151,6 @@ internal class ArbigentReplayScriptRecorder : ArbigentExecuteActionsInterceptor,
       if (elements.screenHeight > 0) screenHeight = elements.screenHeight
       currentTask()?.steps?.add(recorded)
       currentStep = recorded
-    }
-    return try {
-      chain.proceed(executeActionsInput)
-    } finally {
-      synchronized(lock) { currentStep = null }
     }
   }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptRecorder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptRecorder.kt
@@ -1,0 +1,179 @@
+package io.github.takahirom.arbigent
+
+import io.github.takahirom.arbigent.ArbigentAgent.ExecuteActionsInput
+import io.github.takahirom.arbigent.ArbigentAgent.ExecuteActionsOutput
+import java.io.File
+
+/**
+ * Collects, for one scenario execution, what was actually sent to the device and which agent step
+ * sent it, so a replay script can be written from the run.
+ *
+ * The device layer knows what was sent but not why; the agent knows why but not what. This joins
+ * the two: it listens for device events and, as an execute-actions interceptor, marks which step is
+ * running while they arrive. Events that arrive outside any step (initializers, which run before
+ * the first step) are attributed to the task's `init` phase.
+ *
+ * One instance per scenario execution. It is written from the agent's coroutine and read from the
+ * executor's, so every mutation is guarded.
+ */
+internal class ArbigentReplayScriptRecorder : ArbigentExecuteActionsInterceptor, ArbigentDeviceEventListener {
+
+  /**
+   * Where the step's target was on screen, in the coordinate space Arbigent's own element bounds
+   * use.
+   *
+   * Maestro reads the hierarchy through its own instrumentation and sees attributes, notably
+   * Compose test tags surfaced as resource ids, that `android layout` and `uiautomator dump` do
+   * not. Recording the geometry as well gives a replay a way to reach the element by coordinates
+   * when its identity is invisible from the adb side.
+   */
+  internal data class RecordedBounds(
+    val left: Int,
+    val top: Int,
+    val right: Int,
+    val bottom: Int,
+  ) {
+    val centerX: Int get() = (left + right) / 2
+    val centerY: Int get() = (top + bottom) / 2
+  }
+
+  internal data class RecordedStep(
+    val isInit: Boolean,
+    val actionName: String? = null,
+    val actionLog: String? = null,
+    val memo: String? = null,
+    val screenshot: String? = null,
+    val target: ArbigentElementIdentity? = null,
+    val targetBounds: RecordedBounds? = null,
+    /**
+     * A few identities from the screen the decision was made on, labelled elements first. A step
+     * with no target (a bare key press) has nothing else that says which screen it belongs to, so a
+     * replay waits for one of these before sending it rather than pressing into a splash screen.
+     */
+    val screen: List<ArbigentElementIdentity> = emptyList(),
+    val events: MutableList<ArbigentDeviceEvent> = mutableListOf(),
+    val timestamp: Long = TimeProvider.get().currentTimeMillis(),
+  )
+
+  internal data class RecordedTask(
+    val taskIndex: Int,
+    val goal: String,
+    val steps: MutableList<RecordedStep> = mutableListOf(),
+  )
+
+  private val lock = Any()
+  private val tasks = linkedMapOf<Int, RecordedTask>()
+  private var currentTaskIndex: Int? = null
+  private var currentStep: RecordedStep? = null
+  private var screenWidth: Int = 0
+  private var screenHeight: Int = 0
+
+  /**
+   * The screen size the steps' coordinates are in, or `0 to 0` when no step reported one. Read
+   * from the element lists the decisions saw rather than from the device, so it is always the same
+   * space the recorded bounds are in.
+   */
+  fun screenSize(): Pair<Int, Int> = synchronized(lock) { screenWidth to screenHeight }
+
+  /** Everything recorded so far, in task order. */
+  fun recordedTasks(): List<RecordedTask> = synchronized(lock) {
+    tasks.values.map { task -> task.copy(steps = task.steps.map { it.copy(events = it.events.toMutableList()) }.toMutableList()) }
+  }
+
+  /** Forgets the whole scenario. Called when the executor restarts every task from the top. */
+  fun reset(): Unit = synchronized(lock) {
+    tasks.clear()
+    currentTaskIndex = null
+    currentStep = null
+    screenWidth = 0
+    screenHeight = 0
+  }
+
+  /**
+   * Marks [taskIndex] as the task now running.
+   *
+   * [discardPrevious] is for the executor's per-task fallback, which replaces one task's agent and
+   * runs it again. A task that resets the device state starts from the same screen it did before,
+   * so its earlier recording is superseded and must go; a task that carries on from the previous
+   * one needs what it already did kept in front of what it is about to do, or the script would
+   * replay from a screen that never existed.
+   */
+  fun beginTask(taskIndex: Int, goal: String, discardPrevious: Boolean): Unit = synchronized(lock) {
+    val task = tasks.getOrPut(taskIndex) { RecordedTask(taskIndex, goal) }
+    if (discardPrevious) task.steps.clear()
+    currentTaskIndex = taskIndex
+    currentStep = null
+  }
+
+  override fun onDeviceEvent(event: ArbigentDeviceEvent) {
+    synchronized(lock) {
+      val step = currentStep ?: initStep() ?: return
+      step.events += event
+    }
+  }
+
+  override suspend fun intercept(
+    executeActionsInput: ExecuteActionsInput,
+    chain: ArbigentExecuteActionsInterceptor.Chain,
+  ): ExecuteActionsOutput {
+    val step = executeActionsInput.decisionOutput.step
+    val elements = executeActionsInput.elements
+    val recorded = RecordedStep(
+      isInit = false,
+      actionName = step.agentAction?.let { it::class.simpleName },
+      actionLog = step.agentAction?.stepLogText(),
+      memo = step.memo,
+      screenshot = File(executeActionsInput.screenshotFilePath).name,
+      // Already resolved against the elements the decision saw; recomputing it here would match
+      // against a hierarchy that the action is about to change.
+      target = step.targetElement,
+      targetBounds = step.targetElement?.findMatch(elements)?.rect?.let {
+        RecordedBounds(it.left, it.top, it.right, it.bottom)
+      },
+      screen = screenIdentities(elements.elements),
+    )
+    synchronized(lock) {
+      if (elements.screenWidth > 0) screenWidth = elements.screenWidth
+      if (elements.screenHeight > 0) screenHeight = elements.screenHeight
+      currentTask()?.steps?.add(recorded)
+      currentStep = recorded
+    }
+    return try {
+      chain.proceed(executeActionsInput)
+    } finally {
+      synchronized(lock) { currentStep = null }
+    }
+  }
+
+  /**
+   * The `init` bucket events outside any step go to. Appended rather than kept at the head, because
+   * a task that falls back to normal execution runs its initializers again after the steps it had
+   * already replayed, and a replay has to perform them in that same order.
+   */
+  private fun initStep(): RecordedStep? {
+    val task = currentTask() ?: return null
+    val last = task.steps.lastOrNull()
+    if (last != null && last.isInit) return last
+    val created = RecordedStep(isInit = true)
+    task.steps.add(created)
+    return created
+  }
+
+  private fun currentTask(): RecordedTask? = currentTaskIndex?.let { tasks[it] }
+
+  internal companion object {
+    const val MaxScreenIdentities: Int = 5
+
+    /**
+     * Elements with visible text come first because container ids (`content`, `root_layout`) are on
+     * every screen of an app and would say nothing about which one this is.
+     */
+    fun screenIdentities(elements: List<ArbigentElement>): List<ArbigentElementIdentity> =
+      elements
+        .mapNotNull { element -> ArbigentElementIdentity.from(element, elements) }
+        .map { it.copy(occurrence = 0) }
+        .distinct()
+        .sortedBy { if (it.text != null) 0 else 1 }
+        .take(MaxScreenIdentities)
+  }
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptRecorder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptRecorder.kt
@@ -67,6 +67,17 @@ internal class ArbigentReplayScriptRecorder : ArbigentExecuteActionsInterceptor,
   private var currentStep: RecordedStep? = null
   private var screenWidth: Int = 0
   private var screenHeight: Int = 0
+  private var eventsLost = false
+
+  /**
+   * False once a task ran without this recorder attached to the device: the steps it kept from
+   * then on have no device events behind them, and a script written from them would be missing the
+   * actions that reached the screen the later tasks continued from.
+   */
+  val isComplete: Boolean get() = synchronized(lock) { !eventsLost }
+
+  /** Records that a task's device events could not be captured. Cleared by [reset]. */
+  fun markEventsLost(): Unit = synchronized(lock) { eventsLost = true }
 
   /**
    * The screen size the steps' coordinates are in, or `0 to 0` when no step reported one. Read
@@ -87,6 +98,7 @@ internal class ArbigentReplayScriptRecorder : ArbigentExecuteActionsInterceptor,
     currentStep = null
     screenWidth = 0
     screenHeight = 0
+    eventsLost = false
   }
 
   /**

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -209,12 +209,14 @@ internal class ArbigentReplayScriptWriter(
     }
 
     /**
-     * Writes through a sibling temp file and renames, so a reader (a CI upload, a runner started
-     * on the previous script) never sees a half-written file.
+     * Writes through a uniquely named sibling temp file and renames, so a reader (a CI upload, a
+     * runner started on the previous script) never sees a half-written file and two writers (two
+     * arbigent processes sharing an output dir) never stage into the same temp file.
      */
-    fun writeAtomically(target: File, text: String) {
-      val temp = File(target.parentFile, "${target.name}.tmp")
+    fun writeAtomically(target: File, text: String, executable: Boolean = false) {
+      val temp = File(target.parentFile, "${target.name}.${ProcessHandle.current().pid()}.${System.nanoTime()}.tmp")
       temp.writeText(text)
+      if (executable) temp.setExecutable(true, false)
       try {
         java.nio.file.Files.move(
           temp.toPath(), target.toPath(),

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -189,6 +189,8 @@ internal class ArbigentReplayScriptWriter(
      */
     fun sanitizeFileName(scenarioId: String): String =
       scenarioId.replace(Regex("[^\\p{L}\\p{N}_-]"), "_")
+        // A name that starts with a dash reads as an option on the runner's command line.
+        .replaceFirst(Regex("^-"), "_")
   }
 }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -54,11 +54,12 @@ internal class ArbigentReplayScriptWriter(
       return
     }
     outputDir.mkdirs()
-    val baseName = sanitizeFileName(scenarioId)
+    val baseName = fileBaseName(scenarioId)
     val logFile = File(outputDir, "$baseName.jsonl")
-    logFile.writeText(
+    writeAtomically(
+      logFile,
       jsonLines(scenarioId, goals, tasks, steps, signature, screenWidth, screenHeight)
-        .joinToString(separator = "\n", postfix = "\n")
+        .joinToString(separator = "\n", postfix = "\n"),
     )
     arbigentInfoLog("Wrote replay script for scenario $scenarioId to ${logFile.absolutePath}")
   }
@@ -191,6 +192,42 @@ internal class ArbigentReplayScriptWriter(
       scenarioId.replace(Regex("[^\\p{L}\\p{N}_-]"), "_")
         // A name that starts with a dash reads as an option on the runner's command line.
         .replaceFirst(Regex("^-"), "_")
+
+    /**
+     * The file name a scenario's script is written under. Two ids that sanitize to the same string
+     * (`a/b` and `a b`) would otherwise overwrite each other, so a name the sanitizer had to change
+     * carries a short hash of the original id.
+     */
+    fun fileBaseName(scenarioId: String): String {
+      val sanitized = sanitizeFileName(scenarioId)
+      if (sanitized == scenarioId) return sanitized
+      val hash = java.security.MessageDigest.getInstance("SHA-256")
+        .digest(scenarioId.toByteArray())
+        .take(3)
+        .joinToString("") { "%02x".format(it) }
+      return "$sanitized-$hash"
+    }
+
+    /**
+     * Writes through a sibling temp file and renames, so a reader (a CI upload, a runner started
+     * on the previous script) never sees a half-written file.
+     */
+    fun writeAtomically(target: File, text: String) {
+      val temp = File(target.parentFile, "${target.name}.tmp")
+      temp.writeText(text)
+      try {
+        java.nio.file.Files.move(
+          temp.toPath(), target.toPath(),
+          java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+          java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+        )
+      } catch (e: java.nio.file.AtomicMoveNotSupportedException) {
+        java.nio.file.Files.move(
+          temp.toPath(), target.toPath(),
+          java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+        )
+      }
+    }
   }
 }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -1,0 +1,207 @@
+package io.github.takahirom.arbigent
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.io.File
+
+/**
+ * One recorded step of a scenario, after task-local recordings have been flattened and numbered.
+ *
+ * Every artifact written for a run is rendered from this shape, so they cannot disagree about which
+ * step is which.
+ */
+internal data class ArbigentReplayScriptStep(
+  val taskIndex: Int,
+  /** Globally numbered across tasks, from 1. Zero means the task's `init` phase. */
+  val number: Int,
+  val isInit: Boolean,
+  val actionName: String?,
+  val actionLog: String?,
+  val memo: String?,
+  val screenshot: String?,
+  val target: ArbigentElementIdentity?,
+  val targetBounds: ArbigentReplayScriptRecorder.RecordedBounds?,
+  val screen: List<ArbigentElementIdentity>,
+  val events: List<ArbigentDeviceEvent>,
+  val timestamp: Long,
+)
+
+/**
+ * Writes the replay event log for one successful scenario.
+ *
+ * Only successful runs are written. A failed scenario leaves whatever was written before untouched,
+ * because a half-finished log replays to a screen the scenario never reached, which is worse than
+ * a stale one whose scenario id says what it is.
+ */
+internal class ArbigentReplayScriptWriter(
+  private val outputDir: File,
+) {
+  fun write(
+    scenarioId: String,
+    goals: List<String>,
+    tasks: List<ArbigentReplayScriptRecorder.RecordedTask>,
+    signature: List<String>,
+    screenWidth: Int = 0,
+    screenHeight: Int = 0,
+  ) {
+    val steps = flatten(tasks)
+    if (steps.isEmpty()) {
+      arbigentInfoLog("Not writing a replay script for scenario $scenarioId: the run recorded no device events")
+      return
+    }
+    outputDir.mkdirs()
+    val baseName = sanitizeFileName(scenarioId)
+    val logFile = File(outputDir, "$baseName.jsonl")
+    logFile.writeText(
+      jsonLines(scenarioId, goals, tasks, steps, signature, screenWidth, screenHeight)
+        .joinToString(separator = "\n", postfix = "\n")
+    )
+    arbigentInfoLog("Wrote replay script for scenario $scenarioId to ${logFile.absolutePath}")
+  }
+
+  private fun flatten(
+    tasks: List<ArbigentReplayScriptRecorder.RecordedTask>,
+  ): List<ArbigentReplayScriptStep> {
+    var number = 0
+    return tasks.flatMap { task ->
+      task.steps.mapNotNull { step ->
+        // A step that sent nothing to the device (a memo, a goal-achieved decision) has nothing to
+        // replay, and numbering it would make the step numbers in the log skip.
+        if (step.events.isEmpty()) return@mapNotNull null
+        if (!step.isInit) number++
+        ArbigentReplayScriptStep(
+          taskIndex = task.taskIndex,
+          number = if (step.isInit) 0 else number,
+          isInit = step.isInit,
+          actionName = step.actionName,
+          actionLog = step.actionLog,
+          memo = step.memo,
+          screenshot = step.screenshot,
+          target = step.target,
+          targetBounds = step.targetBounds,
+          screen = step.screen,
+          events = step.events.toList(),
+          timestamp = step.timestamp,
+        )
+      }
+    }
+  }
+
+  private fun jsonLines(
+    scenarioId: String,
+    goals: List<String>,
+    tasks: List<ArbigentReplayScriptRecorder.RecordedTask>,
+    steps: List<ArbigentReplayScriptStep>,
+    signature: List<String>,
+    screenWidth: Int,
+    screenHeight: Int,
+  ): List<String> {
+    val lines = mutableListOf<JsonObject>()
+    val firstTimestamp = steps.first().timestamp
+    val appId = steps.asSequence()
+      .flatMap { it.events.asSequence() }
+      .filterIsInstance<ArbigentDeviceEvent.LaunchApp>()
+      .firstOrNull()?.appId
+    lines += buildJsonObject {
+      header("scenario_start", scenarioId, taskIndex = 0, step = 0, ts = firstTimestamp)
+      put("goal", goals.joinToString(separator = " -> "))
+      appId?.let { put("appId", it) }
+      // Only when the device reported one; a zero would read as a real screen size.
+      if (screenWidth > 0 && screenHeight > 0) {
+        put("width", screenWidth)
+        put("height", screenHeight)
+      }
+    }
+    steps.forEach { step ->
+      if (step.isInit) {
+        step.events.forEach { event ->
+          lines += buildJsonObject {
+            header("init", scenarioId, step.taskIndex, step.number, event.timestamp)
+            put("event", json.encodeToJsonElement(ArbigentDeviceEvent.serializer(), event))
+          }
+        }
+        return@forEach
+      }
+      lines += buildJsonObject {
+        header("decision", scenarioId, step.taskIndex, step.number, step.timestamp)
+        put("action", step.actionName ?: "")
+        put("log", step.actionLog ?: "")
+        put("goal", tasks.firstOrNull { it.taskIndex == step.taskIndex }?.goal ?: "")
+        step.memo?.let { put("memo", it) }
+        step.screenshot?.let { put("screenshot", it) }
+        // What the decision was looking at. A step without a target waits for one of these.
+        if (step.screen.isNotEmpty()) {
+          put("screen", buildJsonArray {
+            step.screen.forEach { identity ->
+              add(buildJsonObject {
+                identity.text?.let { put("text", it) }
+                identity.resourceId?.let { put("resourceId", it) }
+                identity.accessibilityId?.let { put("accessibilityId", it) }
+              })
+            }
+          })
+        }
+      }
+      step.target?.let { target ->
+        lines += buildJsonObject {
+          header("target", scenarioId, step.taskIndex, step.number, step.timestamp)
+          target.text?.let { put("text", it) }
+          target.resourceId?.let { put("resourceId", it) }
+          target.accessibilityId?.let { put("accessibilityId", it) }
+          put("occurrence", target.occurrence)
+          // Maestro sees attributes that an adb-side dump may not, so the geometry travels with
+          // the identity as a coordinate fallback.
+          step.targetBounds?.let { bounds ->
+            put("bounds", "[${bounds.left},${bounds.top}][${bounds.right},${bounds.bottom}]")
+            put("center", buildJsonObject {
+              put("x", bounds.centerX)
+              put("y", bounds.centerY)
+            })
+          }
+        }
+      }
+      step.events.forEach { event ->
+        lines += buildJsonObject {
+          header("device", scenarioId, step.taskIndex, step.number, event.timestamp)
+          put("event", json.encodeToJsonElement(ArbigentDeviceEvent.serializer(), event))
+        }
+      }
+    }
+    val last = steps.last()
+    lines += buildJsonObject {
+      header("scenario_end", scenarioId, last.taskIndex, last.number, last.timestamp)
+      put("status", "success")
+      put("signature", buildJsonArray { signature.forEach { add(it) } })
+    }
+    return lines.map { it.toString() }
+  }
+
+  internal companion object {
+    private val json = Json { encodeDefaults = true }
+
+    /**
+     * Scenario ids are free text and become file names, so anything that is not a letter, digit,
+     * underscore or hyphen is replaced rather than escaped.
+     */
+    fun sanitizeFileName(scenarioId: String): String =
+      scenarioId.replace(Regex("[^\\p{L}\\p{N}_-]"), "_")
+  }
+}
+
+private fun kotlinx.serialization.json.JsonObjectBuilder.header(
+  type: String,
+  scenarioId: String,
+  taskIndex: Int,
+  step: Int,
+  ts: Long,
+) {
+  put("type", type)
+  put("task", scenarioId)
+  put("taskIndex", taskIndex)
+  put("step", step)
+  put("ts", ts)
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -217,7 +217,10 @@ internal class ArbigentReplayScriptWriter(
       val temp = File(target.parentFile, "${target.name}.${ProcessHandle.current().pid()}.${System.nanoTime()}.tmp")
       try {
         temp.writeText(text)
-        if (executable) temp.setExecutable(true, false)
+        // A runner nobody can execute is worse than no runner: fail before it replaces the old one.
+        if (executable && !temp.setExecutable(true, false)) {
+          throw java.io.IOException("Could not make ${temp.name} executable")
+        }
         try {
           java.nio.file.Files.move(
             temp.toPath(), target.toPath(),

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -9,6 +9,12 @@ import kotlinx.serialization.json.put
 import java.io.File
 
 /**
+ * The shape of the jsonl replay log. Bump it whenever an existing field changes meaning or goes
+ * away, so a reader can refuse a log it cannot interpret.
+ */
+internal const val ReplayLogSchemaVersion: Int = 1
+
+/**
  * One recorded step of a scenario, after task-local recordings have been flattened and numbered.
  *
  * Every artifact written for a run is rendered from this shape, so they cannot disagree about which
@@ -45,6 +51,7 @@ internal class ArbigentReplayScriptWriter(
     goals: List<String>,
     tasks: List<ArbigentReplayScriptRecorder.RecordedTask>,
     signature: List<String>,
+    platform: ArbigentDeviceOs,
     screenWidth: Int = 0,
     screenHeight: Int = 0,
   ) {
@@ -58,7 +65,7 @@ internal class ArbigentReplayScriptWriter(
     val logFile = File(outputDir, "$baseName.jsonl")
     writeAtomically(
       logFile,
-      jsonLines(scenarioId, goals, tasks, steps, signature, screenWidth, screenHeight)
+      jsonLines(scenarioId, goals, tasks, steps, signature, platform, screenWidth, screenHeight)
         .joinToString(separator = "\n", postfix = "\n"),
     )
     arbigentInfoLog("Wrote replay script for scenario $scenarioId to ${logFile.absolutePath}")
@@ -98,6 +105,7 @@ internal class ArbigentReplayScriptWriter(
     tasks: List<ArbigentReplayScriptRecorder.RecordedTask>,
     steps: List<ArbigentReplayScriptStep>,
     signature: List<String>,
+    platform: ArbigentDeviceOs,
     screenWidth: Int,
     screenHeight: Int,
   ): List<String> {
@@ -109,6 +117,9 @@ internal class ArbigentReplayScriptWriter(
       .firstOrNull()?.appId
     lines += buildJsonObject {
       header("scenario_start", scenarioId, taskIndex = 0, step = 0, ts = firstTimestamp)
+      put("schemaVersion", ReplayLogSchemaVersion)
+      // A log is only replayable on the kind of device it was recorded on.
+      put("platform", platform.name.lowercase())
       put("goal", goals.joinToString(separator = " -> "))
       appId?.let { put("appId", it) }
       // Only when the device reported one; a zero would read as a real screen size.

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -215,19 +215,26 @@ internal class ArbigentReplayScriptWriter(
      */
     fun writeAtomically(target: File, text: String, executable: Boolean = false) {
       val temp = File(target.parentFile, "${target.name}.${ProcessHandle.current().pid()}.${System.nanoTime()}.tmp")
-      temp.writeText(text)
-      if (executable) temp.setExecutable(true, false)
       try {
-        java.nio.file.Files.move(
-          temp.toPath(), target.toPath(),
-          java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-          java.nio.file.StandardCopyOption.ATOMIC_MOVE,
-        )
-      } catch (e: java.nio.file.AtomicMoveNotSupportedException) {
-        java.nio.file.Files.move(
-          temp.toPath(), target.toPath(),
-          java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-        )
+        temp.writeText(text)
+        if (executable) temp.setExecutable(true, false)
+        try {
+          java.nio.file.Files.move(
+            temp.toPath(), target.toPath(),
+            java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+            java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+          )
+        } catch (e: java.io.IOException) {
+          // Filesystems that cannot rename atomically, or cannot replace an existing file that way,
+          // still get the finished content in one step; only the replacement is no longer atomic.
+          java.nio.file.Files.move(
+            temp.toPath(), target.toPath(),
+            java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+          )
+        }
+      } finally {
+        // A failed write or move must not leave staging files next to the logs CI uploads.
+        temp.delete()
       }
     }
   }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -227,13 +227,19 @@ internal class ArbigentReplayScriptWriter(
             java.nio.file.StandardCopyOption.REPLACE_EXISTING,
             java.nio.file.StandardCopyOption.ATOMIC_MOVE,
           )
-        } catch (e: java.io.IOException) {
+        } catch (atomicFailure: java.io.IOException) {
           // Filesystems that cannot rename atomically, or cannot replace an existing file that way,
           // still get the finished content in one step; only the replacement is no longer atomic.
-          java.nio.file.Files.move(
-            temp.toPath(), target.toPath(),
-            java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-          )
+          try {
+            java.nio.file.Files.move(
+              temp.toPath(), target.toPath(),
+              java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+            )
+          } catch (fallbackFailure: java.io.IOException) {
+            // Why the atomic move failed is what explains the fallback's failure, so keep both.
+            fallbackFailure.addSuppressed(atomicFailure)
+            throw fallbackFailure
+          }
         }
       } finally {
         // A failed write or move must not leave staging files next to the logs CI uploads.

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -431,13 +431,23 @@ public class ArbigentScenarioExecutor internal constructor(
   ) {
     val settings = scenario.replayScripts ?: return
     runCatching {
+      // The runner drives the device with adb, so a script recorded on anything else could not be
+      // replayed by it. iOS and Web would need their own event mapping and runner.
+      val device = taskAssignments().last().agent.device
+      val os = device.os()
+      if (os != ArbigentDeviceOs.Android) {
+        arbigentInfoLog(
+          "Not writing a replay script for scenario ${scenario.id}: replay scripts are Android-only and this device is $os",
+        )
+        return
+      }
       val outputDir = settings.outputDir
         ?.let { File(it) }
         ?: File(ArbigentFiles.parentDir, DefaultReplayScriptsDirName)
       // The signature is what the last task left on screen. It is advisory: a replay that reaches a
       // screen with none of these ids has almost certainly gone somewhere else.
       val signature = runCatching {
-        val elements = taskAssignments().last().agent.device.elements().elements
+        val elements = device.elements().elements
         elements
           .mapNotNull { element -> ArbigentElementIdentity.from(element, elements)?.resourceId }
           .distinct()

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -245,6 +245,9 @@ public class ArbigentScenarioExecutor internal constructor(
         // Tasks that already fell back to normal execution in this attempt. A task gets one
         // fallback: failing again is an ordinary failure and restarts the whole scenario.
         val fellBackTaskIndexes = mutableSetOf<Int>()
+        // The task whose already-recorded replay-script steps must survive its re-run, set by the
+        // fallback below for a task that carries on from the screen the previous one left.
+        var keepRecordedStepsOf: Int? = null
         var index = 0
         while (index < taskAssignments().size) {
           val (task, agent) = taskAssignments()[index]
@@ -259,29 +262,36 @@ public class ArbigentScenarioExecutor internal constructor(
           replayScriptRecorder?.beginTask(
             taskIndex = index,
             goal = task.goal,
-            discardPrevious = true,
+            discardPrevious = keepRecordedStepsOf != index,
           )
-          replayScriptRecorder?.let { agent.device.addDeviceEventListener(it) }
-          supervisorScope {
-            agent.latestArbigentContextFlow
-              .flatMapLatest {
-                it?.stepsFlow ?: emptyFlow()
-              }
-              .onEach { steps ->
-                val context = agent.latestArbigentContext()
-                _arbigentScenarioRunningInfoStateFlow.value = _arbigentScenarioRunningInfoStateFlow.value?.copy(
-                  maxStep = task.maxStep,
-                  currentStep = context?.countMeaningfulActions() ?: 0
-                )
-              }
-              .launchIn(coroutineScope)
-            try {
+          keepRecordedStepsOf = null
+          // The recorder must never decide a scenario's fate: a device that cannot take a listener
+          // just loses its replay script for this task.
+          val listening = replayScriptRecorder?.let { recorder ->
+            runCatching { agent.device.addDeviceEventListener(recorder) }.isSuccess
+          } ?: false
+          try {
+            supervisorScope {
+              agent.latestArbigentContextFlow
+                .flatMapLatest {
+                  it?.stepsFlow ?: emptyFlow()
+                }
+                .onEach { steps ->
+                  val context = agent.latestArbigentContext()
+                  _arbigentScenarioRunningInfoStateFlow.value = _arbigentScenarioRunningInfoStateFlow.value?.copy(
+                    maxStep = task.maxStep,
+                    currentStep = context?.countMeaningfulActions() ?: 0
+                  )
+                }
+                .launchIn(coroutineScope)
               agent.execute(
                 agentTask = task,
                 mcpClient = mcpClient,
               )
-            } finally {
-              replayScriptRecorder?.let { agent.device.removeDeviceEventListener(it) }
+            }
+          } finally {
+            if (listening) {
+              runCatching { agent.device.removeDeviceEventListener(replayScriptRecorder!!) }
             }
           }
           if (!agent.isGoalAchieved()) {
@@ -309,11 +319,7 @@ public class ArbigentScenarioExecutor internal constructor(
               // Same reasoning for the replay script: a task that resets the device runs again from
               // the screen it started from, so what it recorded before is superseded; a task that
               // carries on keeps it, or the script would jump over actions the device has had.
-              replayScriptRecorder?.beginTask(
-                taskIndex = index,
-                goal = task.goal,
-                discardPrevious = task.resetsDeviceState(),
-              )
+              if (!task.resetsDeviceState()) keepRecordedStepsOf = index
               agent.cancel()
               _taskAssignmentsStateFlow.value = taskAssignments().toMutableList().also {
                 it[index] = ArbigentTaskAssignment(

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -5,6 +5,7 @@ import io.github.takahirom.arbigent.coroutines.buildFlatMapLatestSingleSourceSta
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.serialization.Serializable
+import java.io.File
 import kotlin.coroutines.cancellation.CancellationException
 
 public data class ArbigentScenarioRunningInfo(
@@ -205,6 +206,12 @@ public class ArbigentScenarioExecutor internal constructor(
       arbigentInfoLog("Starting replay for scenario ${scenario.id}")
     }
 
+    // One recorder for the whole execution: the device is shared by every task, and the script it
+    // writes has to describe the run end to end, not one task at a time.
+    val replayScriptRecorder = scenario.replayScripts
+      ?.takeIf { it.enabled }
+      ?.let { ArbigentReplayScriptRecorder() }
+
     var finishedSuccessfully = false
     var retryRemain = scenario.maxRetry
     var normalRetriesExhausted = false
@@ -216,6 +223,9 @@ public class ArbigentScenarioExecutor internal constructor(
       do {
         yield()
         replayedPrefixes.clear()
+        // Every task starts again from the top on a retry, so anything recorded from the abandoned
+        // attempt would replay actions the successful run never performed.
+        replayScriptRecorder?.reset()
         _taskAssignmentsStateFlow.value.forEach {
           it.agent.cancel()
         }
@@ -227,6 +237,7 @@ public class ArbigentScenarioExecutor internal constructor(
               dispatcher = dispatcher,
               replayTrace = replayTraces?.get(index)
                 .takeIf { attemptMode == ArbigentAttemptMode.ReplayWithFallback },
+              additionalInterceptors = listOfNotNull(replayScriptRecorder),
             ),
           )
         }
@@ -245,6 +256,12 @@ public class ArbigentScenarioExecutor internal constructor(
             maxStep = 0,
             currentStep = 0,
           )
+          replayScriptRecorder?.beginTask(
+            taskIndex = index,
+            goal = task.goal,
+            discardPrevious = true,
+          )
+          replayScriptRecorder?.let { agent.device.addDeviceEventListener(it) }
           supervisorScope {
             agent.latestArbigentContextFlow
               .flatMapLatest {
@@ -258,10 +275,14 @@ public class ArbigentScenarioExecutor internal constructor(
                 )
               }
               .launchIn(coroutineScope)
-            agent.execute(
-              agentTask = task,
-              mcpClient = mcpClient,
-            )
+            try {
+              agent.execute(
+                agentTask = task,
+                mcpClient = mcpClient,
+              )
+            } finally {
+              replayScriptRecorder?.let { agent.device.removeDeviceEventListener(it) }
+            }
           }
           if (!agent.isGoalAchieved()) {
             // A replayed task that fails is not evidence that the tasks before it are wrong: it is
@@ -285,6 +306,14 @@ public class ArbigentScenarioExecutor internal constructor(
               if (!task.resetsDeviceState()) {
                 replayedPrefixes[index] = agent.latestArbigentContext()?.steps().orEmpty()
               }
+              // Same reasoning for the replay script: a task that resets the device runs again from
+              // the screen it started from, so what it recorded before is superseded; a task that
+              // carries on keeps it, or the script would jump over actions the device has had.
+              replayScriptRecorder?.beginTask(
+                taskIndex = index,
+                goal = task.goal,
+                discardPrevious = task.resetsDeviceState(),
+              )
               agent.cancel()
               _taskAssignmentsStateFlow.value = taskAssignments().toMutableList().also {
                 it[index] = ArbigentTaskAssignment(
@@ -293,6 +322,7 @@ public class ArbigentScenarioExecutor internal constructor(
                     agentConfig = task.agentConfig,
                     dispatcher = dispatcher,
                     replayTrace = null,
+                    additionalInterceptors = listOfNotNull(replayScriptRecorder),
                   ),
                 )
               }
@@ -375,9 +405,50 @@ public class ArbigentScenarioExecutor internal constructor(
           }
         }
       }
+      if (replayScriptRecorder != null) {
+        writeReplayScripts(scenario, replayScriptRecorder)
+      }
       arbigentInfoLog("🟢 ${scenario.id} scenario completed successfully")
     }
     arbigentDebugLog("Arbigent.execute end")
+  }
+
+  /**
+   * Writes the replay script for a scenario that has just succeeded.
+   *
+   * Wrapped so a filesystem problem cannot turn a green scenario red: the script is a by-product of
+   * the run, and failing to write it says nothing about whether the goal was reached.
+   */
+  private fun writeReplayScripts(
+    scenario: ArbigentScenario,
+    recorder: ArbigentReplayScriptRecorder,
+  ) {
+    val settings = scenario.replayScripts ?: return
+    runCatching {
+      val outputDir = settings.outputDir
+        ?.let { File(it) }
+        ?: File(ArbigentFiles.parentDir, DefaultReplayScriptsDirName)
+      // The signature is what the last task left on screen. It is advisory: a replay that reaches a
+      // screen with none of these ids has almost certainly gone somewhere else.
+      val signature = runCatching {
+        val elements = taskAssignments().last().agent.device.elements().elements
+        elements
+          .mapNotNull { element -> ArbigentElementIdentity.from(element, elements)?.resourceId }
+          .distinct()
+          .take(MaxSignatureElements)
+      }.getOrElse { emptyList() }
+      val (screenWidth, screenHeight) = recorder.screenSize()
+      ArbigentReplayScriptWriter(outputDir).write(
+        scenarioId = scenario.id,
+        goals = scenario.agentTasks.map { it.goal },
+        tasks = recorder.recordedTasks(),
+        signature = signature,
+        screenWidth = screenWidth,
+        screenHeight = screenHeight,
+      )
+    }.onFailure {
+      arbigentInfoLog("Failed to write a replay script for scenario ${scenario.id}: ${it.message}")
+    }
   }
 
   /**
@@ -458,3 +529,9 @@ public fun ArbigentScenarioExecutor(
   builder.block()
   return builder.build()
 }
+
+/** Where replay scripts go when the project does not say. */
+private const val DefaultReplayScriptsDirName = "replay-scripts"
+
+/** How many resource ids describe the end screen. Enough to recognise it, few enough to read. */
+private const val MaxSignatureElements = 5

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -266,9 +266,12 @@ public class ArbigentScenarioExecutor internal constructor(
           )
           keepRecordedStepsOf = null
           // The recorder must never decide a scenario's fate: a device that cannot take a listener
-          // just loses its replay script for this task.
+          // just costs the scenario its replay script, since a log missing this task's actions
+          // would replay from a screen the recording never reached.
           val listening = replayScriptRecorder?.let { recorder ->
-            runCatching { agent.device.addDeviceEventListener(recorder) }.isSuccess
+            runCatching { agent.device.addDeviceEventListener(recorder) }
+              .onFailure { recorder.markEventsLost() }
+              .isSuccess
           } ?: false
           try {
             supervisorScope {
@@ -430,6 +433,12 @@ public class ArbigentScenarioExecutor internal constructor(
     recorder: ArbigentReplayScriptRecorder,
   ) {
     val settings = scenario.replayScripts ?: return
+    if (!recorder.isComplete) {
+      arbigentInfoLog(
+        "Not writing a replay script for scenario ${scenario.id}: a task ran without its device events being recorded",
+      )
+      return
+    }
     runCatching {
       // The runner drives the device with adb, so a script recorded on anything else could not be
       // replayed by it. iOS and Web would need their own event mapping and runner.

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -440,16 +440,10 @@ public class ArbigentScenarioExecutor internal constructor(
       return
     }
     runCatching {
-      // The runner drives the device with adb, so a script recorded on anything else could not be
-      // replayed by it. iOS and Web would need their own event mapping and runner.
+      // The platform is recorded in the log, because a replay is only meaningful on the kind of
+      // device the events came from.
       val device = taskAssignments().last().agent.device
       val os = device.os()
-      if (os != ArbigentDeviceOs.Android) {
-        arbigentInfoLog(
-          "Not writing a replay script for scenario ${scenario.id}: replay scripts are Android-only and this device is $os",
-        )
-        return
-      }
       val outputDir = settings.outputDir
         ?.let { File(it) }
         ?: File(ArbigentFiles.parentDir, DefaultReplayScriptsDirName)
@@ -468,6 +462,7 @@ public class ArbigentScenarioExecutor internal constructor(
         goals = scenario.agentTasks.map { it.goal },
         tasks = recorder.recordedTasks(),
         signature = signature,
+        platform = os,
         screenWidth = screenWidth,
         screenHeight = screenHeight,
       )

--- a/arbigent-core/src/test/java/ArbigentProjectFileContentTest.kt
+++ b/arbigent-core/src/test/java/ArbigentProjectFileContentTest.kt
@@ -337,6 +337,48 @@ Previous steps:
     )
   }
 
+  private val projectWithReplayScripts = ArbigentProjectSerializer().load(
+    """
+    settings:
+      replayScripts:
+        enabled: true
+        outputDir: "build/replay-scripts"
+    scenarios:
+    - id: "replay-scripts-scenario"
+      goal: "Test replay scripts"
+    """
+  )
+
+  @Test
+  fun testReplayScriptsSettings() {
+    val settings = projectWithReplayScripts.settings.replayScripts
+    assertNotNull(settings, "replayScripts should be parsed")
+    assertEquals(true, settings.enabled)
+    assertEquals("build/replay-scripts", settings.outputDir)
+
+    val scenario = projectWithReplayScripts.scenarioContents.createArbigentScenario(
+      projectSettings = projectWithReplayScripts.settings,
+      scenario = projectWithReplayScripts.scenarioContents[0],
+      aiFactory = { FakeAi() },
+      deviceFactory = { FakeDevice() },
+      aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache()
+    )
+    assertEquals(settings, scenario.replayScripts, "the scenario should carry the project setting")
+  }
+
+  @Test
+  fun testReplayScriptsAbsentMeansOff() {
+    assertNull(basicProject.settings.replayScripts)
+    val scenario = basicProject.scenarioContents.createArbigentScenario(
+      projectSettings = basicProject.settings,
+      scenario = basicProject.scenarioContents[0],
+      aiFactory = { FakeAi() },
+      deviceFactory = { FakeDevice() },
+      aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache()
+    )
+    assertNull(scenario.replayScripts)
+  }
+
   private val projectWithAdditionalActions = ArbigentProjectSerializer().load(
     """
     settings:

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -1,0 +1,365 @@
+package io.github.takahirom.arbigent.sample.test
+
+import io.github.takahirom.arbigent.ArbigentAgent
+import io.github.takahirom.arbigent.ArbigentAi
+import io.github.takahirom.arbigent.ArbigentContextHolder
+import io.github.takahirom.arbigent.ArbigentDeviceEvent
+import io.github.takahirom.arbigent.ArbigentElement
+import io.github.takahirom.arbigent.ArbigentElementIdentity
+import io.github.takahirom.arbigent.ArbigentExecuteActionsInterceptor
+import io.github.takahirom.arbigent.ArbigentReplayScriptRecorder
+import io.github.takahirom.arbigent.ArbigentReplayScriptWriter
+import io.github.takahirom.arbigent.GoalAchievedAgentAction
+import io.github.takahirom.arbigent.MCPClient
+import io.github.takahirom.arbigent.toArbigentDeviceEvents
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private fun executeActionsInput(
+  contextHolder: ArbigentContextHolder,
+  target: ArbigentElementIdentity?,
+): ArbigentAgent.ExecuteActionsInput {
+  val step = ArbigentContextHolder.Step(
+    stepId = "step",
+    agentAction = GoalAchievedAgentAction(),
+    memo = "remembered something",
+    cacheKey = "cache",
+    screenshotFilePath = "/screenshots/step-1.png",
+    targetElement = target,
+  )
+  return ArbigentAgent.ExecuteActionsInput(
+    stepId = "step",
+    decisionOutput = ArbigentAi.DecisionOutput(listOf(GoalAchievedAgentAction()), step),
+    arbigentContextHolder = contextHolder,
+    screenshotFilePath = "/screenshots/step-1.png",
+    device = FakeDevice(),
+    cacheKey = "cache",
+    elements = FakeDevice().elements(),
+    mcpClient = MCPClient(),
+  )
+}
+
+class ArbigentReplayScriptRecorderTest {
+  private val target = ArbigentElementIdentity(text = "Settings", occurrence = 0)
+
+  @Test
+  fun `events sent outside a step are attributed to the task's init phase`() = runTest {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.LaunchApp("com.example.app", clearState = true, timestamp = 1))
+
+    val task = recorder.recordedTasks().single()
+    assertEquals("Open settings", task.goal)
+    val initStep = task.steps.single()
+    assertTrue(initStep.isInit)
+    assertEquals(1, initStep.events.size)
+  }
+
+  @Test
+  fun `events sent while a step runs are attributed to that step`() = runTest {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.LaunchApp("com.example.app", timestamp = 1))
+
+    val contextHolder = ArbigentContextHolder("Open settings", 10)
+    recorder.intercept(
+      executeActionsInput(contextHolder, target),
+      ArbigentExecuteActionsInterceptor.Chain {
+        recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_DOWN", timestamp = 2))
+        recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_CENTER", timestamp = 3))
+        ArbigentAgent.ExecuteActionsOutput()
+      },
+    )
+    // Anything after the chain returns belongs to the task again, not to the step that just ended.
+    recorder.onDeviceEvent(ArbigentDeviceEvent.Wait(100, timestamp = 4))
+
+    val steps = recorder.recordedTasks().single().steps
+    assertEquals(listOf(true, false, true), steps.map { it.isInit })
+    assertEquals(1, steps[0].events.size)
+    assertEquals(2, steps[1].events.size)
+    assertEquals(target, steps[1].target)
+    assertEquals("remembered something", steps[1].memo)
+    assertEquals("step-1.png", steps[1].screenshot)
+    assertEquals(1, steps[2].events.size)
+  }
+
+  @Test
+  fun `a task that reruns from the same screen discards what it recorded before`() = runTest {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_DOWN", timestamp = 1))
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_UP", timestamp = 2))
+
+    val events = recorder.recordedTasks().single().steps.flatMap { it.events }
+    assertEquals(listOf(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_UP", 2)), events)
+  }
+
+  @Test
+  fun `a task that carries on keeps what it already did in front of what it does next`() = runTest {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_DOWN", timestamp = 1))
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = false)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_UP", timestamp = 2))
+
+    val events = recorder.recordedTasks().single().steps.flatMap { it.events }
+    assertEquals(
+      listOf(
+        ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_DOWN", 1),
+        ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_UP", 2),
+      ),
+      events,
+    )
+  }
+
+  @Test
+  fun `a step records where its target was and the screen it was on`() = runTest {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = true)
+    val contextHolder = ArbigentContextHolder("Open settings", 10)
+    // The fake elements all carry text="text", so occurrence 2 picks a known one.
+    val resolvable = ArbigentElementIdentity(text = "text", occurrence = 2)
+    recorder.intercept(
+      executeActionsInput(contextHolder, resolvable),
+      ArbigentExecuteActionsInterceptor.Chain {
+        recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_CENTER", timestamp = 2))
+        ArbigentAgent.ExecuteActionsOutput()
+      },
+    )
+
+    val step = recorder.recordedTasks().single().steps.single()
+    assertEquals(
+      ArbigentReplayScriptRecorder.RecordedBounds(0, 0, 100, 100),
+      step.targetBounds,
+    )
+    assertEquals(50, step.targetBounds!!.centerX)
+    assertEquals(50, step.targetBounds!!.centerY)
+    assertEquals(1000 to 2000, recorder.screenSize())
+    assertTrue(step.screen.isNotEmpty(), "the step should remember what screen it was decided on")
+    assertTrue(step.screen.size <= ArbigentReplayScriptRecorder.MaxScreenIdentities)
+    assertTrue(step.screen.all { it.occurrence == 0 }, "screen hints are about presence, not position")
+  }
+
+  @Test
+  fun `screen hints put labelled elements before bare containers`() {
+    val root = element(resourceId = "com.example.app:id/root_layout")
+    val title = element(text = "Settings")
+    val identities = ArbigentReplayScriptRecorder.screenIdentities(listOf(root, title, root))
+    assertEquals(listOf("Settings", null), identities.map { it.text })
+    assertEquals(listOf(null, "com.example.app:id/root_layout"), identities.map { it.resourceId })
+  }
+
+  private fun element(text: String? = null, resourceId: String? = null): ArbigentElement {
+    val attributes = buildMap {
+      put("text", text.orEmpty())
+      resourceId?.let { put("resource-id", it) }
+    }
+    return ArbigentElement(
+      index = 0,
+      textForAI = text.orEmpty(),
+      rawText = text.orEmpty(),
+      identifierData = ArbigentElement.IdentifierData(emptyList(), 0),
+      treeNode = maestro.TreeNode(attributes = attributes.toMutableMap(), children = emptyList()),
+      x = 0,
+      y = 0,
+      width = 10,
+      height = 10,
+      isVisible = true,
+    )
+  }
+
+  @Test
+  fun `restarting the scenario forgets everything`() = runTest {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_DOWN", timestamp = 1))
+    recorder.reset()
+    assertEquals(emptyList(), recorder.recordedTasks())
+  }
+}
+
+class ArbigentReplayScriptWriterTest {
+  private suspend fun recordedRunWithTarget(): List<ArbigentReplayScriptRecorder.RecordedTask> {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open the settings screen", discardPrevious = true)
+    recorder.intercept(
+      executeActionsInput(
+        ArbigentContextHolder("Open the settings screen", 10),
+        ArbigentElementIdentity(text = "text", occurrence = 2),
+      ),
+      ArbigentExecuteActionsInterceptor.Chain {
+        recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_CENTER", timestamp = 2))
+        ArbigentAgent.ExecuteActionsOutput()
+      },
+    )
+    return recorder.recordedTasks()
+  }
+
+  @Test
+  fun `the log carries the screen size and the target geometry`() = runTest {
+    val dir = Files.createTempDirectory("replay-scripts-bounds").toFile()
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open-settings",
+      goals = listOf("Open the settings screen"),
+      tasks = recordedRunWithTarget(),
+      signature = emptyList(),
+      screenWidth = 1000,
+      screenHeight = 2000,
+    )
+    val log = File(dir, "open-settings.jsonl").readText()
+    assertTrue(log.contains("\"width\":1000"), log)
+    assertTrue(log.contains("\"height\":2000"), log)
+    assertTrue(log.contains("\"bounds\":\"[0,0][100,100]\""), log)
+    assertTrue(log.contains("\"center\":{\"x\":50,\"y\":50}"), log)
+    assertTrue(log.contains("\"screen\":[{\"text\":\"text\""), log)
+  }
+
+  @Test
+  fun `a screen size the device never reported is left out`() = runTest {
+    val dir = Files.createTempDirectory("replay-scripts-nosize").toFile()
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open-settings",
+      goals = listOf("Open the settings screen"),
+      tasks = recordedRun(),
+      signature = emptyList(),
+    )
+    val start = File(dir, "open-settings.jsonl").readLines().first()
+    assertTrue(!start.contains("\"width\""), start)
+  }
+
+  private fun recordedRun(): List<ArbigentReplayScriptRecorder.RecordedTask> {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open the settings screen", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.LaunchApp("com.example.app", clearState = true, timestamp = 1))
+    return recorder.recordedTasks()
+  }
+
+  @Test
+  fun `writes the log with a file-safe name`() {
+    val dir = Files.createTempDirectory("replay-scripts").toFile()
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open settings/main",
+      goals = listOf("Open the settings screen"),
+      tasks = recordedRun(),
+      signature = listOf("com.example.app:id/settings_title"),
+    )
+
+    val log = File(dir, "open_settings_main.jsonl")
+    assertTrue(log.isFile, "expected the sanitized log file to exist")
+
+    val lines = log.readLines().filter { it.isNotBlank() }
+    assertEquals("scenario_start", lineType(lines.first()))
+    assertEquals("scenario_end", lineType(lines.last()))
+    assertTrue(lines.any { lineType(it) == "init" })
+    assertTrue(lines.all { it.contains("\"taskIndex\"") && it.contains("\"step\"") && it.contains("\"ts\"") })
+    assertTrue(log.readText().contains("com.example.app"))
+  }
+
+  @Test
+  fun `a run that sent nothing writes no files`() {
+    val dir = Files.createTempDirectory("replay-scripts").toFile()
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "empty",
+      goals = listOf("Nothing happened"),
+      tasks = listOf(ArbigentReplayScriptRecorder.RecordedTask(0, "Nothing happened")),
+      signature = emptyList(),
+    )
+    assertEquals(emptyList(), dir.listFiles()?.toList().orEmpty())
+  }
+
+  private fun lineType(line: String): String =
+    Regex("\"type\"\\s*:\\s*\"([^\"]+)\"").find(line)!!.groupValues[1]
+}
+
+/** A device that reports what it was asked to do, the way MaestroDevice does. */
+private class RecordingFakeDevice : io.github.takahirom.arbigent.ArbigentDevice by FakeDevice() {
+  private val listeners = mutableListOf<io.github.takahirom.arbigent.ArbigentDeviceEventListener>()
+  private val delegate = FakeDevice()
+
+  override fun addDeviceEventListener(listener: io.github.takahirom.arbigent.ArbigentDeviceEventListener) {
+    if (!listeners.contains(listener)) listeners.add(listener)
+  }
+
+  override fun removeDeviceEventListener(listener: io.github.takahirom.arbigent.ArbigentDeviceEventListener) {
+    listeners.remove(listener)
+  }
+
+  override fun executeActions(actions: List<maestro.orchestra.MaestroCommand>) {
+    delegate.executeActions(actions)
+    actions.forEach { command ->
+      command.toArbigentDeviceEvents(1080, 1920).forEach { event ->
+        listeners.toList().forEach { it.onDeviceEvent(event) }
+      }
+    }
+  }
+}
+
+class ArbigentReplayScriptExecutorTest {
+  @OptIn(ExperimentalStdlibApi::class)
+  @Test
+  fun `a successful scenario writes its replay script`() = runTest {
+    val dispatcher = coroutineContext[kotlinx.coroutines.CoroutineDispatcher]!!
+    val dir = Files.createTempDirectory("replay-scripts-success").toFile()
+    val agentConfig = io.github.takahirom.arbigent.AgentConfig {
+      deviceFactory { RecordingFakeDevice() }
+      aiFactory { FakeAi() }
+    }
+    io.github.takahirom.arbigent.ArbigentScenarioExecutor(dispatcher).execute(
+      scenario(agentConfig, dir),
+      MCPClient(),
+    )
+    advanceUntilIdle()
+
+    assertTrue(File(dir, "settings_scenario.jsonl").isFile)
+  }
+
+  @OptIn(ExperimentalStdlibApi::class)
+  @Test
+  fun `a failed scenario leaves the previous script untouched`() = runTest {
+    val dispatcher = coroutineContext[kotlinx.coroutines.CoroutineDispatcher]!!
+    val dir = Files.createTempDirectory("replay-scripts-failure").toFile()
+    val existing = File(dir, "settings_scenario.jsonl")
+    existing.writeText("previous run\n")
+
+    val agentConfig = io.github.takahirom.arbigent.AgentConfig {
+      deviceFactory { RecordingFakeDevice() }
+      aiFactory { FakeAi().apply { status = NeverAchievesGoal() } }
+    }
+    runCatching {
+      io.github.takahirom.arbigent.ArbigentScenarioExecutor(dispatcher).execute(
+        scenario(agentConfig, dir),
+        MCPClient(),
+      )
+    }
+    advanceUntilIdle()
+
+    assertEquals("previous run\n", existing.readText())
+  }
+
+  private fun scenario(
+    agentConfig: io.github.takahirom.arbigent.AgentConfig,
+    dir: File,
+  ) = io.github.takahirom.arbigent.ArbigentScenario(
+    id = "settings scenario",
+    agentTasks = listOf(io.github.takahirom.arbigent.ArbigentAgentTask("task1", "Open the settings screen", agentConfig)),
+    maxStepCount = 10,
+    tags = emptySet(),
+    isLeaf = true,
+    replayScripts = io.github.takahirom.arbigent.ReplayScriptsSettings(
+      enabled = true,
+      outputDir = dir.absolutePath,
+    ),
+  )
+
+  private class NeverAchievesGoal : FakeAi.Status() {
+    override fun decideAgentActions(
+      decisionInput: ArbigentAi.DecisionInput,
+    ): ArbigentAi.DecisionOutput = createDecisionOutput()
+  }
+}

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -250,8 +250,16 @@ class ArbigentReplayScriptWriterTest {
       signature = listOf("com.example.app:id/settings_title"),
     )
 
-    val log = File(dir, "open_settings_main.jsonl")
-    assertTrue(log.isFile, "expected the sanitized log file to exist")
+    val log = dir.listFiles().orEmpty().single { it.name.endsWith(".jsonl") }
+    assertTrue(
+      log.name.matches(Regex("open_settings_main-[0-9a-f]{6}\\.jsonl")),
+      "a sanitized name carries a hash so 'open settings/main' and 'open settings main' do not collide: ${log.name}",
+    )
+    assertEquals("open-settings", ArbigentReplayScriptWriter.fileBaseName("open-settings"))
+    assertTrue(
+      ArbigentReplayScriptWriter.fileBaseName("a/b") != ArbigentReplayScriptWriter.fileBaseName("a b"),
+    )
+    assertTrue(dir.listFiles().orEmpty().none { it.name.endsWith(".tmp") }, "temp file left behind")
 
     val lines = log.readLines().filter { it.isNotBlank() }
     assertEquals("scenario_start", lineType(lines.first()))
@@ -282,9 +290,13 @@ class ArbigentReplayScriptWriterTest {
 }
 
 /** A device that reports what it was asked to do, the way MaestroDevice does. */
-private class RecordingFakeDevice : io.github.takahirom.arbigent.ArbigentDevice by FakeDevice() {
+private class RecordingFakeDevice(
+  private val os: io.github.takahirom.arbigent.ArbigentDeviceOs = io.github.takahirom.arbigent.ArbigentDeviceOs.Android,
+) : io.github.takahirom.arbigent.ArbigentDevice by FakeDevice() {
   private val listeners = mutableListOf<io.github.takahirom.arbigent.ArbigentDeviceEventListener>()
   private val delegate = FakeDevice()
+
+  override fun os(): io.github.takahirom.arbigent.ArbigentDeviceOs = os
 
   override fun addDeviceEventListener(listener: io.github.takahirom.arbigent.ArbigentDeviceEventListener) {
     if (!listeners.contains(listener)) listeners.add(listener)
@@ -320,7 +332,26 @@ class ArbigentReplayScriptExecutorTest {
     )
     advanceUntilIdle()
 
-    assertTrue(File(dir, "settings_scenario.jsonl").isFile)
+    assertTrue(File(dir, "settings-scenario.jsonl").isFile)
+  }
+
+  @OptIn(ExperimentalStdlibApi::class)
+  @Test
+  fun `a scenario run on anything but Android writes no script`() = runTest {
+    val dispatcher = coroutineContext[kotlinx.coroutines.CoroutineDispatcher]!!
+    val dir = Files.createTempDirectory("replay-scripts-ios").toFile()
+    val agentConfig = io.github.takahirom.arbigent.AgentConfig {
+      deviceFactory { RecordingFakeDevice(os = io.github.takahirom.arbigent.ArbigentDeviceOs.Ios) }
+      aiFactory { FakeAi() }
+    }
+    io.github.takahirom.arbigent.ArbigentScenarioExecutor(dispatcher).execute(
+      scenario(agentConfig, dir),
+      MCPClient(),
+    )
+    advanceUntilIdle()
+
+    // The runner speaks adb, so a script from an iOS run could never be replayed by it.
+    assertEquals(emptyList(), dir.listFiles()?.toList().orEmpty())
   }
 
   @OptIn(ExperimentalStdlibApi::class)
@@ -328,7 +359,7 @@ class ArbigentReplayScriptExecutorTest {
   fun `a failed scenario leaves the previous script untouched`() = runTest {
     val dispatcher = coroutineContext[kotlinx.coroutines.CoroutineDispatcher]!!
     val dir = Files.createTempDirectory("replay-scripts-failure").toFile()
-    val existing = File(dir, "settings_scenario.jsonl")
+    val existing = File(dir, "settings-scenario.jsonl")
     existing.writeText("previous run\n")
 
     val agentConfig = io.github.takahirom.arbigent.AgentConfig {
@@ -350,7 +381,7 @@ class ArbigentReplayScriptExecutorTest {
     agentConfig: io.github.takahirom.arbigent.AgentConfig,
     dir: File,
   ) = io.github.takahirom.arbigent.ArbigentScenario(
-    id = "settings scenario",
+    id = "settings-scenario",
     agentTasks = listOf(io.github.takahirom.arbigent.ArbigentAgentTask("task1", "Open the settings screen", agentConfig)),
     maxStepCount = 10,
     tags = emptySet(),

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -259,6 +259,10 @@ class ArbigentReplayScriptWriterTest {
     assertTrue(lines.any { lineType(it) == "init" })
     assertTrue(lines.all { it.contains("\"taskIndex\"") && it.contains("\"step\"") && it.contains("\"ts\"") })
     assertTrue(log.readText().contains("com.example.app"))
+    assertEquals(
+      "_flag_like", ArbigentReplayScriptWriter.sanitizeFileName("-flag like"),
+      "a name starting with a dash would be read as an option by the runner",
+    )
   }
 
   @Test

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -283,6 +283,11 @@ class ArbigentReplayScriptWriterTest {
     val failed = runCatching { ArbigentReplayScriptWriter.writeAtomically(target, "content") }
     assertTrue(failed.isFailure, "replacing a directory should not succeed")
     assertEquals(listOf("blocked.jsonl"), dir.list().orEmpty().toList(), "the staging file must be cleaned up")
+    // The atomic attempt is what a reader of the stack trace needs to understand the fallback.
+    assertTrue(
+      failed.exceptionOrNull()?.suppressed?.isNotEmpty() == true,
+      "the atomic move failure must survive as a suppressed exception",
+    )
   }
 
   @Test

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -348,6 +348,10 @@ private class RecordingFakeDevice(
     listeners.remove(listener)
   }
 
+  override fun recordDeviceEvent(event: ArbigentDeviceEvent) {
+    listeners.toList().forEach { it.onDeviceEvent(event) }
+  }
+
   override fun executeActions(actions: List<maestro.orchestra.MaestroCommand>) {
     delegate.executeActions(actions)
     actions.forEach { command ->
@@ -463,5 +467,54 @@ class ArbigentReplayScriptExecutorTest {
     override fun decideAgentActions(
       decisionInput: ArbigentAi.DecisionInput,
     ): ArbigentAi.DecisionOutput = createDecisionOutput()
+  }
+}
+
+/**
+ * A wait sends no command, so unless the wait itself is recorded the step leaves no event and is
+ * dropped from the log. The steps after it were recorded against the screen the wait produced.
+ */
+class ArbigentRecordedWaitTest {
+  @Test
+  fun `a wait the AI decided is recorded`() {
+    val device = RecordingFakeDevice()
+    val recorded = mutableListOf<ArbigentDeviceEvent>()
+    device.addDeviceEventListener { recorded += it }
+
+    io.github.takahirom.arbigent.WaitAgentAction(5).runDeviceAction(
+      io.github.takahirom.arbigent.ArbigentAgentAction.RunInput(device, device.elements()),
+    )
+
+    assertEquals(listOf(5L), recorded.map { (it as ArbigentDeviceEvent.Wait).millis })
+  }
+
+  @Test
+  fun `a wait an initializer performs is recorded`() {
+    val config = io.github.takahirom.arbigent.AgentConfigBuilder(
+      prompt = io.github.takahirom.arbigent.ArbigentPrompt(),
+      scenarioType = io.github.takahirom.arbigent.ArbigentScenarioType.Scenario,
+      deviceFormFactor = io.github.takahirom.arbigent.result.ArbigentScenarioDeviceFormFactor.Mobile,
+      initializationMethods = listOf(
+        io.github.takahirom.arbigent.ArbigentScenarioContent.InitializationMethod.Wait(durationMs = 5),
+      ),
+      imageAssertions = io.github.takahirom.arbigent.ArbigentImageAssertions(),
+      cacheOptions = io.github.takahirom.arbigent.ArbigentScenarioCacheOptions(),
+    ).apply {
+      deviceFactory { FakeDevice() }
+      aiFactory { FakeAi() }
+    }.build()
+    val initializer = config.interceptors
+      .filterIsInstance<io.github.takahirom.arbigent.ArbigentInitializerInterceptor>()
+      .single()
+
+    val device = RecordingFakeDevice()
+    val recorded = mutableListOf<ArbigentDeviceEvent>()
+    device.addDeviceEventListener { recorded += it }
+    initializer.intercept(device, object : io.github.takahirom.arbigent.ArbigentInitializerInterceptor.Chain {
+      override fun proceed(device: io.github.takahirom.arbigent.ArbigentDevice) {
+      }
+    })
+
+    assertEquals(listOf(5L), recorded.map { (it as ArbigentDeviceEvent.Wait).millis })
   }
 }

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -4,6 +4,7 @@ import io.github.takahirom.arbigent.ArbigentAgent
 import io.github.takahirom.arbigent.ArbigentAi
 import io.github.takahirom.arbigent.ArbigentContextHolder
 import io.github.takahirom.arbigent.ArbigentDeviceEvent
+import io.github.takahirom.arbigent.ArbigentDeviceOs
 import io.github.takahirom.arbigent.ArbigentElement
 import io.github.takahirom.arbigent.ArbigentElementIdentity
 import io.github.takahirom.arbigent.ArbigentExecuteActionsInterceptor
@@ -209,6 +210,7 @@ class ArbigentReplayScriptWriterTest {
       goals = listOf("Open the settings screen"),
       tasks = recordedRunWithTarget(),
       signature = emptyList(),
+      platform = ArbigentDeviceOs.Android,
       screenWidth = 1000,
       screenHeight = 2000,
     )
@@ -221,6 +223,21 @@ class ArbigentReplayScriptWriterTest {
   }
 
   @Test
+  fun `the log declares its schema version and platform`() = runTest {
+    val dir = Files.createTempDirectory("replay-scripts-platform").toFile()
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open-settings",
+      goals = listOf("Open the settings screen"),
+      tasks = recordedRun(),
+      signature = emptyList(),
+      platform = ArbigentDeviceOs.Ios,
+    )
+    val start = File(dir, "open-settings.jsonl").readLines().first()
+    assertTrue(start.contains("\"schemaVersion\":1"), start)
+    assertTrue(start.contains("\"platform\":\"ios\""), start)
+  }
+
+  @Test
   fun `a screen size the device never reported is left out`() = runTest {
     val dir = Files.createTempDirectory("replay-scripts-nosize").toFile()
     ArbigentReplayScriptWriter(dir).write(
@@ -228,6 +245,7 @@ class ArbigentReplayScriptWriterTest {
       goals = listOf("Open the settings screen"),
       tasks = recordedRun(),
       signature = emptyList(),
+      platform = ArbigentDeviceOs.Android,
     )
     val start = File(dir, "open-settings.jsonl").readLines().first()
     assertTrue(!start.contains("\"width\""), start)
@@ -248,6 +266,7 @@ class ArbigentReplayScriptWriterTest {
       goals = listOf("Open the settings screen"),
       tasks = recordedRun(),
       signature = listOf("com.example.app:id/settings_title"),
+      platform = ArbigentDeviceOs.Android,
     )
 
     val log = dir.listFiles().orEmpty().single { it.name.endsWith(".jsonl") }
@@ -298,6 +317,7 @@ class ArbigentReplayScriptWriterTest {
       goals = listOf("Nothing happened"),
       tasks = listOf(ArbigentReplayScriptRecorder.RecordedTask(0, "Nothing happened")),
       signature = emptyList(),
+      platform = ArbigentDeviceOs.Android,
     )
     assertEquals(emptyList(), dir.listFiles()?.toList().orEmpty())
   }
@@ -381,7 +401,7 @@ class ArbigentReplayScriptExecutorTest {
 
   @OptIn(ExperimentalStdlibApi::class)
   @Test
-  fun `a scenario run on anything but Android writes no script`() = runTest {
+  fun `a scenario run on iOS records its platform`() = runTest {
     val dispatcher = coroutineContext[kotlinx.coroutines.CoroutineDispatcher]!!
     val dir = Files.createTempDirectory("replay-scripts-ios").toFile()
     val agentConfig = io.github.takahirom.arbigent.AgentConfig {
@@ -394,8 +414,8 @@ class ArbigentReplayScriptExecutorTest {
     )
     advanceUntilIdle()
 
-    // The runner speaks adb, so a script from an iOS run could never be replayed by it.
-    assertEquals(emptyList(), dir.listFiles()?.toList().orEmpty())
+    val start = File(dir, "settings-scenario.jsonl").readLines().first()
+    assertTrue(start.contains("\"platform\":\"ios\""), start)
   }
 
   @OptIn(ExperimentalStdlibApi::class)

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -274,6 +274,18 @@ class ArbigentReplayScriptWriterTest {
   }
 
   @Test
+  fun `a write that cannot finish leaves no staging file behind`() {
+    val dir = Files.createTempDirectory("replay-scripts-torn").toFile()
+    // A non-empty directory in the target's place makes both the atomic and the plain move fail
+    // (an empty one would be replaced).
+    val target = File(dir, "blocked.jsonl").apply { mkdirs() }
+    File(target, "inner.txt").writeText("occupied")
+    val failed = runCatching { ArbigentReplayScriptWriter.writeAtomically(target, "content") }
+    assertTrue(failed.isFailure, "replacing a directory should not succeed")
+    assertEquals(listOf("blocked.jsonl"), dir.list().orEmpty().toList(), "the staging file must be cleaned up")
+  }
+
+  @Test
   fun `a run that sent nothing writes no files`() {
     val dir = Files.createTempDirectory("replay-scripts").toFile()
     ArbigentReplayScriptWriter(dir).write(
@@ -292,6 +304,7 @@ class ArbigentReplayScriptWriterTest {
 /** A device that reports what it was asked to do, the way MaestroDevice does. */
 private class RecordingFakeDevice(
   private val os: io.github.takahirom.arbigent.ArbigentDeviceOs = io.github.takahirom.arbigent.ArbigentDeviceOs.Android,
+  private var refusedRegistrations: Int = 0,
 ) : io.github.takahirom.arbigent.ArbigentDevice by FakeDevice() {
   private val listeners = mutableListOf<io.github.takahirom.arbigent.ArbigentDeviceEventListener>()
   private val delegate = FakeDevice()
@@ -299,6 +312,10 @@ private class RecordingFakeDevice(
   override fun os(): io.github.takahirom.arbigent.ArbigentDeviceOs = os
 
   override fun addDeviceEventListener(listener: io.github.takahirom.arbigent.ArbigentDeviceEventListener) {
+    if (refusedRegistrations > 0) {
+      refusedRegistrations--
+      throw IllegalStateException("device refused the listener")
+    }
     if (!listeners.contains(listener)) listeners.add(listener)
   }
 
@@ -333,6 +350,28 @@ class ArbigentReplayScriptExecutorTest {
     advanceUntilIdle()
 
     assertTrue(File(dir, "settings-scenario.jsonl").isFile)
+  }
+
+  @OptIn(ExperimentalStdlibApi::class)
+  @Test
+  fun `a task whose events could not be recorded costs the scenario its script`() = runTest {
+    val dispatcher = coroutineContext[kotlinx.coroutines.CoroutineDispatcher]!!
+    val dir = Files.createTempDirectory("replay-scripts-unrecorded").toFile()
+    // One device serves both tasks; it refuses the first task's listener and accepts the second's.
+    val device = RecordingFakeDevice(refusedRegistrations = 1)
+    val agentConfig = io.github.takahirom.arbigent.AgentConfig {
+      deviceFactory { device }
+      aiFactory { FakeAi() }
+    }
+    io.github.takahirom.arbigent.ArbigentScenarioExecutor(dispatcher).execute(
+      scenario(agentConfig, dir, goals = listOf("Open the settings screen", "Open the account page")),
+      MCPClient(),
+    )
+    advanceUntilIdle()
+
+    // The second task recorded fine, but a log without the first task's actions would replay from a
+    // screen the recording never showed how to reach.
+    assertEquals(emptyList(), dir.listFiles()?.toList().orEmpty())
   }
 
   @OptIn(ExperimentalStdlibApi::class)
@@ -380,9 +419,12 @@ class ArbigentReplayScriptExecutorTest {
   private fun scenario(
     agentConfig: io.github.takahirom.arbigent.AgentConfig,
     dir: File,
+    goals: List<String> = listOf("Open the settings screen"),
   ) = io.github.takahirom.arbigent.ArbigentScenario(
     id = "settings-scenario",
-    agentTasks = listOf(io.github.takahirom.arbigent.ArbigentAgentTask("task1", "Open the settings screen", agentConfig)),
+    agentTasks = goals.mapIndexed { index, goal ->
+      io.github.takahirom.arbigent.ArbigentAgentTask("task${index + 1}", goal, agentConfig)
+    },
     maxStepCount = 10,
     tags = emptySet(),
     isLeaf = true,

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -351,7 +351,7 @@ private class RecordingFakeDevice(
   override fun executeActions(actions: List<maestro.orchestra.MaestroCommand>) {
     delegate.executeActions(actions)
     actions.forEach { command ->
-      command.toArbigentDeviceEvents(1080, 1920).forEach { event ->
+      command.toArbigentDeviceEvents(1080, 1920, os()).forEach { event ->
         listeners.toList().forEach { it.onDeviceEvent(event) }
       }
     }


### PR DESCRIPTION
Part 3 of the replay-scripts stack (on top of the device-events PR).

With the device events observable, this writes them down. After a scenario succeeds, Arbigent emits `<scenario-id>.jsonl`: an append-only event log of what was sent to the device, grouped by step, together with what the step was aiming at.

Each step line carries:

- the AI's decision (action, log, memo, screenshot name),
- the `target` element identity (text / resource id / accessibility id, occurrence, bounds, center) when the step acted on one,
- up to five `screen` hints: identities of elements the AI saw on that screen, text-bearing ones first. A step that presses a bare key with no target (a splash screen, a focus move) otherwise has nothing a replayer can wait for before sending it, which is how the first end-to-end replay ran ahead of the app. This is a small, deliberate departure from "record no layout": five identities, not the tree.

Only successful runs are written. A failed run leaves the previous log untouched, because a half-finished log replays to a screen the scenario never reached.

Wiring:

- `ArbigentReplayScriptRecorder` implements the step interceptor and the device-event listener and attributes events to the running step (or to the task's `init` phase).
- `ArbigentAgent` gains `additionalInterceptors`; `ArbigentScenarioExecutor` attaches the recorder and writes the log on success.
- Project setting `settings.replayScripts { enabled, outputDir }`, off unless present. Default output dir is `replay-scripts/` next to the other Arbigent output.

The runner that consumes this log and a readable summary come in the next two PRs.



A task that falls back from replay to the AI and carries on from the previous screen keeps the steps it had already recorded in front of the new ones (the flag is decided at the top of the task loop, so the re-run cannot discard them). Recording is isolated: a failure while describing a step, or a device that cannot take a listener, is logged and the action still runs.

The log records the platform it was captured on, and the replay runner refuses a log whose platform does not match the connected device, so a log is written whatever the device was. Files are written through a temp sibling and an atomic rename, and a scenario id the sanitizer had to change gets a short hash appended so two ids that sanitize alike do not overwrite each other.


A wait is recorded as a `wait` event. It sends no command, so without this the step leaves no event, is dropped from the log, and a replay acts on a screen that is still loading. Both an AI-decided `Wait` and a `Wait` initializer are covered, through a new `ArbigentDevice.recordDeviceEvent` for interactions a caller performs without `executeActions`.
