### PR TITLE
Ship an adb-only runner beside each replay log

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -39,6 +39,10 @@ public class ArbigentAgent internal constructor(
   // degrade to normal execution, and the failed attempt would then purge the AI-decision cache as
   // if it were an ordinary failure. Null means normal AI-driven execution.
   private val replayTrace: ArbigentReplayTrace?,
+  // Interceptors the executor adds for this one run, on top of the scenario's own. The agent
+  // config is built when the project is loaded, so anything scoped to a single execution (the
+  // replay-script recorder) cannot come from there.
+  additionalInterceptors: List<ArbigentInterceptor> = emptyList(),
 ) {
   private val attemptMode: ArbigentAttemptMode = if (replayTrace != null) {
     ArbigentAttemptMode.ReplayWithFallback
@@ -48,7 +52,7 @@ public class ArbigentAgent internal constructor(
 
   private val ai by lazy { agentConfig.aiFactory() }
   public val device: ArbigentDevice by lazy { agentConfig.deviceFactory() }
-  private val interceptors: List<ArbigentInterceptor> = agentConfig.interceptors
+  private val interceptors: List<ArbigentInterceptor> = agentConfig.interceptors + additionalInterceptors
   private val deviceFormFactor = agentConfig.deviceFormFactor
   private val prompt = agentConfig.prompt
   private val aiOptions = agentConfig.aiOptions

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProject.kt
@@ -180,6 +180,7 @@ public data class ArbigentScenario(
   val isLeaf: Boolean,
   val cacheOptions: ArbigentScenarioCacheOptions? = null,
   val mcpOptions: ArbigentMcpOptions? = null,
+  val replayScripts: ReplayScriptsSettings? = null,
 ) {
   public fun goal(): String? {
     return agentTasks.lastOrNull()?.goal

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -261,11 +261,26 @@ public data class ArbigentProjectSettings(
   public val mcpJson: String = DefaultMcpJson,
   public val deviceFormFactor: ArbigentScenarioDeviceFormFactor = ArbigentScenarioDeviceFormFactor.Unspecified,
   public val additionalActions: List<String>? = null,
+  public val replayScripts: ReplayScriptsSettings? = null,
 ) {
   public companion object {
     public const val DefaultMcpJson: String = "{}"
   }
 }
+
+/**
+ * Emits a replay script per scenario after a successful run: an event log of what was sent to the
+ * device, so the same screens can be reached again without the AI.
+ *
+ * Absent from the project file means the feature is off, so an existing project keeps writing
+ * nothing until it opts in.
+ */
+@Serializable
+public data class ReplayScriptsSettings(
+  public val enabled: Boolean = true,
+  /** Where to write. Relative paths resolve against the working directory. */
+  public val outputDir: String? = null,
+)
 
 @Serializable
 public data class ArbigentPrompt(
@@ -500,7 +515,8 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
     deviceFormFactor = effectiveScenarioDeviceFormFactor,
     isLeaf = this.none { it.dependencyId == scenario.id },
     cacheOptions = scenario.cacheOptions,
-    mcpOptions = scenario.mcpOptions
+    mcpOptions = scenario.mcpOptions,
+    replayScripts = projectSettings.replayScripts?.takeIf { it.enabled },
   )
 }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptRecorder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptRecorder.kt
@@ -116,6 +116,20 @@ internal class ArbigentReplayScriptRecorder : ArbigentExecuteActionsInterceptor,
     executeActionsInput: ExecuteActionsInput,
     chain: ArbigentExecuteActionsInterceptor.Chain,
   ): ExecuteActionsOutput {
+    // Recording is a side line: whatever goes wrong while describing the step, the action itself
+    // still runs. Events sent while no step is open land in the init bucket, which the runner
+    // treats as setup, so a step that failed to record loses its metadata but not its events.
+    val opened = runCatching { openStep(executeActionsInput) }
+      .onFailure { arbigentDebugLog("Replay script: could not record a step: $it") }
+      .isSuccess
+    return try {
+      chain.proceed(executeActionsInput)
+    } finally {
+      if (opened) synchronized(lock) { currentStep = null }
+    }
+  }
+
+  private fun openStep(executeActionsInput: ExecuteActionsInput) {
     val step = executeActionsInput.decisionOutput.step
     val elements = executeActionsInput.elements
     val recorded = RecordedStep(
@@ -137,11 +151,6 @@ internal class ArbigentReplayScriptRecorder : ArbigentExecuteActionsInterceptor,
       if (elements.screenHeight > 0) screenHeight = elements.screenHeight
       currentTask()?.steps?.add(recorded)
       currentStep = recorded
-    }
-    return try {
-      chain.proceed(executeActionsInput)
-    } finally {
-      synchronized(lock) { currentStep = null }
     }
   }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptRecorder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptRecorder.kt
@@ -1,0 +1,179 @@
+package io.github.takahirom.arbigent
+
+import io.github.takahirom.arbigent.ArbigentAgent.ExecuteActionsInput
+import io.github.takahirom.arbigent.ArbigentAgent.ExecuteActionsOutput
+import java.io.File
+
+/**
+ * Collects, for one scenario execution, what was actually sent to the device and which agent step
+ * sent it, so a replay script can be written from the run.
+ *
+ * The device layer knows what was sent but not why; the agent knows why but not what. This joins
+ * the two: it listens for device events and, as an execute-actions interceptor, marks which step is
+ * running while they arrive. Events that arrive outside any step (initializers, which run before
+ * the first step) are attributed to the task's `init` phase.
+ *
+ * One instance per scenario execution. It is written from the agent's coroutine and read from the
+ * executor's, so every mutation is guarded.
+ */
+internal class ArbigentReplayScriptRecorder : ArbigentExecuteActionsInterceptor, ArbigentDeviceEventListener {
+
+  /**
+   * Where the step's target was on screen, in the coordinate space Arbigent's own element bounds
+   * use.
+   *
+   * Maestro reads the hierarchy through its own instrumentation and sees attributes, notably
+   * Compose test tags surfaced as resource ids, that `android layout` and `uiautomator dump` do
+   * not. Recording the geometry as well gives a replay a way to reach the element by coordinates
+   * when its identity is invisible from the adb side.
+   */
+  internal data class RecordedBounds(
+    val left: Int,
+    val top: Int,
+    val right: Int,
+    val bottom: Int,
+  ) {
+    val centerX: Int get() = (left + right) / 2
+    val centerY: Int get() = (top + bottom) / 2
+  }
+
+  internal data class RecordedStep(
+    val isInit: Boolean,
+    val actionName: String? = null,
+    val actionLog: String? = null,
+    val memo: String? = null,
+    val screenshot: String? = null,
+    val target: ArbigentElementIdentity? = null,
+    val targetBounds: RecordedBounds? = null,
+    /**
+     * A few identities from the screen the decision was made on, labelled elements first. A step
+     * with no target (a bare key press) has nothing else that says which screen it belongs to, so a
+     * replay waits for one of these before sending it rather than pressing into a splash screen.
+     */
+    val screen: List<ArbigentElementIdentity> = emptyList(),
+    val events: MutableList<ArbigentDeviceEvent> = mutableListOf(),
+    val timestamp: Long = TimeProvider.get().currentTimeMillis(),
+  )
+
+  internal data class RecordedTask(
+    val taskIndex: Int,
+    val goal: String,
+    val steps: MutableList<RecordedStep> = mutableListOf(),
+  )
+
+  private val lock = Any()
+  private val tasks = linkedMapOf<Int, RecordedTask>()
+  private var currentTaskIndex: Int? = null
+  private var currentStep: RecordedStep? = null
+  private var screenWidth: Int = 0
+  private var screenHeight: Int = 0
+
+  /**
+   * The screen size the steps' coordinates are in, or `0 to 0` when no step reported one. Read
+   * from the element lists the decisions saw rather than from the device, so it is always the same
+   * space the recorded bounds are in.
+   */
+  fun screenSize(): Pair<Int, Int> = synchronized(lock) { screenWidth to screenHeight }
+
+  /** Everything recorded so far, in task order. */
+  fun recordedTasks(): List<RecordedTask> = synchronized(lock) {
+    tasks.values.map { task -> task.copy(steps = task.steps.map { it.copy(events = it.events.toMutableList()) }.toMutableList()) }
+  }
+
+  /** Forgets the whole scenario. Called when the executor restarts every task from the top. */
+  fun reset(): Unit = synchronized(lock) {
+    tasks.clear()
+    currentTaskIndex = null
+    currentStep = null
+    screenWidth = 0
+    screenHeight = 0
+  }
+
+  /**
+   * Marks [taskIndex] as the task now running.
+   *
+   * [discardPrevious] is for the executor's per-task fallback, which replaces one task's agent and
+   * runs it again. A task that resets the device state starts from the same screen it did before,
+   * so its earlier recording is superseded and must go; a task that carries on from the previous
+   * one needs what it already did kept in front of what it is about to do, or the script would
+   * replay from a screen that never existed.
+   */
+  fun beginTask(taskIndex: Int, goal: String, discardPrevious: Boolean): Unit = synchronized(lock) {
+    val task = tasks.getOrPut(taskIndex) { RecordedTask(taskIndex, goal) }
+    if (discardPrevious) task.steps.clear()
+    currentTaskIndex = taskIndex
+    currentStep = null
+  }
+
+  override fun onDeviceEvent(event: ArbigentDeviceEvent) {
+    synchronized(lock) {
+      val step = currentStep ?: initStep() ?: return
+      step.events += event
+    }
+  }
+
+  override suspend fun intercept(
+    executeActionsInput: ExecuteActionsInput,
+    chain: ArbigentExecuteActionsInterceptor.Chain,
+  ): ExecuteActionsOutput {
+    val step = executeActionsInput.decisionOutput.step
+    val elements = executeActionsInput.elements
+    val recorded = RecordedStep(
+      isInit = false,
+      actionName = step.agentAction?.let { it::class.simpleName },
+      actionLog = step.agentAction?.stepLogText(),
+      memo = step.memo,
+      screenshot = File(executeActionsInput.screenshotFilePath).name,
+      // Already resolved against the elements the decision saw; recomputing it here would match
+      // against a hierarchy that the action is about to change.
+      target = step.targetElement,
+      targetBounds = step.targetElement?.findMatch(elements)?.rect?.let {
+        RecordedBounds(it.left, it.top, it.right, it.bottom)
+      },
+      screen = screenIdentities(elements.elements),
+    )
+    synchronized(lock) {
+      if (elements.screenWidth > 0) screenWidth = elements.screenWidth
+      if (elements.screenHeight > 0) screenHeight = elements.screenHeight
+      currentTask()?.steps?.add(recorded)
+      currentStep = recorded
+    }
+    return try {
+      chain.proceed(executeActionsInput)
+    } finally {
+      synchronized(lock) { currentStep = null }
+    }
+  }
+
+  /**
+   * The `init` bucket events outside any step go to. Appended rather than kept at the head, because
+   * a task that falls back to normal execution runs its initializers again after the steps it had
+   * already replayed, and a replay has to perform them in that same order.
+   */
+  private fun initStep(): RecordedStep? {
+    val task = currentTask() ?: return null
+    val last = task.steps.lastOrNull()
+    if (last != null && last.isInit) return last
+    val created = RecordedStep(isInit = true)
+    task.steps.add(created)
+    return created
+  }
+
+  private fun currentTask(): RecordedTask? = currentTaskIndex?.let { tasks[it] }
+
+  internal companion object {
+    const val MaxScreenIdentities: Int = 5
+
+    /**
+     * Elements with visible text come first because container ids (`content`, `root_layout`) are on
+     * every screen of an app and would say nothing about which one this is.
+     */
+    fun screenIdentities(elements: List<ArbigentElement>): List<ArbigentElementIdentity> =
+      elements
+        .mapNotNull { element -> ArbigentElementIdentity.from(element, elements) }
+        .map { it.copy(occurrence = 0) }
+        .distinct()
+        .sortedBy { if (it.text != null) 0 else 1 }
+        .take(MaxScreenIdentities)
+  }
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptRecorder.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptRecorder.kt
@@ -67,6 +67,17 @@ internal class ArbigentReplayScriptRecorder : ArbigentExecuteActionsInterceptor,
   private var currentStep: RecordedStep? = null
   private var screenWidth: Int = 0
   private var screenHeight: Int = 0
+  private var eventsLost = false
+
+  /**
+   * False once a task ran without this recorder attached to the device: the steps it kept from
+   * then on have no device events behind them, and a script written from them would be missing the
+   * actions that reached the screen the later tasks continued from.
+   */
+  val isComplete: Boolean get() = synchronized(lock) { !eventsLost }
+
+  /** Records that a task's device events could not be captured. Cleared by [reset]. */
+  fun markEventsLost(): Unit = synchronized(lock) { eventsLost = true }
 
   /**
    * The screen size the steps' coordinates are in, or `0 to 0` when no step reported one. Read
@@ -87,6 +98,7 @@ internal class ArbigentReplayScriptRecorder : ArbigentExecuteActionsInterceptor,
     currentStep = null
     screenWidth = 0
     screenHeight = 0
+    eventsLost = false
   }
 
   /**

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -209,12 +209,14 @@ internal class ArbigentReplayScriptWriter(
     }
 
     /**
-     * Writes through a sibling temp file and renames, so a reader (a CI upload, a runner started
-     * on the previous script) never sees a half-written file.
+     * Writes through a uniquely named sibling temp file and renames, so a reader (a CI upload, a
+     * runner started on the previous script) never sees a half-written file and two writers (two
+     * arbigent processes sharing an output dir) never stage into the same temp file.
      */
-    fun writeAtomically(target: File, text: String) {
-      val temp = File(target.parentFile, "${target.name}.tmp")
+    fun writeAtomically(target: File, text: String, executable: Boolean = false) {
+      val temp = File(target.parentFile, "${target.name}.${ProcessHandle.current().pid()}.${System.nanoTime()}.tmp")
       temp.writeText(text)
+      if (executable) temp.setExecutable(true, false)
       try {
         java.nio.file.Files.move(
           temp.toPath(), target.toPath(),

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -189,6 +189,8 @@ internal class ArbigentReplayScriptWriter(
      */
     fun sanitizeFileName(scenarioId: String): String =
       scenarioId.replace(Regex("[^\\p{L}\\p{N}_-]"), "_")
+        // A name that starts with a dash reads as an option on the runner's command line.
+        .replaceFirst(Regex("^-"), "_")
   }
 }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -54,11 +54,12 @@ internal class ArbigentReplayScriptWriter(
       return
     }
     outputDir.mkdirs()
-    val baseName = sanitizeFileName(scenarioId)
+    val baseName = fileBaseName(scenarioId)
     val logFile = File(outputDir, "$baseName.jsonl")
-    logFile.writeText(
+    writeAtomically(
+      logFile,
       jsonLines(scenarioId, goals, tasks, steps, signature, screenWidth, screenHeight)
-        .joinToString(separator = "\n", postfix = "\n")
+        .joinToString(separator = "\n", postfix = "\n"),
     )
     arbigentInfoLog("Wrote replay script for scenario $scenarioId to ${logFile.absolutePath}")
   }
@@ -191,6 +192,42 @@ internal class ArbigentReplayScriptWriter(
       scenarioId.replace(Regex("[^\\p{L}\\p{N}_-]"), "_")
         // A name that starts with a dash reads as an option on the runner's command line.
         .replaceFirst(Regex("^-"), "_")
+
+    /**
+     * The file name a scenario's script is written under. Two ids that sanitize to the same string
+     * (`a/b` and `a b`) would otherwise overwrite each other, so a name the sanitizer had to change
+     * carries a short hash of the original id.
+     */
+    fun fileBaseName(scenarioId: String): String {
+      val sanitized = sanitizeFileName(scenarioId)
+      if (sanitized == scenarioId) return sanitized
+      val hash = java.security.MessageDigest.getInstance("SHA-256")
+        .digest(scenarioId.toByteArray())
+        .take(3)
+        .joinToString("") { "%02x".format(it) }
+      return "$sanitized-$hash"
+    }
+
+    /**
+     * Writes through a sibling temp file and renames, so a reader (a CI upload, a runner started
+     * on the previous script) never sees a half-written file.
+     */
+    fun writeAtomically(target: File, text: String) {
+      val temp = File(target.parentFile, "${target.name}.tmp")
+      temp.writeText(text)
+      try {
+        java.nio.file.Files.move(
+          temp.toPath(), target.toPath(),
+          java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+          java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+        )
+      } catch (e: java.nio.file.AtomicMoveNotSupportedException) {
+        java.nio.file.Files.move(
+          temp.toPath(), target.toPath(),
+          java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+        )
+      }
+    }
   }
 }
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -1,0 +1,207 @@
+package io.github.takahirom.arbigent
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.io.File
+
+/**
+ * One recorded step of a scenario, after task-local recordings have been flattened and numbered.
+ *
+ * Every artifact written for a run is rendered from this shape, so they cannot disagree about which
+ * step is which.
+ */
+internal data class ArbigentReplayScriptStep(
+  val taskIndex: Int,
+  /** Globally numbered across tasks, from 1. Zero means the task's `init` phase. */
+  val number: Int,
+  val isInit: Boolean,
+  val actionName: String?,
+  val actionLog: String?,
+  val memo: String?,
+  val screenshot: String?,
+  val target: ArbigentElementIdentity?,
+  val targetBounds: ArbigentReplayScriptRecorder.RecordedBounds?,
+  val screen: List<ArbigentElementIdentity>,
+  val events: List<ArbigentDeviceEvent>,
+  val timestamp: Long,
+)
+
+/**
+ * Writes the replay event log for one successful scenario.
+ *
+ * Only successful runs are written. A failed scenario leaves whatever was written before untouched,
+ * because a half-finished log replays to a screen the scenario never reached, which is worse than
+ * a stale one whose scenario id says what it is.
+ */
+internal class ArbigentReplayScriptWriter(
+  private val outputDir: File,
+) {
+  fun write(
+    scenarioId: String,
+    goals: List<String>,
+    tasks: List<ArbigentReplayScriptRecorder.RecordedTask>,
+    signature: List<String>,
+    screenWidth: Int = 0,
+    screenHeight: Int = 0,
+  ) {
+    val steps = flatten(tasks)
+    if (steps.isEmpty()) {
+      arbigentInfoLog("Not writing a replay script for scenario $scenarioId: the run recorded no device events")
+      return
+    }
+    outputDir.mkdirs()
+    val baseName = sanitizeFileName(scenarioId)
+    val logFile = File(outputDir, "$baseName.jsonl")
+    logFile.writeText(
+      jsonLines(scenarioId, goals, tasks, steps, signature, screenWidth, screenHeight)
+        .joinToString(separator = "\n", postfix = "\n")
+    )
+    arbigentInfoLog("Wrote replay script for scenario $scenarioId to ${logFile.absolutePath}")
+  }
+
+  private fun flatten(
+    tasks: List<ArbigentReplayScriptRecorder.RecordedTask>,
+  ): List<ArbigentReplayScriptStep> {
+    var number = 0
+    return tasks.flatMap { task ->
+      task.steps.mapNotNull { step ->
+        // A step that sent nothing to the device (a memo, a goal-achieved decision) has nothing to
+        // replay, and numbering it would make the step numbers in the log skip.
+        if (step.events.isEmpty()) return@mapNotNull null
+        if (!step.isInit) number++
+        ArbigentReplayScriptStep(
+          taskIndex = task.taskIndex,
+          number = if (step.isInit) 0 else number,
+          isInit = step.isInit,
+          actionName = step.actionName,
+          actionLog = step.actionLog,
+          memo = step.memo,
+          screenshot = step.screenshot,
+          target = step.target,
+          targetBounds = step.targetBounds,
+          screen = step.screen,
+          events = step.events.toList(),
+          timestamp = step.timestamp,
+        )
+      }
+    }
+  }
+
+  private fun jsonLines(
+    scenarioId: String,
+    goals: List<String>,
+    tasks: List<ArbigentReplayScriptRecorder.RecordedTask>,
+    steps: List<ArbigentReplayScriptStep>,
+    signature: List<String>,
+    screenWidth: Int,
+    screenHeight: Int,
+  ): List<String> {
+    val lines = mutableListOf<JsonObject>()
+    val firstTimestamp = steps.first().timestamp
+    val appId = steps.asSequence()
+      .flatMap { it.events.asSequence() }
+      .filterIsInstance<ArbigentDeviceEvent.LaunchApp>()
+      .firstOrNull()?.appId
+    lines += buildJsonObject {
+      header("scenario_start", scenarioId, taskIndex = 0, step = 0, ts = firstTimestamp)
+      put("goal", goals.joinToString(separator = " -> "))
+      appId?.let { put("appId", it) }
+      // Only when the device reported one; a zero would read as a real screen size.
+      if (screenWidth > 0 && screenHeight > 0) {
+        put("width", screenWidth)
+        put("height", screenHeight)
+      }
+    }
+    steps.forEach { step ->
+      if (step.isInit) {
+        step.events.forEach { event ->
+          lines += buildJsonObject {
+            header("init", scenarioId, step.taskIndex, step.number, event.timestamp)
+            put("event", json.encodeToJsonElement(ArbigentDeviceEvent.serializer(), event))
+          }
+        }
+        return@forEach
+      }
+      lines += buildJsonObject {
+        header("decision", scenarioId, step.taskIndex, step.number, step.timestamp)
+        put("action", step.actionName ?: "")
+        put("log", step.actionLog ?: "")
+        put("goal", tasks.firstOrNull { it.taskIndex == step.taskIndex }?.goal ?: "")
+        step.memo?.let { put("memo", it) }
+        step.screenshot?.let { put("screenshot", it) }
+        // What the decision was looking at. A step without a target waits for one of these.
+        if (step.screen.isNotEmpty()) {
+          put("screen", buildJsonArray {
+            step.screen.forEach { identity ->
+              add(buildJsonObject {
+                identity.text?.let { put("text", it) }
+                identity.resourceId?.let { put("resourceId", it) }
+                identity.accessibilityId?.let { put("accessibilityId", it) }
+              })
+            }
+          })
+        }
+      }
+      step.target?.let { target ->
+        lines += buildJsonObject {
+          header("target", scenarioId, step.taskIndex, step.number, step.timestamp)
+          target.text?.let { put("text", it) }
+          target.resourceId?.let { put("resourceId", it) }
+          target.accessibilityId?.let { put("accessibilityId", it) }
+          put("occurrence", target.occurrence)
+          // Maestro sees attributes that an adb-side dump may not, so the geometry travels with
+          // the identity as a coordinate fallback.
+          step.targetBounds?.let { bounds ->
+            put("bounds", "[${bounds.left},${bounds.top}][${bounds.right},${bounds.bottom}]")
+            put("center", buildJsonObject {
+              put("x", bounds.centerX)
+              put("y", bounds.centerY)
+            })
+          }
+        }
+      }
+      step.events.forEach { event ->
+        lines += buildJsonObject {
+          header("device", scenarioId, step.taskIndex, step.number, event.timestamp)
+          put("event", json.encodeToJsonElement(ArbigentDeviceEvent.serializer(), event))
+        }
+      }
+    }
+    val last = steps.last()
+    lines += buildJsonObject {
+      header("scenario_end", scenarioId, last.taskIndex, last.number, last.timestamp)
+      put("status", "success")
+      put("signature", buildJsonArray { signature.forEach { add(it) } })
+    }
+    return lines.map { it.toString() }
+  }
+
+  internal companion object {
+    private val json = Json { encodeDefaults = true }
+
+    /**
+     * Scenario ids are free text and become file names, so anything that is not a letter, digit,
+     * underscore or hyphen is replaced rather than escaped.
+     */
+    fun sanitizeFileName(scenarioId: String): String =
+      scenarioId.replace(Regex("[^\\p{L}\\p{N}_-]"), "_")
+  }
+}
+
+private fun kotlinx.serialization.json.JsonObjectBuilder.header(
+  type: String,
+  scenarioId: String,
+  taskIndex: Int,
+  step: Int,
+  ts: Long,
+) {
+  put("type", type)
+  put("task", scenarioId)
+  put("taskIndex", taskIndex)
+  put("step", step)
+  put("ts", ts)
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -31,7 +31,8 @@ internal data class ArbigentReplayScriptStep(
 )
 
 /**
- * Writes the replay event log for one successful scenario.
+ * Writes the replay event log for one successful scenario, and the runner shared by every scenario
+ * in the directory.
  *
  * Only successful runs are written. A failed scenario leaves whatever was written before untouched,
  * because a half-finished log replays to a screen the scenario never reached, which is worse than
@@ -61,7 +62,17 @@ internal class ArbigentReplayScriptWriter(
       jsonLines(scenarioId, goals, tasks, steps, signature, screenWidth, screenHeight)
         .joinToString(separator = "\n", postfix = "\n"),
     )
+    writeRunner()
     arbigentInfoLog("Wrote replay script for scenario $scenarioId to ${logFile.absolutePath}")
+  }
+
+  private fun writeRunner() {
+    val runner = File(outputDir, RUNNER_FILE_NAME)
+    val source = checkNotNull(javaClass.classLoader.getResourceAsStream(RUNNER_FILE_NAME)) {
+      "$RUNNER_FILE_NAME is missing from the arbigent resources"
+    }
+    source.use { input -> runner.outputStream().use { output -> input.copyTo(output) } }
+    runner.setExecutable(true, false)
   }
 
   private fun flatten(
@@ -71,7 +82,7 @@ internal class ArbigentReplayScriptWriter(
     return tasks.flatMap { task ->
       task.steps.mapNotNull { step ->
         // A step that sent nothing to the device (a memo, a goal-achieved decision) has nothing to
-        // replay, and numbering it would make the step numbers in the log skip.
+        // replay, and numbering it would make the runner's --step numbers skip.
         if (step.events.isEmpty()) return@mapNotNull null
         if (!step.isInit) number++
         ArbigentReplayScriptStep(
@@ -182,6 +193,8 @@ internal class ArbigentReplayScriptWriter(
   }
 
   internal companion object {
+    const val RUNNER_FILE_NAME: String = "replay.sh"
+
     private val json = Json { encodeDefaults = true }
 
     /**

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -57,22 +57,24 @@ internal class ArbigentReplayScriptWriter(
     outputDir.mkdirs()
     val baseName = fileBaseName(scenarioId)
     val logFile = File(outputDir, "$baseName.jsonl")
+    // The runner lands before the log so a log that exists is always runnable.
+    writeRunner()
     writeAtomically(
       logFile,
       jsonLines(scenarioId, goals, tasks, steps, signature, screenWidth, screenHeight)
         .joinToString(separator = "\n", postfix = "\n"),
     )
-    writeRunner()
     arbigentInfoLog("Wrote replay script for scenario $scenarioId to ${logFile.absolutePath}")
   }
 
+  // The runner is shared by every replay in the directory, so it is replaced atomically like the
+  // logs: a runner mid-copy must never be what a concurrent replay executes.
   private fun writeRunner() {
-    val runner = File(outputDir, RUNNER_FILE_NAME)
     val source = checkNotNull(javaClass.classLoader.getResourceAsStream(RUNNER_FILE_NAME)) {
       "$RUNNER_FILE_NAME is missing from the arbigent resources"
     }
-    source.use { input -> runner.outputStream().use { output -> input.copyTo(output) } }
-    runner.setExecutable(true, false)
+    val text = source.use { it.readBytes().decodeToString() }
+    writeAtomically(File(outputDir, RUNNER_FILE_NAME), text, executable = true)
   }
 
   private fun flatten(

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -217,7 +217,10 @@ internal class ArbigentReplayScriptWriter(
       val temp = File(target.parentFile, "${target.name}.${ProcessHandle.current().pid()}.${System.nanoTime()}.tmp")
       try {
         temp.writeText(text)
-        if (executable) temp.setExecutable(true, false)
+        // A runner nobody can execute is worse than no runner: fail before it replaces the old one.
+        if (executable && !temp.setExecutable(true, false)) {
+          throw java.io.IOException("Could not make ${temp.name} executable")
+        }
         try {
           java.nio.file.Files.move(
             temp.toPath(), target.toPath(),

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -215,19 +215,26 @@ internal class ArbigentReplayScriptWriter(
      */
     fun writeAtomically(target: File, text: String, executable: Boolean = false) {
       val temp = File(target.parentFile, "${target.name}.${ProcessHandle.current().pid()}.${System.nanoTime()}.tmp")
-      temp.writeText(text)
-      if (executable) temp.setExecutable(true, false)
       try {
-        java.nio.file.Files.move(
-          temp.toPath(), target.toPath(),
-          java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-          java.nio.file.StandardCopyOption.ATOMIC_MOVE,
-        )
-      } catch (e: java.nio.file.AtomicMoveNotSupportedException) {
-        java.nio.file.Files.move(
-          temp.toPath(), target.toPath(),
-          java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-        )
+        temp.writeText(text)
+        if (executable) temp.setExecutable(true, false)
+        try {
+          java.nio.file.Files.move(
+            temp.toPath(), target.toPath(),
+            java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+            java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+          )
+        } catch (e: java.io.IOException) {
+          // Filesystems that cannot rename atomically, or cannot replace an existing file that way,
+          // still get the finished content in one step; only the replacement is no longer atomic.
+          java.nio.file.Files.move(
+            temp.toPath(), target.toPath(),
+            java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+          )
+        }
+      } finally {
+        // A failed write or move must not leave staging files next to the logs CI uploads.
+        temp.delete()
       }
     }
   }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -227,13 +227,19 @@ internal class ArbigentReplayScriptWriter(
             java.nio.file.StandardCopyOption.REPLACE_EXISTING,
             java.nio.file.StandardCopyOption.ATOMIC_MOVE,
           )
-        } catch (e: java.io.IOException) {
+        } catch (atomicFailure: java.io.IOException) {
           // Filesystems that cannot rename atomically, or cannot replace an existing file that way,
           // still get the finished content in one step; only the replacement is no longer atomic.
-          java.nio.file.Files.move(
-            temp.toPath(), target.toPath(),
-            java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-          )
+          try {
+            java.nio.file.Files.move(
+              temp.toPath(), target.toPath(),
+              java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+            )
+          } catch (fallbackFailure: java.io.IOException) {
+            // Why the atomic move failed is what explains the fallback's failure, so keep both.
+            fallbackFailure.addSuppressed(atomicFailure)
+            throw fallbackFailure
+          }
         }
       } finally {
         // A failed write or move must not leave staging files next to the logs CI uploads.

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -431,13 +431,23 @@ public class ArbigentScenarioExecutor internal constructor(
   ) {
     val settings = scenario.replayScripts ?: return
     runCatching {
+      // The runner drives the device with adb, so a script recorded on anything else could not be
+      // replayed by it. iOS and Web would need their own event mapping and runner.
+      val device = taskAssignments().last().agent.device
+      val os = device.os()
+      if (os != ArbigentDeviceOs.Android) {
+        arbigentInfoLog(
+          "Not writing a replay script for scenario ${scenario.id}: replay scripts are Android-only and this device is $os",
+        )
+        return
+      }
       val outputDir = settings.outputDir
         ?.let { File(it) }
         ?: File(ArbigentFiles.parentDir, DefaultReplayScriptsDirName)
       // The signature is what the last task left on screen. It is advisory: a replay that reaches a
       // screen with none of these ids has almost certainly gone somewhere else.
       val signature = runCatching {
-        val elements = taskAssignments().last().agent.device.elements().elements
+        val elements = device.elements().elements
         elements
           .mapNotNull { element -> ArbigentElementIdentity.from(element, elements)?.resourceId }
           .distinct()

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -245,6 +245,9 @@ public class ArbigentScenarioExecutor internal constructor(
         // Tasks that already fell back to normal execution in this attempt. A task gets one
         // fallback: failing again is an ordinary failure and restarts the whole scenario.
         val fellBackTaskIndexes = mutableSetOf<Int>()
+        // The task whose already-recorded replay-script steps must survive its re-run, set by the
+        // fallback below for a task that carries on from the screen the previous one left.
+        var keepRecordedStepsOf: Int? = null
         var index = 0
         while (index < taskAssignments().size) {
           val (task, agent) = taskAssignments()[index]
@@ -259,29 +262,36 @@ public class ArbigentScenarioExecutor internal constructor(
           replayScriptRecorder?.beginTask(
             taskIndex = index,
             goal = task.goal,
-            discardPrevious = true,
+            discardPrevious = keepRecordedStepsOf != index,
           )
-          replayScriptRecorder?.let { agent.device.addDeviceEventListener(it) }
-          supervisorScope {
-            agent.latestArbigentContextFlow
-              .flatMapLatest {
-                it?.stepsFlow ?: emptyFlow()
-              }
-              .onEach { steps ->
-                val context = agent.latestArbigentContext()
-                _arbigentScenarioRunningInfoStateFlow.value = _arbigentScenarioRunningInfoStateFlow.value?.copy(
-                  maxStep = task.maxStep,
-                  currentStep = context?.countMeaningfulActions() ?: 0
-                )
-              }
-              .launchIn(coroutineScope)
-            try {
+          keepRecordedStepsOf = null
+          // The recorder must never decide a scenario's fate: a device that cannot take a listener
+          // just loses its replay script for this task.
+          val listening = replayScriptRecorder?.let { recorder ->
+            runCatching { agent.device.addDeviceEventListener(recorder) }.isSuccess
+          } ?: false
+          try {
+            supervisorScope {
+              agent.latestArbigentContextFlow
+                .flatMapLatest {
+                  it?.stepsFlow ?: emptyFlow()
+                }
+                .onEach { steps ->
+                  val context = agent.latestArbigentContext()
+                  _arbigentScenarioRunningInfoStateFlow.value = _arbigentScenarioRunningInfoStateFlow.value?.copy(
+                    maxStep = task.maxStep,
+                    currentStep = context?.countMeaningfulActions() ?: 0
+                  )
+                }
+                .launchIn(coroutineScope)
               agent.execute(
                 agentTask = task,
                 mcpClient = mcpClient,
               )
-            } finally {
-              replayScriptRecorder?.let { agent.device.removeDeviceEventListener(it) }
+            }
+          } finally {
+            if (listening) {
+              runCatching { agent.device.removeDeviceEventListener(replayScriptRecorder!!) }
             }
           }
           if (!agent.isGoalAchieved()) {
@@ -309,11 +319,7 @@ public class ArbigentScenarioExecutor internal constructor(
               // Same reasoning for the replay script: a task that resets the device runs again from
               // the screen it started from, so what it recorded before is superseded; a task that
               // carries on keeps it, or the script would jump over actions the device has had.
-              replayScriptRecorder?.beginTask(
-                taskIndex = index,
-                goal = task.goal,
-                discardPrevious = task.resetsDeviceState(),
-              )
+              if (!task.resetsDeviceState()) keepRecordedStepsOf = index
               agent.cancel()
               _taskAssignmentsStateFlow.value = taskAssignments().toMutableList().also {
                 it[index] = ArbigentTaskAssignment(

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -5,6 +5,7 @@ import io.github.takahirom.arbigent.coroutines.buildFlatMapLatestSingleSourceSta
 import kotlinx.coroutines.*
 import kotlinx.coroutines.flow.*
 import kotlinx.serialization.Serializable
+import java.io.File
 import kotlin.coroutines.cancellation.CancellationException
 
 public data class ArbigentScenarioRunningInfo(
@@ -205,6 +206,12 @@ public class ArbigentScenarioExecutor internal constructor(
       arbigentInfoLog("Starting replay for scenario ${scenario.id}")
     }
 
+    // One recorder for the whole execution: the device is shared by every task, and the script it
+    // writes has to describe the run end to end, not one task at a time.
+    val replayScriptRecorder = scenario.replayScripts
+      ?.takeIf { it.enabled }
+      ?.let { ArbigentReplayScriptRecorder() }
+
     var finishedSuccessfully = false
     var retryRemain = scenario.maxRetry
     var normalRetriesExhausted = false
@@ -216,6 +223,9 @@ public class ArbigentScenarioExecutor internal constructor(
       do {
         yield()
         replayedPrefixes.clear()
+        // Every task starts again from the top on a retry, so anything recorded from the abandoned
+        // attempt would replay actions the successful run never performed.
+        replayScriptRecorder?.reset()
         _taskAssignmentsStateFlow.value.forEach {
           it.agent.cancel()
         }
@@ -227,6 +237,7 @@ public class ArbigentScenarioExecutor internal constructor(
               dispatcher = dispatcher,
               replayTrace = replayTraces?.get(index)
                 .takeIf { attemptMode == ArbigentAttemptMode.ReplayWithFallback },
+              additionalInterceptors = listOfNotNull(replayScriptRecorder),
             ),
           )
         }
@@ -245,6 +256,12 @@ public class ArbigentScenarioExecutor internal constructor(
             maxStep = 0,
             currentStep = 0,
           )
+          replayScriptRecorder?.beginTask(
+            taskIndex = index,
+            goal = task.goal,
+            discardPrevious = true,
+          )
+          replayScriptRecorder?.let { agent.device.addDeviceEventListener(it) }
           supervisorScope {
             agent.latestArbigentContextFlow
               .flatMapLatest {
@@ -258,10 +275,14 @@ public class ArbigentScenarioExecutor internal constructor(
                 )
               }
               .launchIn(coroutineScope)
-            agent.execute(
-              agentTask = task,
-              mcpClient = mcpClient,
-            )
+            try {
+              agent.execute(
+                agentTask = task,
+                mcpClient = mcpClient,
+              )
+            } finally {
+              replayScriptRecorder?.let { agent.device.removeDeviceEventListener(it) }
+            }
           }
           if (!agent.isGoalAchieved()) {
             // A replayed task that fails is not evidence that the tasks before it are wrong: it is
@@ -285,6 +306,14 @@ public class ArbigentScenarioExecutor internal constructor(
               if (!task.resetsDeviceState()) {
                 replayedPrefixes[index] = agent.latestArbigentContext()?.steps().orEmpty()
               }
+              // Same reasoning for the replay script: a task that resets the device runs again from
+              // the screen it started from, so what it recorded before is superseded; a task that
+              // carries on keeps it, or the script would jump over actions the device has had.
+              replayScriptRecorder?.beginTask(
+                taskIndex = index,
+                goal = task.goal,
+                discardPrevious = task.resetsDeviceState(),
+              )
               agent.cancel()
               _taskAssignmentsStateFlow.value = taskAssignments().toMutableList().also {
                 it[index] = ArbigentTaskAssignment(
@@ -293,6 +322,7 @@ public class ArbigentScenarioExecutor internal constructor(
                     agentConfig = task.agentConfig,
                     dispatcher = dispatcher,
                     replayTrace = null,
+                    additionalInterceptors = listOfNotNull(replayScriptRecorder),
                   ),
                 )
               }
@@ -375,9 +405,50 @@ public class ArbigentScenarioExecutor internal constructor(
           }
         }
       }
+      if (replayScriptRecorder != null) {
+        writeReplayScripts(scenario, replayScriptRecorder)
+      }
       arbigentInfoLog("🟢 ${scenario.id} scenario completed successfully")
     }
     arbigentDebugLog("Arbigent.execute end")
+  }
+
+  /**
+   * Writes the replay script for a scenario that has just succeeded.
+   *
+   * Wrapped so a filesystem problem cannot turn a green scenario red: the script is a by-product of
+   * the run, and failing to write it says nothing about whether the goal was reached.
+   */
+  private fun writeReplayScripts(
+    scenario: ArbigentScenario,
+    recorder: ArbigentReplayScriptRecorder,
+  ) {
+    val settings = scenario.replayScripts ?: return
+    runCatching {
+      val outputDir = settings.outputDir
+        ?.let { File(it) }
+        ?: File(ArbigentFiles.parentDir, DefaultReplayScriptsDirName)
+      // The signature is what the last task left on screen. It is advisory: a replay that reaches a
+      // screen with none of these ids has almost certainly gone somewhere else.
+      val signature = runCatching {
+        val elements = taskAssignments().last().agent.device.elements().elements
+        elements
+          .mapNotNull { element -> ArbigentElementIdentity.from(element, elements)?.resourceId }
+          .distinct()
+          .take(MaxSignatureElements)
+      }.getOrElse { emptyList() }
+      val (screenWidth, screenHeight) = recorder.screenSize()
+      ArbigentReplayScriptWriter(outputDir).write(
+        scenarioId = scenario.id,
+        goals = scenario.agentTasks.map { it.goal },
+        tasks = recorder.recordedTasks(),
+        signature = signature,
+        screenWidth = screenWidth,
+        screenHeight = screenHeight,
+      )
+    }.onFailure {
+      arbigentInfoLog("Failed to write a replay script for scenario ${scenario.id}: ${it.message}")
+    }
   }
 
   /**
@@ -458,3 +529,9 @@ public fun ArbigentScenarioExecutor(
   builder.block()
   return builder.build()
 }
+
+/** Where replay scripts go when the project does not say. */
+private const val DefaultReplayScriptsDirName = "replay-scripts"
+
+/** How many resource ids describe the end screen. Enough to recognise it, few enough to read. */
+private const val MaxSignatureElements = 5

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -266,9 +266,12 @@ public class ArbigentScenarioExecutor internal constructor(
           )
           keepRecordedStepsOf = null
           // The recorder must never decide a scenario's fate: a device that cannot take a listener
-          // just loses its replay script for this task.
+          // just costs the scenario its replay script, since a log missing this task's actions
+          // would replay from a screen the recording never reached.
           val listening = replayScriptRecorder?.let { recorder ->
-            runCatching { agent.device.addDeviceEventListener(recorder) }.isSuccess
+            runCatching { agent.device.addDeviceEventListener(recorder) }
+              .onFailure { recorder.markEventsLost() }
+              .isSuccess
           } ?: false
           try {
             supervisorScope {
@@ -430,6 +433,12 @@ public class ArbigentScenarioExecutor internal constructor(
     recorder: ArbigentReplayScriptRecorder,
   ) {
     val settings = scenario.replayScripts ?: return
+    if (!recorder.isComplete) {
+      arbigentInfoLog(
+        "Not writing a replay script for scenario ${scenario.id}: a task ran without its device events being recorded",
+      )
+      return
+    }
     runCatching {
       // The runner drives the device with adb, so a script recorded on anything else could not be
       // replayed by it. iOS and Web would need their own event mapping and runner.

--- a/arbigent-core/src/main/resources/replay.sh
+++ b/arbigent-core/src/main/resources/replay.sh
@@ -4,6 +4,10 @@
 # The event log beside this script records what Arbigent actually sent to the device. This script
 # sends the same things again, waiting before each step for the element that step targeted so a
 # replay that drifts stops and says where, instead of tapping blindly.
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "replay.sh: python3 is required but was not found on PATH" >&2
+  exit 1
+fi
 exec python3 - "$@" <<'PY'
 """Replay an Arbigent device event log with adb."""
 
@@ -126,14 +130,20 @@ def parse_args(argv):
         index += 1
     if options.log is None:
         fail_usage("no event log given")
+    if options.start is not None and options.until is not None and options.start > options.until:
+        fail_usage("--from %d is after --until %d" % (options.start, options.until))
     return options
 
 
 def int_or_fail(name, value):
+    """Steps are numbered from 1, so zero or a negative number never names one."""
     try:
-        return int(value)
+        number = int(value)
     except ValueError:
         fail_usage("%s needs a whole number, got %r" % (name, value))
+    if number < 1:
+        fail_usage("%s needs a step number of 1 or more, got %r" % (name, value))
+    return number
 
 
 def timeout_or_fail(name, value):
@@ -169,18 +179,22 @@ def load_events(path):
     if not os.path.exists(path):
         fail_usage("no such event log: %s" % path)
     events = []
-    with open(path, "r") as handle:
-        for number, line in enumerate(handle, 1):
-            line = line.strip()
-            if not line:
-                continue
-            try:
-                event = json.loads(line)
-            except ValueError:
-                fail_usage("%s line %d is not JSON: %s" % (path, number, line[:120]))
-            if not isinstance(event, dict) or not isinstance(event.get("type"), str):
-                fail_usage("%s line %d is not an event record" % (path, number))
-            events.append(event)
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            lines = handle.read().splitlines()
+    except (OSError, UnicodeError) as error:
+        fail_usage("could not read event log %s: %s" % (path, error))
+    for number, line in enumerate(lines, 1):
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except ValueError:
+            fail_usage("%s line %d is not JSON: %s" % (path, number, line[:120]))
+        if not isinstance(event, dict) or not isinstance(event.get("type"), str):
+            fail_usage("%s line %d is not an event record" % (path, number))
+        events.append(event)
     return events
 
 

--- a/arbigent-core/src/main/resources/replay.sh
+++ b/arbigent-core/src/main/resources/replay.sh
@@ -10,6 +10,7 @@ exec python3 - "$@" <<'PY'
 import json
 import os
 import re
+import shlex
 import shutil
 import subprocess
 import sys
@@ -30,11 +31,18 @@ USAGE = """usage: replay.sh <log.jsonl> [options]
                     events
   --backend NAME    how to read the hierarchy: auto (default), android,
                     uiautomator or maestro
+
+exit codes: 0 replayed, 1 usage or unreadable log, 2 the screen diverged
+from the recording, 3 a device command failed
 """
 
 EXIT_OK = 0
 EXIT_USAGE = 1
 EXIT_DIVERGED = 2
+EXIT_DEVICE = 3
+
+# No single adb command should take longer than this; a hung adb otherwise hangs the replay.
+ADB_TIMEOUT_SECONDS = 60.0
 
 TEXT_KEYS = ["text", "value"]
 RESOURCE_ID_KEYS = ["resourceId", "resource-id", "id"]
@@ -101,11 +109,15 @@ def parse_args(argv):
                     fail_usage("--backend must be one of %s" % ", ".join(BACKENDS))
                 options.backend = value
             else:
-                try:
-                    options.timeout = float(value)
-                except ValueError:
-                    fail_usage("%s needs a number, got %r" % (arg, value))
-        elif arg.startswith("-"):
+                options.timeout = timeout_or_fail(arg, value)
+        elif arg == "--":
+            for rest in argv[index + 1:]:
+                if options.log is None:
+                    options.log = rest
+                else:
+                    fail_usage("unexpected argument %s" % rest)
+            break
+        elif arg.startswith("-") and arg != "-":
             fail_usage("unknown option %s" % arg)
         elif options.log is None:
             options.log = arg
@@ -124,36 +136,76 @@ def int_or_fail(name, value):
         fail_usage("%s needs a whole number, got %r" % (name, value))
 
 
+def timeout_or_fail(name, value):
+    """A finite, positive number of seconds; NaN or infinity would make a wait never end."""
+    try:
+        seconds = float(value)
+    except ValueError:
+        fail_usage("%s needs a number, got %r" % (name, value))
+    if seconds != seconds or seconds in (float("inf"), float("-inf")) or seconds <= 0:
+        fail_usage("%s needs a positive number of seconds, got %r" % (name, value))
+    return seconds
+
+
 def fail_usage(message):
     sys.stderr.write("replay.sh: %s\n\n%s" % (message, USAGE))
     sys.exit(EXIT_USAGE)
 
 
+class DeviceCommandFailed(Exception):
+    """A command the device rejected; carrying on would replay against a screen we did not reach."""
+
+
+class Diverged(Exception):
+    """The screen no longer matches the recording at this step."""
+
+
 def load_events(path):
-    """Every line of the jsonl log, in order. Unreadable lines are skipped rather than fatal."""
+    """Every line of the jsonl log, in order.
+
+    A line that does not parse means the log was cut short or edited, and a replay that skipped it
+    would send fewer commands than the recording without saying so, so it is refused instead.
+    """
     if not os.path.exists(path):
         fail_usage("no such event log: %s" % path)
     events = []
     with open(path, "r") as handle:
-        for line in handle:
+        for number, line in enumerate(handle, 1):
             line = line.strip()
             if not line:
                 continue
             try:
-                events.append(json.loads(line))
+                event = json.loads(line)
             except ValueError:
-                sys.stderr.write("skipping unreadable log line: %s\n" % line[:120])
+                fail_usage("%s line %d is not JSON: %s" % (path, number, line[:120]))
+            if not isinstance(event, dict) or not isinstance(event.get("type"), str):
+                fail_usage("%s line %d is not an event record" % (path, number))
+            events.append(event)
     return events
+
+
+def require_complete(meta, path):
+    """A log without a successful end was never finished; replaying part of it is not a replay."""
+    if not meta["started"]:
+        fail_usage("%s has no scenario_start line" % path)
+    if meta["status"] != "success":
+        fail_usage(
+            "%s does not end with a successful scenario_end (the run was cut short or failed)" % path
+        )
 
 
 def group_steps(events):
     """Turns the flat log into (meta, steps): one entry per step, in the order they ran."""
-    meta = {"goal": "", "appId": None, "signature": [], "task": "", "width": None, "height": None}
+    meta = {
+        "goal": "", "appId": None, "signature": [], "task": "", "width": None, "height": None,
+        "started": False, "status": None,
+    }
     steps = []
-    by_key = {}
+    previous_key = None
     for event in events:
         kind = event.get("type")
         if kind == "scenario_start":
+            meta["started"] = True
             meta["goal"] = event.get("goal", "")
             meta["appId"] = event.get("appId")
             meta["task"] = event.get("task", "")
@@ -161,13 +213,17 @@ def group_steps(events):
             meta["height"] = event.get("height")
             continue
         if kind == "scenario_end":
+            meta["status"] = event.get("status")
             meta["signature"] = event.get("signature", [])
             continue
         number = event.get("step", 0)
         task_index = event.get("taskIndex", 0)
         key = (task_index, number)
-        step = by_key.get(key)
-        if step is None:
+        # Groups are consecutive runs of the same key, not one group per key: a task that fell back
+        # to the AI launches the app again after the steps it had already replayed, and that second
+        # setup block has to stay where it happened rather than merge into the first.
+        if key != previous_key:
+            previous_key = key
             step = {
                 "number": number,
                 "taskIndex": task_index,
@@ -180,8 +236,9 @@ def group_steps(events):
                 "screen": [],
                 "events": [],
             }
-            by_key[key] = step
             steps.append(step)
+        else:
+            step = steps[-1]
         if kind == "decision":
             step["action"] = event.get("action", "")
             step["log"] = event.get("log", "")
@@ -257,6 +314,8 @@ def describe_event(event):
     kind = event.get("type")
     if kind == "tap":
         return "tap(%s,%s)" % (event.get("x"), event.get("y"))
+    if kind == "tap_element":
+        return "tap(%s)" % describe_selector(event)
     if kind == "key_press":
         return event.get("keyName", "?")
     if kind == "input_text":
@@ -268,6 +327,8 @@ def describe_event(event):
         )
     if kind == "launch_app":
         suffix = ", clearState" if event.get("clearState") else ""
+        if event.get("stopApp") is False:
+            suffix += ", keepRunning"
         return "launch(%s%s%s)" % (event.get("appId"), suffix, describe_launch_arguments(event))
     if kind == "stop_app":
         return "stop(%s)" % event.get("appId")
@@ -280,6 +341,17 @@ def describe_event(event):
     if kind == "unsupported":
         return "unsupported(%s)" % event.get("command")
     return str(event)
+
+
+def describe_selector(event):
+    parts = []
+    if event.get("textRegex") is not None:
+        parts.append("text=%r" % event["textRegex"])
+    if event.get("idRegex") is not None:
+        parts.append("id=%r" % event["idRegex"])
+    if event.get("index"):
+        parts.append("index=%s" % event["index"])
+    return ", ".join(parts) or "element"
 
 
 def summarize_events(events):
@@ -313,19 +385,49 @@ def show(meta, steps):
         sys.stdout.write("\nexpect: resource ids %s\n" % ", ".join(meta["signature"]))
 
 
+def adb_command(args):
+    """The argv for one adb call.
+
+    Everything after `shell` or `exec-out` is run by the device's shell as one line, so each remote
+    argument is quoted for it: a typed text with a space or a launch extra with a `;` in it must
+    reach the device as data, not as more commands.
+    """
+    if args and args[0] in ("shell", "exec-out"):
+        return ["adb", args[0], " ".join(shlex.quote(arg) for arg in args[1:])]
+    return ["adb"] + args
+
+
 def adb(options, args, capture=False):
-    """Runs one adb command. --device is passed as ANDROID_SERIAL so `android` sees it too."""
+    """Runs one adb command and returns (code, stdout, stderr).
+
+    --device is passed as ANDROID_SERIAL so `android` sees it too. Output is captured either way so
+    a failure can be quoted; with capture=False it is also echoed, as it was before.
+    """
     env = dict(os.environ)
     if options.device:
         env["ANDROID_SERIAL"] = options.device
-    command = ["adb"] + args
-    if capture:
-        process = subprocess.Popen(
-            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+    try:
+        process = subprocess.run(
+            adb_command(args), stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env,
+            timeout=ADB_TIMEOUT_SECONDS,
         )
-        out, err = process.communicate()
-        return process.returncode, out, err
-    return subprocess.call(command, env=env), b"", b""
+    except subprocess.TimeoutExpired:
+        return 124, b"", ("adb %s took longer than %.0fs" % (args[0], ADB_TIMEOUT_SECONDS)).encode()
+    if not capture:
+        if process.stdout:
+            sys.stdout.write(process.stdout.decode("utf-8", "replace"))
+        if process.stderr:
+            sys.stderr.write(process.stderr.decode("utf-8", "replace"))
+    return process.returncode, process.stdout, process.stderr
+
+
+def checked(result, what):
+    """Raises DeviceCommandFailed unless the adb result succeeded."""
+    code, out, err = result
+    if code != 0:
+        detail = (out + err).decode("utf-8", "replace").strip()
+        raise DeviceCommandFailed("%s failed (exit %d)%s" % (what, code, ": " + detail if detail else ""))
+    return result
 
 
 def require_adb():
@@ -413,14 +515,14 @@ def dump_tree_android_cli(options):
     if options.device:
         env["ANDROID_SERIAL"] = options.device
     try:
-        process = subprocess.Popen(
-            ["android", "layout"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+        process = subprocess.run(
+            ["android", "layout"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env,
+            timeout=ADB_TIMEOUT_SECONDS,
         )
-        out, _ = process.communicate()
         if process.returncode != 0:
             return None
-        payload = json.loads(out.decode("utf-8", "replace"))
-    except (OSError, ValueError):
+        payload = json.loads(process.stdout.decode("utf-8", "replace"))
+    except (OSError, ValueError, subprocess.TimeoutExpired):
         return None
     # The CLI prints a flat list of nodes, but be forgiving about a wrapper object.
     if isinstance(payload, dict):
@@ -442,26 +544,30 @@ def dump_tree_uiautomator(options):
     While the screen is still moving the command exits 0 but prints "could not get idle state"
     instead of writing the file, so the exit code alone is not enough to tell success from failure.
     """
-    remote = "/sdcard/arbigent-replay-dump.xml"
-    for attempt in range(UIAUTOMATOR_DUMP_ATTEMPTS):
-        if attempt:
-            time.sleep(STABILITY_POLL_SECONDS)
+    # One file per runner process, removed once read: the dump holds every string on screen, and
+    # two replays against the same device must not read each other's.
+    remote = "/sdcard/arbigent-replay-dump-%d.xml" % os.getpid()
+    try:
+        for attempt in range(UIAUTOMATOR_DUMP_ATTEMPTS):
+            if attempt:
+                time.sleep(STABILITY_POLL_SECONDS)
+            code, out, err = adb(options, ["shell", "uiautomator", "dump", remote], capture=True)
+            combined = (out + err).decode("utf-8", "replace")
+            if code != 0 or "ERROR" in combined or "could not get idle state" in combined:
+                continue
+            code, out, _ = adb(options, ["exec-out", "cat", remote], capture=True)
+            if code != 0 or not out.strip():
+                continue
+            try:
+                root = ElementTree.fromstring(out.decode("utf-8", "replace"))
+            except ElementTree.ParseError:
+                continue
+            nodes = []
+            flatten_xml(root, nodes)
+            return nodes
+        return []
+    finally:
         adb(options, ["shell", "rm", "-f", remote], capture=True)
-        code, out, err = adb(options, ["shell", "uiautomator", "dump", remote], capture=True)
-        combined = (out + err).decode("utf-8", "replace")
-        if code != 0 or "ERROR" in combined or "could not get idle state" in combined:
-            continue
-        code, out, _ = adb(options, ["exec-out", "cat", remote], capture=True)
-        if code != 0 or not out.strip():
-            continue
-        try:
-            root = ElementTree.fromstring(out.decode("utf-8", "replace"))
-        except ElementTree.ParseError:
-            continue
-        nodes = []
-        flatten_xml(root, nodes)
-        return nodes
-    return []
 
 
 def flatten_xml(element, out):
@@ -580,14 +686,14 @@ def wait_for(options, target):
     A dump taken mid-transition can look unresolvable while the screen it is turning into is not, so
     an unresolvable dump is only believed once the screen has settled.
     """
-    deadline = time.time() + options.timeout
+    deadline = time.monotonic() + options.timeout
     nodes = []
     while True:
         nodes = dump_tree(options)
         if find_match(nodes, target) is not None:
             return "matched", wait_until_stable(options, nodes)
         if nodes and not identity_is_resolvable(nodes, target):
-            stable = wait_until_stable(options, nodes, cap=max(0.0, deadline - time.time()))
+            stable = wait_until_stable(options, nodes, cap=max(0.0, deadline - time.monotonic()))
             if find_match(stable, target) is not None:
                 return "matched", stable
             if not identity_is_resolvable(stable, target):
@@ -596,16 +702,16 @@ def wait_for(options, target):
             # The first dump was mid-transition; the settled screen does show identities, so the
             # target's absence is meaningful again and the deadline still applies.
             nodes = stable
-        if time.time() >= deadline:
+        if time.monotonic() >= deadline:
             return "absent", nodes
         time.sleep(STABILITY_POLL_SECONDS)
 
 
 def wait_until_stable(options, nodes, cap=STABILITY_CAP_SECONDS):
     """Two consecutive identical dumps, capped, so an animation does not eat the next tap."""
-    deadline = time.time() + cap
+    deadline = time.monotonic() + cap
     previous = nodes
-    while time.time() < deadline:
+    while time.monotonic() < deadline:
         time.sleep(STABILITY_POLL_SECONDS)
         current = dump_tree(options)
         if current == previous:
@@ -614,39 +720,119 @@ def wait_until_stable(options, nodes, cap=STABILITY_CAP_SECONDS):
     return previous
 
 
-def send_event(options, event):
+REGEX_FLAGS = re.IGNORECASE | re.DOTALL | re.MULTILINE
+
+
+def selector_matches(node, event):
+    """Whether a node is what Maestro's text/id regex selector would have picked.
+
+    Maestro matches the whole value, case-insensitively, with `.` spanning lines; text also matches
+    the accessibility label. An id regex is tried against the short id too, for the `android` CLI.
+    """
+    text_regex = event.get("textRegex")
+    id_regex = event.get("idRegex")
+    if text_regex is not None:
+        values = [node.get("text"), node.get("accessibilityId")]
+        if not any(
+            isinstance(value, str) and re.fullmatch(text_regex, value, REGEX_FLAGS) for value in values
+        ):
+            return False
+    if id_regex is not None:
+        node_id = node.get("resourceId")
+        if not isinstance(node_id, str):
+            return False
+        if not re.fullmatch(id_regex, node_id, REGEX_FLAGS) and not re.fullmatch(
+            short_resource_id(id_regex), short_resource_id(node_id), REGEX_FLAGS
+        ):
+            return False
+    return True
+
+
+def resolve_element(nodes, event):
+    """The node an element tap should land on now, or None."""
+    try:
+        matched = [node for node in nodes if selector_matches(node, event)]
+    except re.error:
+        return None
+    index = event.get("index") or 0
+    if index < len(matched):
+        return matched[index]
+    return None
+
+
+def tap_element(options, event, step, nodes):
+    """Taps the element the recorded run tapped by selector, wherever it is on screen now.
+
+    The current hierarchy decides; the recorded target center is only a last resort for a backend
+    that cannot see the element, and a selector nothing matches is a divergence, since Maestro would
+    have refused the tap at the same point.
+    """
+    node = resolve_element(nodes, event) or resolve_element(dump_tree(options), event)
+    center = node.get("center") if node else None
+    if center is None and step.get("target") and step["target"].get("center"):
+        center = step["target"]["center"]
+        sys.stdout.write("   tap: element not in the dump, using the recorded position\n")
+    if not center:
+        raise Diverged("no element on screen matches %s" % describe_selector(event))
+    checked(
+        adb(options, ["shell", "input", "tap", str(center["x"]), str(center["y"])]),
+        "tap on %s" % describe_selector(event),
+    )
+
+
+def send_event(options, event, step, nodes):
+    """Sends one recorded event. Returns False for an event adb cannot reproduce."""
     kind = event.get("type")
     if kind == "tap":
-        adb(options, ["shell", "input", "tap", str(event["x"]), str(event["y"])])
+        checked(adb(options, ["shell", "input", "tap", str(event["x"]), str(event["y"])]), "tap")
+    elif kind == "tap_element":
+        tap_element(options, event, step, nodes)
     elif kind == "key_press":
-        adb(options, ["shell", "input", "keyevent", str(event["keyName"])])
+        checked(adb(options, ["shell", "input", "keyevent", str(event["keyName"])]), "key press")
     elif kind == "input_text":
-        adb(options, ["shell", "input", "text", escape_text(event.get("text", ""))])
+        text = event.get("text", "")
+        if not typeable(text):
+            raise Diverged(
+                "adb shell input text cannot type %r (only printable ASCII travels through it)" % text
+            )
+        checked(adb(options, ["shell", "input", "text", escape_text(text)]), "text input")
     elif kind == "swipe":
-        adb(options, [
+        checked(adb(options, [
             "shell", "input", "swipe",
             str(event["startX"]), str(event["startY"]),
             str(event["endX"]), str(event["endY"]),
             str(event.get("durationMs", 400)),
-        ])
+        ]), "swipe")
     elif kind == "launch_app":
+        app_id = str(event["appId"])
         if event.get("clearState"):
-            adb(options, ["shell", "pm", "clear", str(event["appId"])], capture=True)
-        launch_app(options, str(event["appId"]), event.get("launchArguments") or {})
+            clear_state(options, app_id)
+        elif event.get("stopApp", True):
+            # Maestro force-stops before launching unless told not to; pm clear already did.
+            checked(adb(options, ["shell", "am", "force-stop", app_id], capture=True), "force-stop")
+        launch_app(options, app_id, event.get("launchArguments") or {})
     elif kind == "stop_app":
-        adb(options, ["shell", "am", "force-stop", str(event["appId"])])
+        checked(adb(options, ["shell", "am", "force-stop", str(event["appId"])]), "force-stop")
     elif kind == "clear_state":
-        adb(options, ["shell", "pm", "clear", str(event["appId"])], capture=True)
+        clear_state(options, str(event["appId"]))
     elif kind == "wait":
         time.sleep(float(event.get("millis", 0)) / 1000.0)
     elif kind == "open_link":
-        adb(options, [
-            "shell", "am", "start", "-a", "android.intent.action.VIEW",
+        checked(adb(options, [
+            "shell", "am", "start", "-W", "-a", "android.intent.action.VIEW",
             "-d", str(event["url"]),
-        ])
+        ], capture=True), "open link")
     else:
         return False
     return True
+
+
+def clear_state(options, app_id):
+    # `pm clear` reports a package it could not clear with "Failed" on stdout and exit code 0.
+    code, out, err = adb(options, ["shell", "pm", "clear", app_id], capture=True)
+    combined = (out + err).decode("utf-8", "replace")
+    if code != 0 or "Success" not in combined:
+        raise DeviceCommandFailed("pm clear %s failed: %s" % (app_id, combined.strip() or "no output"))
 
 
 def launcher_activity(options, app_id):
@@ -665,7 +851,11 @@ def launcher_activity(options, app_id):
 
 
 def extra_flag(value):
-    """The `am start` flag that carries a JSON value of this type as an intent extra."""
+    """The `am start` flag that carries a JSON value of this type as an intent extra.
+
+    The log keeps extras as JSON primitives, so a whole number is passed as an int extra; Maestro's
+    YAML gives it the same type, and an app reading it as a long would already differ under Maestro.
+    """
     if isinstance(value, bool):
         return "--ez", "true" if value else "false"
     if isinstance(value, int):
@@ -686,9 +876,12 @@ def launch_app(options, app_id, arguments):
     if component is None:
         if arguments:
             sys.stdout.write("   launch: could not resolve the launcher activity, extras dropped\n")
-        adb(options, [
+        code, out, err = adb(options, [
             "shell", "monkey", "-p", app_id, "-c", "android.intent.category.LAUNCHER", "1",
         ], capture=True)
+        combined = (out + err).decode("utf-8", "replace")
+        if code != 0 or "Events injected: 1" not in combined:
+            raise DeviceCommandFailed("could not launch %s: %s" % (app_id, combined.strip()))
         return
     command = ["shell", "am", "start", "-W", "-n", component]
     for key in sorted(arguments):
@@ -697,21 +890,29 @@ def launch_app(options, app_id, arguments):
     code, out, err = adb(options, command, capture=True)
     combined = (out + err).decode("utf-8", "replace")
     if code != 0 or "Error" in combined:
-        sys.stderr.write(combined)
+        raise DeviceCommandFailed("am start %s failed: %s" % (component, combined.strip()))
+
+
+def typeable(text):
+    """`input text` only carries printable ASCII faithfully; anything else comes out changed."""
+    return all(" " <= character <= "~" for character in text)
 
 
 def escape_text(text):
-    """`input text` splits on spaces and eats a few punctuation marks, so encode them."""
-    out = text.replace("%", "%%").replace(" ", "%s")
-    return re.sub(r"([()<>|;&*\\~\"'`$])", r"\\\1", out)
+    """`input text` splits its argument on spaces, so a space travels as `%s`.
+
+    The argument is shell-quoted on the way in, so no other character needs escaping. A literal
+    `%s` in the text is the one thing this cannot express: the device turns it into a space too.
+    """
+    return text.replace(" ", "%s")
 
 
-def send_step_events(options, step):
+def send_step_events(options, step, nodes):
     previous_was_key = False
     for event in step["events"]:
         if event.get("type") == "key_press" and previous_was_key:
             time.sleep(KEY_PRESS_GAP_SECONDS)
-        if not send_event(options, event):
+        if not send_event(options, event, step, nodes):
             return event
         previous_was_key = event.get("type") == "key_press"
     return None
@@ -743,7 +944,7 @@ def report_divergence(options, meta, step, remaining, nodes, reason):
         out.write("  remaining steps:\n")
         for later in remaining:
             out.write("    %d. %s\n" % (later["number"], later["log"] or later["action"]))
-    out.write("  resume with: replay.sh %s --from %d\n" % (options.log, step["number"]))
+    out.write("  resume with: ./replay.sh %s --from %d\n" % (shlex.quote(options.log), step["number"]))
 
 
 def describe_node(node):
@@ -760,13 +961,13 @@ def wait_for_screen(options, hints):
     Advisory only: the hints say which screen the decision was looking at, not what it acted on, so
     running out of time is reported and the step still goes ahead. Returns True when a hint matched.
     """
-    deadline = time.time() + options.timeout
+    deadline = time.monotonic() + options.timeout
     while True:
         nodes = dump_tree(options)
         if any(find_match(nodes, hint) is not None for hint in hints):
             wait_until_stable(options, nodes)
             return True
-        if time.time() >= deadline:
+        if time.monotonic() >= deadline:
             sys.stdout.write(
                 "   wait: none of the recorded screen hints appeared within %.0fs, continuing\n"
                 % options.timeout
@@ -799,6 +1000,7 @@ def check_signature(options, signature):
 def main():
     options = parse_args(sys.argv[1:])
     meta, steps = group_steps(load_events(options.log))
+    require_complete(meta, options.log)
     selected = select_steps(steps, options)
     if options.show:
         show(meta, selected)
@@ -824,7 +1026,17 @@ def main():
                 return EXIT_DIVERGED
         elif step["screen"] and not options.no_wait and not step["isInit"]:
             wait_for_screen(options, step["screen"])
-        unsupported = send_step_events(options, step)
+        try:
+            unsupported = send_step_events(options, step, nodes)
+        except Diverged as error:
+            report_divergence(options, meta, step, remaining, nodes or dump_tree(options), str(error))
+            return EXIT_DIVERGED
+        except DeviceCommandFailed as error:
+            sys.stderr.write("\nreplay.sh: step %d: %s\n" % (step["number"], error))
+            sys.stderr.write(
+                "  resume with: ./replay.sh %s --from %d\n" % (shlex.quote(options.log), step["number"])
+            )
+            return EXIT_DEVICE
         if unsupported is not None:
             report_divergence(
                 options, meta, step, remaining, nodes or dump_tree(options),
@@ -841,6 +1053,9 @@ def run():
     except NotImplementedError as error:
         sys.stderr.write("replay.sh: %s\n" % error)
         return EXIT_USAGE
+    except DeviceCommandFailed as error:
+        sys.stderr.write("replay.sh: %s\n" % error)
+        return EXIT_DEVICE
 
 
 if __name__ == "__main__":

--- a/arbigent-core/src/main/resources/replay.sh
+++ b/arbigent-core/src/main/resources/replay.sh
@@ -198,28 +198,41 @@ def load_events(path):
     return events
 
 
-def require_complete(meta, path):
-    """A log without a successful end was never finished; replaying part of it is not a replay."""
-    if not meta["started"]:
-        fail_usage("%s has no scenario_start line" % path)
-    if meta["status"] != "success":
+def require_complete(events, path):
+    """A replay log is one finished run: a scenario_start first, a successful scenario_end last.
+
+    Anything else (a missing or failed end, lines after the end, a second start, or lines from
+    another scenario) means the file is not the record of one successful run, and replaying a part
+    of it would not be a replay.
+    """
+    if not events or events[0].get("type") != "scenario_start":
+        fail_usage("%s does not start with a scenario_start line" % path)
+    if len([event for event in events if event.get("type") == "scenario_start"]) > 1:
+        fail_usage("%s has more than one scenario_start line; a replay log holds a single run" % path)
+    last = events[-1]
+    if last.get("type") != "scenario_end" or last.get("status") != "success":
         fail_usage(
-            "%s does not end with a successful scenario_end (the run was cut short or failed)" % path
+            "%s does not end with a successful scenario_end "
+            "(the run was cut short or failed, or lines were appended after it)" % path
         )
+    if any(event.get("type") == "scenario_end" for event in events[:-1]):
+        fail_usage("%s has a scenario_end line before the end of the file" % path)
+    task = events[0].get("task")
+    for event in events:
+        if event.get("task", task) != task:
+            fail_usage("%s mixes lines from scenarios %r and %r" % (path, task, event.get("task")))
 
 
 def group_steps(events):
     """Turns the flat log into (meta, steps): one entry per step, in the order they ran."""
     meta = {
         "goal": "", "appId": None, "signature": [], "task": "", "width": None, "height": None,
-        "started": False, "status": None,
     }
     steps = []
     previous_key = None
     for event in events:
         kind = event.get("type")
         if kind == "scenario_start":
-            meta["started"] = True
             meta["goal"] = event.get("goal", "")
             meta["appId"] = event.get("appId")
             meta["task"] = event.get("task", "")
@@ -227,7 +240,6 @@ def group_steps(events):
             meta["height"] = event.get("height")
             continue
         if kind == "scenario_end":
-            meta["status"] = event.get("status")
             meta["signature"] = event.get("signature", [])
             continue
         number = event.get("step", 0)
@@ -1037,7 +1049,24 @@ def report_divergence(options, meta, step, remaining, nodes, reason):
         out.write("  remaining steps:\n")
         for later in remaining:
             out.write("    %d. %s\n" % (later["number"], later["log"] or later["action"]))
-    out.write("  resume with: ./replay.sh %s --from %d\n" % (shlex.quote(options.log), step["number"]))
+    write_resume_hint(out, options, step, remaining)
+
+
+def write_resume_hint(out, options, step, remaining):
+    """The command that picks up where this run stopped, when there is one.
+
+    Step zero is not a valid `--from`, so a failed setup block points at the first numbered step it
+    was preparing (with `--with-init`, so that block is replayed first); when nothing numbered is
+    left there is nothing to resume.
+    """
+    if not step["isInit"]:
+        out.write("  resume with: ./replay.sh %s --from %d\n" % (shlex.quote(options.log), step["number"]))
+        return
+    later = [item["number"] for item in remaining if not item["isInit"]]
+    if later:
+        out.write(
+            "  resume with: ./replay.sh %s --with-init --from %d\n" % (shlex.quote(options.log), later[0])
+        )
 
 
 def describe_node(node):
@@ -1094,8 +1123,9 @@ def check_signature(options, signature):
 
 def main():
     options = parse_args(sys.argv[1:])
-    meta, steps = group_steps(load_events(options.log))
-    require_complete(meta, options.log)
+    events = load_events(options.log)
+    require_complete(events, options.log)
+    meta, steps = group_steps(events)
     selected = select_steps(steps, options)
     if not selected:
         sys.stderr.write("replay.sh: nothing to replay for the given range\n")
@@ -1131,9 +1161,7 @@ def main():
             return EXIT_DIVERGED
         except DeviceCommandFailed as error:
             sys.stderr.write("\nreplay.sh: step %d: %s\n" % (step["number"], error))
-            sys.stderr.write(
-                "  resume with: ./replay.sh %s --from %d\n" % (shlex.quote(options.log), step["number"])
-            )
+            write_resume_hint(sys.stderr, options, step, remaining)
             return EXIT_DEVICE
         if unsupported is not None:
             report_divergence(

--- a/arbigent-core/src/main/resources/replay.sh
+++ b/arbigent-core/src/main/resources/replay.sh
@@ -424,7 +424,7 @@ def adb_command(args):
 def adb(options, args, capture=False):
     """Runs one adb command and returns (code, stdout, stderr).
 
-    --device is passed as ANDROID_SERIAL so `android` sees it too. Output is captured either way so
+    --device is passed as ANDROID_SERIAL. Output is captured either way so
     a failure can be quoted; with capture=False it is also echoed, as it was before.
     """
     env = dict(os.environ)
@@ -526,11 +526,12 @@ def dump_tree(options, backend=None):
         nodes = dump_tree_uiautomator(options)
     except DeviceCommandFailed:
         # adb itself failed, so `android layout` (which also goes through adb) is tried only because
-        # it may reach the device a different way; without it the failure stands.
+        # it may reach the device a different way. An empty answer from it proves nothing here: it
+        # prints an empty tree for a device it cannot reach either, so the failure stands.
         if shutil.which("android") is None:
             raise
         nodes = dump_tree_android_cli(options)
-        if nodes is None:
+        if not nodes:
             raise
         return nodes
     if nodes:
@@ -552,8 +553,13 @@ def dump_tree_android_cli(options):
     if options.device:
         env["ANDROID_SERIAL"] = options.device
     try:
+        # The CLI does not read ANDROID_SERIAL: with it alone, a serial that does not exist quietly
+        # reads whatever single device is attached instead.
+        command = ["android", "layout"]
+        if options.device:
+            command += ["--device", options.device]
         process = subprocess.run(
-            ["android", "layout"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env,
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env,
             timeout=ADB_TIMEOUT_SECONDS,
         )
         if process.returncode != 0:

--- a/arbigent-core/src/main/resources/replay.sh
+++ b/arbigent-core/src/main/resources/replay.sh
@@ -292,9 +292,10 @@ def select_steps(steps, options):
     A setup block rides with the step that came after it: a relaunch in the middle of a run is only
     needed if the step it prepared for is replayed. The block before the first step is the exception
     and is always included with --with-init, because it is how the app gets launched at all. A block
-    at the very end rides with the step before it.
+    at the very end rides with the step before it. --step N follows the same rule, so
+    `--step N --with-init` launches the app and replays the setup that prepared step N.
     """
-    include_init = options.with_init and options.step is None
+    include_init = options.with_init
     selected = []
     pending = []
     seen_step = False
@@ -606,8 +607,10 @@ def dump_tree_uiautomator(options):
     would be wrong, so that case raises DeviceCommandFailed instead of pretending the screen is empty.
     """
     # One file per runner process, removed once read: the dump holds every string on screen, and
-    # two replays against the same device must not read each other's.
-    remote = "/sdcard/arbigent-replay-dump-%d.xml" % os.getpid()
+    # two replays against the same device must not read each other's. It goes under the shell
+    # user's private tmp rather than shared external storage, so a dump left behind by a killed
+    # runner is not readable by every app on the device.
+    remote = "/data/local/tmp/arbigent-replay-dump-%d.xml" % os.getpid()
     adb_failures = []
     try:
         for attempt in range(UIAUTOMATOR_DUMP_ATTEMPTS):
@@ -1103,6 +1106,9 @@ def main():
     require_adb()
     if options.backend == "android" and shutil.which("android") is None:
         fail_usage("--backend android needs the `android` CLI on PATH")
+    if options.backend == "maestro":
+        # Refused before anything is sent: the first hierarchy read may come after a step's events.
+        fail_usage("--backend maestro is not implemented yet; use uiautomator or android")
     for position, step in enumerate(selected):
         remaining = selected[position + 1:]
         label = "setup" if step["isInit"] else (step["log"] or step["action"])

--- a/arbigent-core/src/main/resources/replay.sh
+++ b/arbigent-core/src/main/resources/replay.sh
@@ -1,0 +1,848 @@
+#!/bin/sh
+# Replays an Arbigent run against a device using nothing but adb.
+#
+# The event log beside this script records what Arbigent actually sent to the device. This script
+# sends the same things again, waiting before each step for the element that step targeted so a
+# replay that drifts stops and says where, instead of tapping blindly.
+exec python3 - "$@" <<'PY'
+"""Replay an Arbigent device event log with adb."""
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+import xml.etree.ElementTree as ElementTree
+
+USAGE = """usage: replay.sh <log.jsonl> [options]
+
+  --show            print the steps and exit, without touching a device
+  --step N          replay only step N
+  --from N          start at step N
+  --until N         stop after step N
+  --with-init       also replay the setup phase (app launch, state clear)
+  --device SERIAL   use this device
+  --timeout SEC     how long to wait for each step's target or screen hints
+                    (default 10)
+  --no-wait         do not wait for targets or screen hints, just send the
+                    events
+  --backend NAME    how to read the hierarchy: auto (default), android,
+                    uiautomator or maestro
+"""
+
+EXIT_OK = 0
+EXIT_USAGE = 1
+EXIT_DIVERGED = 2
+
+TEXT_KEYS = ["text", "value"]
+RESOURCE_ID_KEYS = ["resourceId", "resource-id", "id"]
+ACCESSIBILITY_KEYS = [
+    "contentDesc",
+    "content-desc",
+    "accessibilityText",
+    "contentDescription",
+    "accessibility-id",
+    "label",
+    "name",
+]
+
+BACKENDS = ("auto", "android", "uiautomator", "maestro")
+
+KEY_PRESS_GAP_SECONDS = 0.15
+STABILITY_POLL_SECONDS = 0.5
+STABILITY_CAP_SECONDS = 3.0
+
+
+class Options(object):
+    def __init__(self):
+        self.log = None
+        self.show = False
+        self.step = None
+        self.start = None
+        self.until = None
+        self.with_init = False
+        self.device = None
+        self.timeout = 10.0
+        self.no_wait = False
+        self.backend = "auto"
+
+
+def parse_args(argv):
+    options = Options()
+    index = 0
+    while index < len(argv):
+        arg = argv[index]
+        if arg in ("-h", "--help"):
+            sys.stdout.write(USAGE)
+            sys.exit(EXIT_OK)
+        elif arg == "--show":
+            options.show = True
+        elif arg == "--with-init":
+            options.with_init = True
+        elif arg == "--no-wait":
+            options.no_wait = True
+        elif arg in ("--step", "--from", "--until", "--device", "--timeout", "--backend"):
+            index += 1
+            if index >= len(argv):
+                fail_usage("%s needs a value" % arg)
+            value = argv[index]
+            if arg == "--step":
+                options.step = int_or_fail(arg, value)
+            elif arg == "--from":
+                options.start = int_or_fail(arg, value)
+            elif arg == "--until":
+                options.until = int_or_fail(arg, value)
+            elif arg == "--device":
+                options.device = value
+            elif arg == "--backend":
+                if value not in BACKENDS:
+                    fail_usage("--backend must be one of %s" % ", ".join(BACKENDS))
+                options.backend = value
+            else:
+                try:
+                    options.timeout = float(value)
+                except ValueError:
+                    fail_usage("%s needs a number, got %r" % (arg, value))
+        elif arg.startswith("-"):
+            fail_usage("unknown option %s" % arg)
+        elif options.log is None:
+            options.log = arg
+        else:
+            fail_usage("unexpected argument %s" % arg)
+        index += 1
+    if options.log is None:
+        fail_usage("no event log given")
+    return options
+
+
+def int_or_fail(name, value):
+    try:
+        return int(value)
+    except ValueError:
+        fail_usage("%s needs a whole number, got %r" % (name, value))
+
+
+def fail_usage(message):
+    sys.stderr.write("replay.sh: %s\n\n%s" % (message, USAGE))
+    sys.exit(EXIT_USAGE)
+
+
+def load_events(path):
+    """Every line of the jsonl log, in order. Unreadable lines are skipped rather than fatal."""
+    if not os.path.exists(path):
+        fail_usage("no such event log: %s" % path)
+    events = []
+    with open(path, "r") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                events.append(json.loads(line))
+            except ValueError:
+                sys.stderr.write("skipping unreadable log line: %s\n" % line[:120])
+    return events
+
+
+def group_steps(events):
+    """Turns the flat log into (meta, steps): one entry per step, in the order they ran."""
+    meta = {"goal": "", "appId": None, "signature": [], "task": "", "width": None, "height": None}
+    steps = []
+    by_key = {}
+    for event in events:
+        kind = event.get("type")
+        if kind == "scenario_start":
+            meta["goal"] = event.get("goal", "")
+            meta["appId"] = event.get("appId")
+            meta["task"] = event.get("task", "")
+            meta["width"] = event.get("width")
+            meta["height"] = event.get("height")
+            continue
+        if kind == "scenario_end":
+            meta["signature"] = event.get("signature", [])
+            continue
+        number = event.get("step", 0)
+        task_index = event.get("taskIndex", 0)
+        key = (task_index, number)
+        step = by_key.get(key)
+        if step is None:
+            step = {
+                "number": number,
+                "taskIndex": task_index,
+                "isInit": number == 0,
+                "action": "",
+                "log": "",
+                "memo": None,
+                "screenshot": None,
+                "target": None,
+                "screen": [],
+                "events": [],
+            }
+            by_key[key] = step
+            steps.append(step)
+        if kind == "decision":
+            step["action"] = event.get("action", "")
+            step["log"] = event.get("log", "")
+            step["memo"] = event.get("memo")
+            step["screenshot"] = event.get("screenshot")
+            step["screen"] = [
+                hint for hint in event.get("screen") or [] if isinstance(hint, dict)
+            ]
+        elif kind == "target":
+            step["target"] = {
+                "text": event.get("text"),
+                "resourceId": event.get("resourceId"),
+                "accessibilityId": event.get("accessibilityId"),
+                "occurrence": event.get("occurrence", 0),
+                "bounds": event.get("bounds"),
+                "center": event.get("center"),
+            }
+        elif kind in ("device", "init"):
+            step["events"].append(event.get("event", {}))
+    return meta, steps
+
+
+def select_steps(steps, options):
+    selected = []
+    for step in steps:
+        if step["isInit"]:
+            if options.with_init and options.step is None:
+                selected.append(step)
+            continue
+        number = step["number"]
+        if options.step is not None and number != options.step:
+            continue
+        if options.start is not None and number < options.start:
+            continue
+        if options.until is not None and number > options.until:
+            continue
+        selected.append(step)
+    return selected
+
+
+def describe_target(target):
+    if not target:
+        return "(none)"
+    parts = []
+    for key in ("text", "resourceId", "accessibilityId"):
+        if target.get(key):
+            parts.append("%s='%s'" % (key, target[key]))
+    center = target.get("center")
+    if isinstance(center, dict):
+        parts.append("center=(%s,%s)" % (center.get("x"), center.get("y")))
+    return "%s (occurrence %d)" % (", ".join(parts), target.get("occurrence", 0))
+
+
+def describe_screen(hints):
+    parts = []
+    for hint in hints:
+        for key in ("text", "resourceId", "accessibilityId"):
+            if hint.get(key):
+                parts.append("%s='%s'" % (key, hint[key]))
+                break
+    return ", ".join(parts)
+
+
+def describe_launch_arguments(event):
+    arguments = event.get("launchArguments") or {}
+    return "".join(
+        ", %s=%s" % (key, json.dumps(value, ensure_ascii=False))
+        for key, value in sorted(arguments.items())
+    )
+
+
+def describe_event(event):
+    kind = event.get("type")
+    if kind == "tap":
+        return "tap(%s,%s)" % (event.get("x"), event.get("y"))
+    if kind == "key_press":
+        return event.get("keyName", "?")
+    if kind == "input_text":
+        return 'text("%s")' % event.get("text", "")
+    if kind == "swipe":
+        return "swipe(%s,%s -> %s,%s, %sms)" % (
+            event.get("startX"), event.get("startY"),
+            event.get("endX"), event.get("endY"), event.get("durationMs"),
+        )
+    if kind == "launch_app":
+        suffix = ", clearState" if event.get("clearState") else ""
+        return "launch(%s%s%s)" % (event.get("appId"), suffix, describe_launch_arguments(event))
+    if kind == "stop_app":
+        return "stop(%s)" % event.get("appId")
+    if kind == "clear_state":
+        return "clearState(%s)" % event.get("appId")
+    if kind == "wait":
+        return "wait(%sms)" % event.get("millis")
+    if kind == "open_link":
+        return "openLink(%s)" % event.get("url")
+    if kind == "unsupported":
+        return "unsupported(%s)" % event.get("command")
+    return str(event)
+
+
+def summarize_events(events):
+    if not events:
+        return "none"
+    parts = []
+    for event in events:
+        label = describe_event(event)
+        if parts and parts[-1][0] == label:
+            parts[-1][1] += 1
+        else:
+            parts.append([label, 1])
+    return ", ".join(
+        ("%s x%d" % (label, count)) if count > 1 else label for label, count in parts
+    )
+
+
+def show(meta, steps):
+    sys.stdout.write("goal: %s\n\n" % meta.get("goal", ""))
+    for step in steps:
+        if step["isInit"]:
+            sys.stdout.write("0. setup\n")
+        else:
+            sys.stdout.write("%d. %s\n" % (step["number"], step["log"] or step["action"]))
+        if step["target"]:
+            sys.stdout.write("   target: %s\n" % describe_target(step["target"]))
+        elif step["screen"]:
+            sys.stdout.write("   screen: %s\n" % describe_screen(step["screen"]))
+        sys.stdout.write("   device: %s\n" % summarize_events(step["events"]))
+    if meta.get("signature"):
+        sys.stdout.write("\nexpect: resource ids %s\n" % ", ".join(meta["signature"]))
+
+
+def adb(options, args, capture=False):
+    """Runs one adb command. --device is passed as ANDROID_SERIAL so `android` sees it too."""
+    env = dict(os.environ)
+    if options.device:
+        env["ANDROID_SERIAL"] = options.device
+    command = ["adb"] + args
+    if capture:
+        process = subprocess.Popen(
+            command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+        )
+        out, err = process.communicate()
+        return process.returncode, out, err
+    return subprocess.call(command, env=env), b"", b""
+
+
+def require_adb():
+    if shutil.which("adb") is None:
+        sys.stderr.write("replay.sh: adb is not on PATH\n")
+        sys.exit(EXIT_USAGE)
+
+
+def first_non_blank(node, keys):
+    for key in keys:
+        value = node.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def center_of(value):
+    """A point from either geometry shape a dump uses, or None when it is neither.
+
+    `uiautomator dump` reports a rectangle as "[x1,y1][x2,y2]" and the middle of it is the point to
+    tap. `android layout` reports no rectangle at all, only a "[x,y]" centre, so two numbers are
+    already the answer.
+    """
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str):
+        return None
+    numbers = [int(number) for number in re.findall(r"-?\d+", value)]
+    if len(numbers) >= 4:
+        left, top, right, bottom = numbers[:4]
+        return {"x": (left + right) // 2, "y": (top + bottom) // 2}
+    if len(numbers) == 2:
+        return {"x": numbers[0], "y": numbers[1]}
+    return None
+
+
+def normalize(node):
+    bounds = node.get("bounds")
+    center = center_of(node.get("center"))
+    if center is None:
+        center = center_of(bounds)
+    return {
+        "text": first_non_blank(node, TEXT_KEYS),
+        "resourceId": first_non_blank(node, RESOURCE_ID_KEYS),
+        "accessibilityId": first_non_blank(node, ACCESSIBILITY_KEYS),
+        "bounds": bounds,
+        "center": center,
+    }
+
+
+def dump_tree(options, backend=None):
+    """The nodes currently on screen, as a flat list.
+
+    Every hierarchy read goes through here, so a replay reads the screen exactly one way and the
+    choice is a single flag. `auto` tries `uiautomator dump` first, then `android layout`.
+    uiautomator comes first because it reports a far fuller tree: measured on a TV app, a video
+    player screen gave 3 nodes through `android layout` against 23, nineteen of them with resource
+    ids, through uiautomator, and a home screen gave 35 against 135. That tree is also the closer
+    match to what Maestro recorded, and uiautomator needs nothing but adb.
+    """
+    backend = backend or options.backend
+    if backend == "android":
+        return dump_tree_android_cli(options) or []
+    if backend == "uiautomator":
+        return dump_tree_uiautomator(options)
+    if backend == "maestro":
+        return dump_tree_maestro(options)
+    nodes = dump_tree_uiautomator(options)
+    if nodes:
+        return nodes
+    if shutil.which("android") is not None:
+        return dump_tree_android_cli(options) or []
+    return nodes
+
+
+def dump_tree_maestro(options):
+    """Not implemented: `maestro hierarchy` output was never verified against a device here."""
+    raise NotImplementedError(
+        "the maestro backend is not implemented; use --backend android or --backend uiautomator"
+    )
+
+
+def dump_tree_android_cli(options):
+    env = dict(os.environ)
+    if options.device:
+        env["ANDROID_SERIAL"] = options.device
+    try:
+        process = subprocess.Popen(
+            ["android", "layout"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env
+        )
+        out, _ = process.communicate()
+        if process.returncode != 0:
+            return None
+        payload = json.loads(out.decode("utf-8", "replace"))
+    except (OSError, ValueError):
+        return None
+    # The CLI prints a flat list of nodes, but be forgiving about a wrapper object.
+    if isinstance(payload, dict):
+        for key in ("nodes", "elements", "layout"):
+            if isinstance(payload.get(key), list):
+                payload = payload[key]
+                break
+    if not isinstance(payload, list):
+        return None
+    return [normalize(node) for node in payload if isinstance(node, dict)]
+
+
+UIAUTOMATOR_DUMP_ATTEMPTS = 3
+
+
+def dump_tree_uiautomator(options):
+    """A flat list from `uiautomator dump`, retried because the dump refuses to run mid-animation.
+
+    While the screen is still moving the command exits 0 but prints "could not get idle state"
+    instead of writing the file, so the exit code alone is not enough to tell success from failure.
+    """
+    remote = "/sdcard/arbigent-replay-dump.xml"
+    for attempt in range(UIAUTOMATOR_DUMP_ATTEMPTS):
+        if attempt:
+            time.sleep(STABILITY_POLL_SECONDS)
+        adb(options, ["shell", "rm", "-f", remote], capture=True)
+        code, out, err = adb(options, ["shell", "uiautomator", "dump", remote], capture=True)
+        combined = (out + err).decode("utf-8", "replace")
+        if code != 0 or "ERROR" in combined or "could not get idle state" in combined:
+            continue
+        code, out, _ = adb(options, ["exec-out", "cat", remote], capture=True)
+        if code != 0 or not out.strip():
+            continue
+        try:
+            root = ElementTree.fromstring(out.decode("utf-8", "replace"))
+        except ElementTree.ParseError:
+            continue
+        nodes = []
+        flatten_xml(root, nodes)
+        return nodes
+    return []
+
+
+def flatten_xml(element, out):
+    """Depth first, so siblings keep the order the device reported, which occurrence counts on."""
+    attributes = element.attrib
+    if attributes:
+        out.append(
+            normalize(
+                {
+                    "text": attributes.get("text"),
+                    "resourceId": attributes.get("resource-id"),
+                    "contentDesc": attributes.get("content-desc"),
+                    "bounds": attributes.get("bounds"),
+                }
+            )
+        )
+    for child in list(element):
+        flatten_xml(child, out)
+
+
+def short_resource_id(value):
+    """The part of a resource id after the last "/", which is the only part both sides always have.
+
+    `android layout` prints a resource id without its package, as `fragment_container`, while
+    uiautomator and Maestro print `com.example.app:id/fragment_container`. Neither form is wrong, so
+    ids are compared on the segment they share.
+    """
+    if not isinstance(value, str):
+        return value
+    return value.rsplit("/", 1)[-1]
+
+
+def resource_ids_match(recorded, on_screen):
+    """Equal ids match; a qualified id also matches the bare one the `android` CLI prints."""
+    if recorded == on_screen:
+        return True
+    if not isinstance(recorded, str) or not isinstance(on_screen, str):
+        return False
+    if ":id/" in recorded and ":id/" in on_screen:
+        return False
+    return short_resource_id(recorded) == short_resource_id(on_screen)
+
+
+def attribute_matches(node, target, key):
+    if key == "resourceId":
+        return resource_ids_match(target.get(key), node.get(key))
+    return node.get(key) == target[key]
+
+
+def identity_keys(target):
+    return [key for key in ("resourceId", "text", "accessibilityId") if target.get(key)]
+
+
+def find_match(nodes, target):
+    """Mirrors Arbigent's own element matching, then relaxes it one attribute at a time.
+
+    A strict match on every recorded attribute wins. Failing that, resourceId, then text, then
+    contentDesc is tried on its own, because Arbigent reads an element's text from its descendants
+    while a flattened dump splits the container and its label into separate nodes, so a node that is
+    plainly the right one can carry only part of the recorded identity.
+    """
+    if not target:
+        return None
+    keys = identity_keys(target)
+    if not keys:
+        return None
+    candidate_sets = [keys]
+    if len(keys) > 1:
+        candidate_sets += [[key] for key in keys]
+    for subset in candidate_sets:
+        matched = [
+            node for node in nodes if all(attribute_matches(node, target, key) for key in subset)
+        ]
+        if not matched:
+            continue
+        occurrence = target.get("occurrence", 0)
+        if occurrence < len(matched):
+            return matched[occurrence]
+        # An element that moved up the list is still the right element; the recorded index only
+        # picks between equally matching candidates.
+        return matched[0]
+    return None
+
+
+def identity_is_resolvable(nodes, target):
+    """Whether the dump could show this identity at all.
+
+    Maestro reads the hierarchy through its own instrumentation and sees attributes, notably Compose
+    test tags surfaced as resource ids, that `android layout` and `uiautomator dump` do not. If no
+    node in the dump carries a value of any attribute kind the identity uses, the identity is simply
+    invisible from here and its absence says nothing about the screen.
+
+    The heuristic is deliberately coarse: a screen where only a system node happens to carry a
+    resource id counts as resolvable, so a Compose target can still be reported as diverged.
+    """
+    for key in identity_keys(target):
+        for node in nodes:
+            value = node.get(key)
+            if isinstance(value, str) and value.strip():
+                return True
+    return False
+
+
+def wait_for(options, target):
+    """Waits for the step's target, then for the screen to stop changing.
+
+    Returns (status, nodes) where status is one of:
+
+      matched     the target was found, and the screen then settled.
+      unresolved  the settled screen shows no value of any attribute kind the identity uses, so the
+                  identity is invisible from this backend and its absence says nothing. The step
+                  goes ahead.
+      absent      the screen does show those attribute kinds and the target was still not there when
+                  the timeout ran out.
+
+    A dump taken mid-transition can look unresolvable while the screen it is turning into is not, so
+    an unresolvable dump is only believed once the screen has settled.
+    """
+    deadline = time.time() + options.timeout
+    nodes = []
+    while True:
+        nodes = dump_tree(options)
+        if find_match(nodes, target) is not None:
+            return "matched", wait_until_stable(options, nodes)
+        if nodes and not identity_is_resolvable(nodes, target):
+            stable = wait_until_stable(options, nodes, cap=max(0.0, deadline - time.time()))
+            if find_match(stable, target) is not None:
+                return "matched", stable
+            if not identity_is_resolvable(stable, target):
+                sys.stdout.write("   wait: unresolved target, used stability\n")
+                return "unresolved", stable
+            # The first dump was mid-transition; the settled screen does show identities, so the
+            # target's absence is meaningful again and the deadline still applies.
+            nodes = stable
+        if time.time() >= deadline:
+            return "absent", nodes
+        time.sleep(STABILITY_POLL_SECONDS)
+
+
+def wait_until_stable(options, nodes, cap=STABILITY_CAP_SECONDS):
+    """Two consecutive identical dumps, capped, so an animation does not eat the next tap."""
+    deadline = time.time() + cap
+    previous = nodes
+    while time.time() < deadline:
+        time.sleep(STABILITY_POLL_SECONDS)
+        current = dump_tree(options)
+        if current == previous:
+            return current
+        previous = current
+    return previous
+
+
+def send_event(options, event):
+    kind = event.get("type")
+    if kind == "tap":
+        adb(options, ["shell", "input", "tap", str(event["x"]), str(event["y"])])
+    elif kind == "key_press":
+        adb(options, ["shell", "input", "keyevent", str(event["keyName"])])
+    elif kind == "input_text":
+        adb(options, ["shell", "input", "text", escape_text(event.get("text", ""))])
+    elif kind == "swipe":
+        adb(options, [
+            "shell", "input", "swipe",
+            str(event["startX"]), str(event["startY"]),
+            str(event["endX"]), str(event["endY"]),
+            str(event.get("durationMs", 400)),
+        ])
+    elif kind == "launch_app":
+        if event.get("clearState"):
+            adb(options, ["shell", "pm", "clear", str(event["appId"])], capture=True)
+        launch_app(options, str(event["appId"]), event.get("launchArguments") or {})
+    elif kind == "stop_app":
+        adb(options, ["shell", "am", "force-stop", str(event["appId"])])
+    elif kind == "clear_state":
+        adb(options, ["shell", "pm", "clear", str(event["appId"])], capture=True)
+    elif kind == "wait":
+        time.sleep(float(event.get("millis", 0)) / 1000.0)
+    elif kind == "open_link":
+        adb(options, [
+            "shell", "am", "start", "-a", "android.intent.action.VIEW",
+            "-d", str(event["url"]),
+        ])
+    else:
+        return False
+    return True
+
+
+def launcher_activity(options, app_id):
+    """The component the launcher would start, or None when the package manager cannot say."""
+    code, out, _ = adb(options, [
+        "shell", "cmd", "package", "resolve-activity", "--brief",
+        "-c", "android.intent.category.LAUNCHER", app_id,
+    ], capture=True)
+    if code != 0:
+        return None
+    for line in reversed(out.decode("utf-8", "replace").splitlines()):
+        line = line.strip()
+        if "/" in line and not line.startswith("priority="):
+            return line
+    return None
+
+
+def extra_flag(value):
+    """The `am start` flag that carries a JSON value of this type as an intent extra."""
+    if isinstance(value, bool):
+        return "--ez", "true" if value else "false"
+    if isinstance(value, int):
+        return "--ei", str(value)
+    if isinstance(value, float):
+        return "--ef", str(value)
+    return "--es", str(value)
+
+
+def launch_app(options, app_id, arguments):
+    """Starts the app the way the recorded run did.
+
+    Launch extras only travel through `am start`, and `am start` needs a component, so the launcher
+    activity is resolved first. The monkey fallback handles a package the resolver cannot describe,
+    at the cost of any extras, and says so.
+    """
+    component = launcher_activity(options, app_id)
+    if component is None:
+        if arguments:
+            sys.stdout.write("   launch: could not resolve the launcher activity, extras dropped\n")
+        adb(options, [
+            "shell", "monkey", "-p", app_id, "-c", "android.intent.category.LAUNCHER", "1",
+        ], capture=True)
+        return
+    command = ["shell", "am", "start", "-W", "-n", component]
+    for key in sorted(arguments):
+        flag, rendered = extra_flag(arguments[key])
+        command += [flag, key, rendered]
+    code, out, err = adb(options, command, capture=True)
+    combined = (out + err).decode("utf-8", "replace")
+    if code != 0 or "Error" in combined:
+        sys.stderr.write(combined)
+
+
+def escape_text(text):
+    """`input text` splits on spaces and eats a few punctuation marks, so encode them."""
+    out = text.replace("%", "%%").replace(" ", "%s")
+    return re.sub(r"([()<>|;&*\\~\"'`$])", r"\\\1", out)
+
+
+def send_step_events(options, step):
+    previous_was_key = False
+    for event in step["events"]:
+        if event.get("type") == "key_press" and previous_was_key:
+            time.sleep(KEY_PRESS_GAP_SECONDS)
+        if not send_event(options, event):
+            return event
+        previous_was_key = event.get("type") == "key_press"
+    return None
+
+
+def report_divergence(options, meta, step, remaining, nodes, reason):
+    out = sys.stderr
+    out.write("\nDIVERGED\n")
+    out.write("  goal: %s\n" % meta.get("goal", ""))
+    out.write("  step %d: %s\n" % (step["number"], step["log"] or step["action"]))
+    if step.get("memo"):
+        out.write("  memo: %s\n" % step["memo"].replace("\n", " "))
+    out.write("  reason: %s\n" % reason)
+    out.write("  expected: %s\n" % describe_target(step["target"]))
+    out.write("  on screen now:\n")
+    shown = 0
+    for node in nodes:
+        label = describe_node(node)
+        if not label:
+            continue
+        out.write("    - %s\n" % label)
+        shown += 1
+        if shown >= 40:
+            out.write("    ... (more nodes not shown)\n")
+            break
+    if not shown:
+        out.write("    (nothing readable)\n")
+    if remaining:
+        out.write("  remaining steps:\n")
+        for later in remaining:
+            out.write("    %d. %s\n" % (later["number"], later["log"] or later["action"]))
+    out.write("  resume with: replay.sh %s --from %d\n" % (options.log, step["number"]))
+
+
+def describe_node(node):
+    parts = []
+    for key in ("text", "resourceId", "accessibilityId"):
+        if node.get(key):
+            parts.append("%s='%s'" % (key, node[key]))
+    return ", ".join(parts)
+
+
+def wait_for_screen(options, hints):
+    """Waits until one of the screen hints a targetless step recorded is on screen, then settles.
+
+    Advisory only: the hints say which screen the decision was looking at, not what it acted on, so
+    running out of time is reported and the step still goes ahead. Returns True when a hint matched.
+    """
+    deadline = time.time() + options.timeout
+    while True:
+        nodes = dump_tree(options)
+        if any(find_match(nodes, hint) is not None for hint in hints):
+            wait_until_stable(options, nodes)
+            return True
+        if time.time() >= deadline:
+            sys.stdout.write(
+                "   wait: none of the recorded screen hints appeared within %.0fs, continuing\n"
+                % options.timeout
+            )
+            wait_until_stable(options, nodes)
+            return False
+        time.sleep(STABILITY_POLL_SECONDS)
+
+
+def check_signature(options, signature):
+    if not signature:
+        return
+    # The last step may still be animating into the end screen.
+    nodes = wait_until_stable(options, dump_tree(options))
+    present = set()
+    for node in nodes:
+        for recorded in signature:
+            if resource_ids_match(recorded, node.get("resourceId")):
+                present.add(recorded)
+    if present:
+        sys.stdout.write(
+            "PASS: end screen matches %d of %d recorded ids\n" % (len(present), len(signature))
+        )
+    else:
+        sys.stdout.write(
+            "WARN: none of the recorded end-screen ids are present (%s)\n" % ", ".join(signature)
+        )
+
+
+def main():
+    options = parse_args(sys.argv[1:])
+    meta, steps = group_steps(load_events(options.log))
+    selected = select_steps(steps, options)
+    if options.show:
+        show(meta, selected)
+        return EXIT_OK
+    if not selected:
+        sys.stderr.write("replay.sh: nothing to replay for the given range\n")
+        return EXIT_USAGE
+    require_adb()
+    if options.backend == "android" and shutil.which("android") is None:
+        fail_usage("--backend android needs the `android` CLI on PATH")
+    for position, step in enumerate(selected):
+        remaining = selected[position + 1:]
+        label = "setup" if step["isInit"] else (step["log"] or step["action"])
+        sys.stdout.write("step %d: %s\n" % (step["number"], label))
+        nodes = []
+        if step["target"] and not options.no_wait and not step["isInit"]:
+            status, nodes = wait_for(options, step["target"])
+            if status == "absent":
+                report_divergence(
+                    options, meta, step, remaining, nodes,
+                    "the target never appeared within %.0fs" % options.timeout,
+                )
+                return EXIT_DIVERGED
+        elif step["screen"] and not options.no_wait and not step["isInit"]:
+            wait_for_screen(options, step["screen"])
+        unsupported = send_step_events(options, step)
+        if unsupported is not None:
+            report_divergence(
+                options, meta, step, remaining, nodes or dump_tree(options),
+                "this step used %s, which adb cannot reproduce" % describe_event(unsupported),
+            )
+            return EXIT_DIVERGED
+    check_signature(options, meta.get("signature", []))
+    return EXIT_OK
+
+
+def run():
+    try:
+        return main()
+    except NotImplementedError as error:
+        sys.stderr.write("replay.sh: %s\n" % error)
+        return EXIT_USAGE
+
+
+if __name__ == "__main__":
+    sys.exit(run())
+PY

--- a/arbigent-core/src/main/resources/replay.sh
+++ b/arbigent-core/src/main/resources/replay.sh
@@ -261,21 +261,45 @@ def group_steps(events):
     return meta, steps
 
 
+def step_is_wanted(step, options):
+    number = step["number"]
+    if options.step is not None and number != options.step:
+        return False
+    if options.start is not None and number < options.start:
+        return False
+    if options.until is not None and number > options.until:
+        return False
+    return True
+
+
 def select_steps(steps, options):
+    """The steps a range asks for, with the setup blocks that belong to them.
+
+    A setup block rides with the step that came after it: a relaunch in the middle of a run is only
+    needed if the step it prepared for is replayed. The block before the first step is the exception
+    and is always included with --with-init, because it is how the app gets launched at all. A block
+    at the very end rides with the step before it.
+    """
+    include_init = options.with_init and options.step is None
     selected = []
+    pending = []
+    seen_step = False
+    last_wanted = False
     for step in steps:
         if step["isInit"]:
-            if options.with_init and options.step is None:
-                selected.append(step)
+            if include_init:
+                pending.append(step)
             continue
-        number = step["number"]
-        if options.step is not None and number != options.step:
-            continue
-        if options.start is not None and number < options.start:
-            continue
-        if options.until is not None and number > options.until:
-            continue
-        selected.append(step)
+        last_wanted = step_is_wanted(step, options)
+        if last_wanted:
+            selected.extend(pending)
+            selected.append(step)
+        elif not seen_step:
+            selected.extend(pending)
+        pending = []
+        seen_step = True
+    if pending and (last_wanted or not seen_step):
+        selected.extend(pending)
     return selected
 
 
@@ -490,12 +514,25 @@ def dump_tree(options, backend=None):
     """
     backend = backend or options.backend
     if backend == "android":
-        return dump_tree_android_cli(options) or []
+        nodes = dump_tree_android_cli(options)
+        if nodes is None:
+            raise DeviceCommandFailed("android layout failed")
+        return nodes
     if backend == "uiautomator":
         return dump_tree_uiautomator(options)
     if backend == "maestro":
         return dump_tree_maestro(options)
-    nodes = dump_tree_uiautomator(options)
+    try:
+        nodes = dump_tree_uiautomator(options)
+    except DeviceCommandFailed:
+        # adb itself failed, so `android layout` (which also goes through adb) is tried only because
+        # it may reach the device a different way; without it the failure stands.
+        if shutil.which("android") is None:
+            raise
+        nodes = dump_tree_android_cli(options)
+        if nodes is None:
+            raise
+        return nodes
     if nodes:
         return nodes
     if shutil.which("android") is not None:
@@ -543,20 +580,31 @@ def dump_tree_uiautomator(options):
 
     While the screen is still moving the command exits 0 but prints "could not get idle state"
     instead of writing the file, so the exit code alone is not enough to tell success from failure.
+
+    A dump that never produced a tree is an empty list, which a caller reads as "nothing on screen".
+    When adb itself failed every time (no device, a serial that is not there, a hang) that reading
+    would be wrong, so that case raises DeviceCommandFailed instead of pretending the screen is empty.
     """
     # One file per runner process, removed once read: the dump holds every string on screen, and
     # two replays against the same device must not read each other's.
     remote = "/sdcard/arbigent-replay-dump-%d.xml" % os.getpid()
+    adb_failures = []
     try:
         for attempt in range(UIAUTOMATOR_DUMP_ATTEMPTS):
             if attempt:
                 time.sleep(STABILITY_POLL_SECONDS)
             code, out, err = adb(options, ["shell", "uiautomator", "dump", remote], capture=True)
             combined = (out + err).decode("utf-8", "replace")
+            if code != 0 and "could not get idle state" not in combined:
+                adb_failures.append(combined.strip() or "exit %d" % code)
+                continue
             if code != 0 or "ERROR" in combined or "could not get idle state" in combined:
                 continue
-            code, out, _ = adb(options, ["exec-out", "cat", remote], capture=True)
-            if code != 0 or not out.strip():
+            code, out, err = adb(options, ["exec-out", "cat", remote], capture=True)
+            if code != 0:
+                adb_failures.append((out + err).decode("utf-8", "replace").strip() or "exit %d" % code)
+                continue
+            if not out.strip():
                 continue
             try:
                 root = ElementTree.fromstring(out.decode("utf-8", "replace"))
@@ -565,6 +613,8 @@ def dump_tree_uiautomator(options):
             nodes = []
             flatten_xml(root, nodes)
             return nodes
+        if len(adb_failures) == UIAUTOMATOR_DUMP_ATTEMPTS:
+            raise DeviceCommandFailed("uiautomator dump failed: %s" % adb_failures[-1])
         return []
     finally:
         adb(options, ["shell", "rm", "-f", remote], capture=True)
@@ -691,7 +741,12 @@ def wait_for(options, target):
     while True:
         nodes = dump_tree(options)
         if find_match(nodes, target) is not None:
-            return "matched", wait_until_stable(options, nodes)
+            stable = wait_until_stable(options, nodes)
+            if find_match(stable, target) is not None:
+                return "matched", stable
+            # The target was on a screen that was still changing and is gone from the one it turned
+            # into (a splash, a list that reloaded), so the wait starts over from the settled screen.
+            nodes = stable
         if nodes and not identity_is_resolvable(nodes, target):
             stable = wait_until_stable(options, nodes, cap=max(0.0, deadline - time.monotonic()))
             if find_match(stable, target) is not None:
@@ -794,6 +849,10 @@ def send_event(options, event, step, nodes):
         if not typeable(text):
             raise Diverged(
                 "adb shell input text cannot type %r (only printable ASCII travels through it)" % text
+            )
+        if "%s" in text:
+            raise Diverged(
+                "adb shell input text cannot type %r (a literal %%s comes out as a space)" % text
             )
         checked(adb(options, ["shell", "input", "text", escape_text(text)]), "text input")
     elif kind == "swipe":
@@ -902,7 +961,8 @@ def escape_text(text):
     """`input text` splits its argument on spaces, so a space travels as `%s`.
 
     The argument is shell-quoted on the way in, so no other character needs escaping. A literal
-    `%s` in the text is the one thing this cannot express: the device turns it into a space too.
+    `%s` in the text is the one thing this cannot express: the device turns it into a space too, so
+    send_event refuses such a text before it gets here.
     """
     return text.replace(" ", "%s")
 
@@ -916,6 +976,16 @@ def send_step_events(options, step, nodes):
             return event
         previous_was_key = event.get("type") == "key_press"
     return None
+
+
+def nodes_for_report(options, nodes):
+    """The nodes to print with a divergence: a fresh dump unless reading the screen fails too."""
+    if nodes:
+        return nodes
+    try:
+        return dump_tree(options)
+    except DeviceCommandFailed:
+        return []
 
 
 def report_divergence(options, meta, step, remaining, nodes, reason):
@@ -965,8 +1035,10 @@ def wait_for_screen(options, hints):
     while True:
         nodes = dump_tree(options)
         if any(find_match(nodes, hint) is not None for hint in hints):
-            wait_until_stable(options, nodes)
-            return True
+            stable = wait_until_stable(options, nodes)
+            if any(find_match(stable, hint) is not None for hint in hints):
+                return True
+            nodes = stable
         if time.monotonic() >= deadline:
             sys.stdout.write(
                 "   wait: none of the recorded screen hints appeared within %.0fs, continuing\n"
@@ -1002,12 +1074,12 @@ def main():
     meta, steps = group_steps(load_events(options.log))
     require_complete(meta, options.log)
     selected = select_steps(steps, options)
-    if options.show:
-        show(meta, selected)
-        return EXIT_OK
     if not selected:
         sys.stderr.write("replay.sh: nothing to replay for the given range\n")
         return EXIT_USAGE
+    if options.show:
+        show(meta, selected)
+        return EXIT_OK
     require_adb()
     if options.backend == "android" and shutil.which("android") is None:
         fail_usage("--backend android needs the `android` CLI on PATH")
@@ -1016,20 +1088,20 @@ def main():
         label = "setup" if step["isInit"] else (step["log"] or step["action"])
         sys.stdout.write("step %d: %s\n" % (step["number"], label))
         nodes = []
-        if step["target"] and not options.no_wait and not step["isInit"]:
-            status, nodes = wait_for(options, step["target"])
-            if status == "absent":
-                report_divergence(
-                    options, meta, step, remaining, nodes,
-                    "the target never appeared within %.0fs" % options.timeout,
-                )
-                return EXIT_DIVERGED
-        elif step["screen"] and not options.no_wait and not step["isInit"]:
-            wait_for_screen(options, step["screen"])
         try:
+            if step["target"] and not options.no_wait and not step["isInit"]:
+                status, nodes = wait_for(options, step["target"])
+                if status == "absent":
+                    report_divergence(
+                        options, meta, step, remaining, nodes,
+                        "the target never appeared within %.0fs" % options.timeout,
+                    )
+                    return EXIT_DIVERGED
+            elif step["screen"] and not options.no_wait and not step["isInit"]:
+                wait_for_screen(options, step["screen"])
             unsupported = send_step_events(options, step, nodes)
         except Diverged as error:
-            report_divergence(options, meta, step, remaining, nodes or dump_tree(options), str(error))
+            report_divergence(options, meta, step, remaining, nodes_for_report(options, nodes), str(error))
             return EXIT_DIVERGED
         except DeviceCommandFailed as error:
             sys.stderr.write("\nreplay.sh: step %d: %s\n" % (step["number"], error))
@@ -1039,7 +1111,7 @@ def main():
             return EXIT_DEVICE
         if unsupported is not None:
             report_divergence(
-                options, meta, step, remaining, nodes or dump_tree(options),
+                options, meta, step, remaining, nodes_for_report(options, nodes),
                 "this step used %s, which adb cannot reproduce" % describe_event(unsupported),
             )
             return EXIT_DIVERGED

--- a/arbigent-core/src/test/java/ArbigentProjectFileContentTest.kt
+++ b/arbigent-core/src/test/java/ArbigentProjectFileContentTest.kt
@@ -337,6 +337,48 @@ Previous steps:
     )
   }
 
+  private val projectWithReplayScripts = ArbigentProjectSerializer().load(
+    """
+    settings:
+      replayScripts:
+        enabled: true
+        outputDir: "build/replay-scripts"
+    scenarios:
+    - id: "replay-scripts-scenario"
+      goal: "Test replay scripts"
+    """
+  )
+
+  @Test
+  fun testReplayScriptsSettings() {
+    val settings = projectWithReplayScripts.settings.replayScripts
+    assertNotNull(settings, "replayScripts should be parsed")
+    assertEquals(true, settings.enabled)
+    assertEquals("build/replay-scripts", settings.outputDir)
+
+    val scenario = projectWithReplayScripts.scenarioContents.createArbigentScenario(
+      projectSettings = projectWithReplayScripts.settings,
+      scenario = projectWithReplayScripts.scenarioContents[0],
+      aiFactory = { FakeAi() },
+      deviceFactory = { FakeDevice() },
+      aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache()
+    )
+    assertEquals(settings, scenario.replayScripts, "the scenario should carry the project setting")
+  }
+
+  @Test
+  fun testReplayScriptsAbsentMeansOff() {
+    assertNull(basicProject.settings.replayScripts)
+    val scenario = basicProject.scenarioContents.createArbigentScenario(
+      projectSettings = basicProject.settings,
+      scenario = basicProject.scenarioContents[0],
+      aiFactory = { FakeAi() },
+      deviceFactory = { FakeDevice() },
+      aiDecisionCache = AiDecisionCacheStrategy.Disabled.toCache()
+    )
+    assertNull(scenario.replayScripts)
+  }
+
   private val projectWithAdditionalActions = ArbigentProjectSerializer().load(
     """
     settings:

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -1,0 +1,365 @@
+package io.github.takahirom.arbigent.sample.test
+
+import io.github.takahirom.arbigent.ArbigentAgent
+import io.github.takahirom.arbigent.ArbigentAi
+import io.github.takahirom.arbigent.ArbigentContextHolder
+import io.github.takahirom.arbigent.ArbigentDeviceEvent
+import io.github.takahirom.arbigent.ArbigentElement
+import io.github.takahirom.arbigent.ArbigentElementIdentity
+import io.github.takahirom.arbigent.ArbigentExecuteActionsInterceptor
+import io.github.takahirom.arbigent.ArbigentReplayScriptRecorder
+import io.github.takahirom.arbigent.ArbigentReplayScriptWriter
+import io.github.takahirom.arbigent.GoalAchievedAgentAction
+import io.github.takahirom.arbigent.MCPClient
+import io.github.takahirom.arbigent.toArbigentDeviceEvents
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import java.io.File
+import java.nio.file.Files
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private fun executeActionsInput(
+  contextHolder: ArbigentContextHolder,
+  target: ArbigentElementIdentity?,
+): ArbigentAgent.ExecuteActionsInput {
+  val step = ArbigentContextHolder.Step(
+    stepId = "step",
+    agentAction = GoalAchievedAgentAction(),
+    memo = "remembered something",
+    cacheKey = "cache",
+    screenshotFilePath = "/screenshots/step-1.png",
+    targetElement = target,
+  )
+  return ArbigentAgent.ExecuteActionsInput(
+    stepId = "step",
+    decisionOutput = ArbigentAi.DecisionOutput(listOf(GoalAchievedAgentAction()), step),
+    arbigentContextHolder = contextHolder,
+    screenshotFilePath = "/screenshots/step-1.png",
+    device = FakeDevice(),
+    cacheKey = "cache",
+    elements = FakeDevice().elements(),
+    mcpClient = MCPClient(),
+  )
+}
+
+class ArbigentReplayScriptRecorderTest {
+  private val target = ArbigentElementIdentity(text = "Settings", occurrence = 0)
+
+  @Test
+  fun `events sent outside a step are attributed to the task's init phase`() = runTest {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.LaunchApp("com.example.app", clearState = true, timestamp = 1))
+
+    val task = recorder.recordedTasks().single()
+    assertEquals("Open settings", task.goal)
+    val initStep = task.steps.single()
+    assertTrue(initStep.isInit)
+    assertEquals(1, initStep.events.size)
+  }
+
+  @Test
+  fun `events sent while a step runs are attributed to that step`() = runTest {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.LaunchApp("com.example.app", timestamp = 1))
+
+    val contextHolder = ArbigentContextHolder("Open settings", 10)
+    recorder.intercept(
+      executeActionsInput(contextHolder, target),
+      ArbigentExecuteActionsInterceptor.Chain {
+        recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_DOWN", timestamp = 2))
+        recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_CENTER", timestamp = 3))
+        ArbigentAgent.ExecuteActionsOutput()
+      },
+    )
+    // Anything after the chain returns belongs to the task again, not to the step that just ended.
+    recorder.onDeviceEvent(ArbigentDeviceEvent.Wait(100, timestamp = 4))
+
+    val steps = recorder.recordedTasks().single().steps
+    assertEquals(listOf(true, false, true), steps.map { it.isInit })
+    assertEquals(1, steps[0].events.size)
+    assertEquals(2, steps[1].events.size)
+    assertEquals(target, steps[1].target)
+    assertEquals("remembered something", steps[1].memo)
+    assertEquals("step-1.png", steps[1].screenshot)
+    assertEquals(1, steps[2].events.size)
+  }
+
+  @Test
+  fun `a task that reruns from the same screen discards what it recorded before`() = runTest {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_DOWN", timestamp = 1))
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_UP", timestamp = 2))
+
+    val events = recorder.recordedTasks().single().steps.flatMap { it.events }
+    assertEquals(listOf(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_UP", 2)), events)
+  }
+
+  @Test
+  fun `a task that carries on keeps what it already did in front of what it does next`() = runTest {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_DOWN", timestamp = 1))
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = false)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_UP", timestamp = 2))
+
+    val events = recorder.recordedTasks().single().steps.flatMap { it.events }
+    assertEquals(
+      listOf(
+        ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_DOWN", 1),
+        ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_UP", 2),
+      ),
+      events,
+    )
+  }
+
+  @Test
+  fun `a step records where its target was and the screen it was on`() = runTest {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = true)
+    val contextHolder = ArbigentContextHolder("Open settings", 10)
+    // The fake elements all carry text="text", so occurrence 2 picks a known one.
+    val resolvable = ArbigentElementIdentity(text = "text", occurrence = 2)
+    recorder.intercept(
+      executeActionsInput(contextHolder, resolvable),
+      ArbigentExecuteActionsInterceptor.Chain {
+        recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_CENTER", timestamp = 2))
+        ArbigentAgent.ExecuteActionsOutput()
+      },
+    )
+
+    val step = recorder.recordedTasks().single().steps.single()
+    assertEquals(
+      ArbigentReplayScriptRecorder.RecordedBounds(0, 0, 100, 100),
+      step.targetBounds,
+    )
+    assertEquals(50, step.targetBounds!!.centerX)
+    assertEquals(50, step.targetBounds!!.centerY)
+    assertEquals(1000 to 2000, recorder.screenSize())
+    assertTrue(step.screen.isNotEmpty(), "the step should remember what screen it was decided on")
+    assertTrue(step.screen.size <= ArbigentReplayScriptRecorder.MaxScreenIdentities)
+    assertTrue(step.screen.all { it.occurrence == 0 }, "screen hints are about presence, not position")
+  }
+
+  @Test
+  fun `screen hints put labelled elements before bare containers`() {
+    val root = element(resourceId = "com.example.app:id/root_layout")
+    val title = element(text = "Settings")
+    val identities = ArbigentReplayScriptRecorder.screenIdentities(listOf(root, title, root))
+    assertEquals(listOf("Settings", null), identities.map { it.text })
+    assertEquals(listOf(null, "com.example.app:id/root_layout"), identities.map { it.resourceId })
+  }
+
+  private fun element(text: String? = null, resourceId: String? = null): ArbigentElement {
+    val attributes = buildMap {
+      put("text", text.orEmpty())
+      resourceId?.let { put("resource-id", it) }
+    }
+    return ArbigentElement(
+      index = 0,
+      textForAI = text.orEmpty(),
+      rawText = text.orEmpty(),
+      identifierData = ArbigentElement.IdentifierData(emptyList(), 0),
+      treeNode = maestro.TreeNode(attributes = attributes.toMutableMap(), children = emptyList()),
+      x = 0,
+      y = 0,
+      width = 10,
+      height = 10,
+      isVisible = true,
+    )
+  }
+
+  @Test
+  fun `restarting the scenario forgets everything`() = runTest {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open settings", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_DOWN", timestamp = 1))
+    recorder.reset()
+    assertEquals(emptyList(), recorder.recordedTasks())
+  }
+}
+
+class ArbigentReplayScriptWriterTest {
+  private suspend fun recordedRunWithTarget(): List<ArbigentReplayScriptRecorder.RecordedTask> {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open the settings screen", discardPrevious = true)
+    recorder.intercept(
+      executeActionsInput(
+        ArbigentContextHolder("Open the settings screen", 10),
+        ArbigentElementIdentity(text = "text", occurrence = 2),
+      ),
+      ArbigentExecuteActionsInterceptor.Chain {
+        recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_CENTER", timestamp = 2))
+        ArbigentAgent.ExecuteActionsOutput()
+      },
+    )
+    return recorder.recordedTasks()
+  }
+
+  @Test
+  fun `the log carries the screen size and the target geometry`() = runTest {
+    val dir = Files.createTempDirectory("replay-scripts-bounds").toFile()
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open-settings",
+      goals = listOf("Open the settings screen"),
+      tasks = recordedRunWithTarget(),
+      signature = emptyList(),
+      screenWidth = 1000,
+      screenHeight = 2000,
+    )
+    val log = File(dir, "open-settings.jsonl").readText()
+    assertTrue(log.contains("\"width\":1000"), log)
+    assertTrue(log.contains("\"height\":2000"), log)
+    assertTrue(log.contains("\"bounds\":\"[0,0][100,100]\""), log)
+    assertTrue(log.contains("\"center\":{\"x\":50,\"y\":50}"), log)
+    assertTrue(log.contains("\"screen\":[{\"text\":\"text\""), log)
+  }
+
+  @Test
+  fun `a screen size the device never reported is left out`() = runTest {
+    val dir = Files.createTempDirectory("replay-scripts-nosize").toFile()
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open-settings",
+      goals = listOf("Open the settings screen"),
+      tasks = recordedRun(),
+      signature = emptyList(),
+    )
+    val start = File(dir, "open-settings.jsonl").readLines().first()
+    assertTrue(!start.contains("\"width\""), start)
+  }
+
+  private fun recordedRun(): List<ArbigentReplayScriptRecorder.RecordedTask> {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open the settings screen", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.LaunchApp("com.example.app", clearState = true, timestamp = 1))
+    return recorder.recordedTasks()
+  }
+
+  @Test
+  fun `writes the log with a file-safe name`() {
+    val dir = Files.createTempDirectory("replay-scripts").toFile()
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open settings/main",
+      goals = listOf("Open the settings screen"),
+      tasks = recordedRun(),
+      signature = listOf("com.example.app:id/settings_title"),
+    )
+
+    val log = File(dir, "open_settings_main.jsonl")
+    assertTrue(log.isFile, "expected the sanitized log file to exist")
+
+    val lines = log.readLines().filter { it.isNotBlank() }
+    assertEquals("scenario_start", lineType(lines.first()))
+    assertEquals("scenario_end", lineType(lines.last()))
+    assertTrue(lines.any { lineType(it) == "init" })
+    assertTrue(lines.all { it.contains("\"taskIndex\"") && it.contains("\"step\"") && it.contains("\"ts\"") })
+    assertTrue(log.readText().contains("com.example.app"))
+  }
+
+  @Test
+  fun `a run that sent nothing writes no files`() {
+    val dir = Files.createTempDirectory("replay-scripts").toFile()
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "empty",
+      goals = listOf("Nothing happened"),
+      tasks = listOf(ArbigentReplayScriptRecorder.RecordedTask(0, "Nothing happened")),
+      signature = emptyList(),
+    )
+    assertEquals(emptyList(), dir.listFiles()?.toList().orEmpty())
+  }
+
+  private fun lineType(line: String): String =
+    Regex("\"type\"\\s*:\\s*\"([^\"]+)\"").find(line)!!.groupValues[1]
+}
+
+/** A device that reports what it was asked to do, the way MaestroDevice does. */
+private class RecordingFakeDevice : io.github.takahirom.arbigent.ArbigentDevice by FakeDevice() {
+  private val listeners = mutableListOf<io.github.takahirom.arbigent.ArbigentDeviceEventListener>()
+  private val delegate = FakeDevice()
+
+  override fun addDeviceEventListener(listener: io.github.takahirom.arbigent.ArbigentDeviceEventListener) {
+    if (!listeners.contains(listener)) listeners.add(listener)
+  }
+
+  override fun removeDeviceEventListener(listener: io.github.takahirom.arbigent.ArbigentDeviceEventListener) {
+    listeners.remove(listener)
+  }
+
+  override fun executeActions(actions: List<maestro.orchestra.MaestroCommand>) {
+    delegate.executeActions(actions)
+    actions.forEach { command ->
+      command.toArbigentDeviceEvents(1080, 1920).forEach { event ->
+        listeners.toList().forEach { it.onDeviceEvent(event) }
+      }
+    }
+  }
+}
+
+class ArbigentReplayScriptExecutorTest {
+  @OptIn(ExperimentalStdlibApi::class)
+  @Test
+  fun `a successful scenario writes its replay script`() = runTest {
+    val dispatcher = coroutineContext[kotlinx.coroutines.CoroutineDispatcher]!!
+    val dir = Files.createTempDirectory("replay-scripts-success").toFile()
+    val agentConfig = io.github.takahirom.arbigent.AgentConfig {
+      deviceFactory { RecordingFakeDevice() }
+      aiFactory { FakeAi() }
+    }
+    io.github.takahirom.arbigent.ArbigentScenarioExecutor(dispatcher).execute(
+      scenario(agentConfig, dir),
+      MCPClient(),
+    )
+    advanceUntilIdle()
+
+    assertTrue(File(dir, "settings_scenario.jsonl").isFile)
+  }
+
+  @OptIn(ExperimentalStdlibApi::class)
+  @Test
+  fun `a failed scenario leaves the previous script untouched`() = runTest {
+    val dispatcher = coroutineContext[kotlinx.coroutines.CoroutineDispatcher]!!
+    val dir = Files.createTempDirectory("replay-scripts-failure").toFile()
+    val existing = File(dir, "settings_scenario.jsonl")
+    existing.writeText("previous run\n")
+
+    val agentConfig = io.github.takahirom.arbigent.AgentConfig {
+      deviceFactory { RecordingFakeDevice() }
+      aiFactory { FakeAi().apply { status = NeverAchievesGoal() } }
+    }
+    runCatching {
+      io.github.takahirom.arbigent.ArbigentScenarioExecutor(dispatcher).execute(
+        scenario(agentConfig, dir),
+        MCPClient(),
+      )
+    }
+    advanceUntilIdle()
+
+    assertEquals("previous run\n", existing.readText())
+  }
+
+  private fun scenario(
+    agentConfig: io.github.takahirom.arbigent.AgentConfig,
+    dir: File,
+  ) = io.github.takahirom.arbigent.ArbigentScenario(
+    id = "settings scenario",
+    agentTasks = listOf(io.github.takahirom.arbigent.ArbigentAgentTask("task1", "Open the settings screen", agentConfig)),
+    maxStepCount = 10,
+    tags = emptySet(),
+    isLeaf = true,
+    replayScripts = io.github.takahirom.arbigent.ReplayScriptsSettings(
+      enabled = true,
+      outputDir = dir.absolutePath,
+    ),
+  )
+
+  private class NeverAchievesGoal : FakeAi.Status() {
+    override fun decideAgentActions(
+      decisionInput: ArbigentAi.DecisionInput,
+    ): ArbigentAi.DecisionOutput = createDecisionOutput()
+  }
+}

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -250,8 +250,16 @@ class ArbigentReplayScriptWriterTest {
       signature = listOf("com.example.app:id/settings_title"),
     )
 
-    val log = File(dir, "open_settings_main.jsonl")
-    assertTrue(log.isFile, "expected the sanitized log file to exist")
+    val log = dir.listFiles().orEmpty().single { it.name.endsWith(".jsonl") }
+    assertTrue(
+      log.name.matches(Regex("open_settings_main-[0-9a-f]{6}\\.jsonl")),
+      "a sanitized name carries a hash so 'open settings/main' and 'open settings main' do not collide: ${log.name}",
+    )
+    assertEquals("open-settings", ArbigentReplayScriptWriter.fileBaseName("open-settings"))
+    assertTrue(
+      ArbigentReplayScriptWriter.fileBaseName("a/b") != ArbigentReplayScriptWriter.fileBaseName("a b"),
+    )
+    assertTrue(dir.listFiles().orEmpty().none { it.name.endsWith(".tmp") }, "temp file left behind")
 
     val lines = log.readLines().filter { it.isNotBlank() }
     assertEquals("scenario_start", lineType(lines.first()))
@@ -282,9 +290,13 @@ class ArbigentReplayScriptWriterTest {
 }
 
 /** A device that reports what it was asked to do, the way MaestroDevice does. */
-private class RecordingFakeDevice : io.github.takahirom.arbigent.ArbigentDevice by FakeDevice() {
+private class RecordingFakeDevice(
+  private val os: io.github.takahirom.arbigent.ArbigentDeviceOs = io.github.takahirom.arbigent.ArbigentDeviceOs.Android,
+) : io.github.takahirom.arbigent.ArbigentDevice by FakeDevice() {
   private val listeners = mutableListOf<io.github.takahirom.arbigent.ArbigentDeviceEventListener>()
   private val delegate = FakeDevice()
+
+  override fun os(): io.github.takahirom.arbigent.ArbigentDeviceOs = os
 
   override fun addDeviceEventListener(listener: io.github.takahirom.arbigent.ArbigentDeviceEventListener) {
     if (!listeners.contains(listener)) listeners.add(listener)
@@ -320,7 +332,26 @@ class ArbigentReplayScriptExecutorTest {
     )
     advanceUntilIdle()
 
-    assertTrue(File(dir, "settings_scenario.jsonl").isFile)
+    assertTrue(File(dir, "settings-scenario.jsonl").isFile)
+  }
+
+  @OptIn(ExperimentalStdlibApi::class)
+  @Test
+  fun `a scenario run on anything but Android writes no script`() = runTest {
+    val dispatcher = coroutineContext[kotlinx.coroutines.CoroutineDispatcher]!!
+    val dir = Files.createTempDirectory("replay-scripts-ios").toFile()
+    val agentConfig = io.github.takahirom.arbigent.AgentConfig {
+      deviceFactory { RecordingFakeDevice(os = io.github.takahirom.arbigent.ArbigentDeviceOs.Ios) }
+      aiFactory { FakeAi() }
+    }
+    io.github.takahirom.arbigent.ArbigentScenarioExecutor(dispatcher).execute(
+      scenario(agentConfig, dir),
+      MCPClient(),
+    )
+    advanceUntilIdle()
+
+    // The runner speaks adb, so a script from an iOS run could never be replayed by it.
+    assertEquals(emptyList(), dir.listFiles()?.toList().orEmpty())
   }
 
   @OptIn(ExperimentalStdlibApi::class)
@@ -328,7 +359,7 @@ class ArbigentReplayScriptExecutorTest {
   fun `a failed scenario leaves the previous script untouched`() = runTest {
     val dispatcher = coroutineContext[kotlinx.coroutines.CoroutineDispatcher]!!
     val dir = Files.createTempDirectory("replay-scripts-failure").toFile()
-    val existing = File(dir, "settings_scenario.jsonl")
+    val existing = File(dir, "settings-scenario.jsonl")
     existing.writeText("previous run\n")
 
     val agentConfig = io.github.takahirom.arbigent.AgentConfig {
@@ -350,7 +381,7 @@ class ArbigentReplayScriptExecutorTest {
     agentConfig: io.github.takahirom.arbigent.AgentConfig,
     dir: File,
   ) = io.github.takahirom.arbigent.ArbigentScenario(
-    id = "settings scenario",
+    id = "settings-scenario",
     agentTasks = listOf(io.github.takahirom.arbigent.ArbigentAgentTask("task1", "Open the settings screen", agentConfig)),
     maxStepCount = 10,
     tags = emptySet(),

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -259,6 +259,10 @@ class ArbigentReplayScriptWriterTest {
     assertTrue(lines.any { lineType(it) == "init" })
     assertTrue(lines.all { it.contains("\"taskIndex\"") && it.contains("\"step\"") && it.contains("\"ts\"") })
     assertTrue(log.readText().contains("com.example.app"))
+    assertEquals(
+      "_flag_like", ArbigentReplayScriptWriter.sanitizeFileName("-flag like"),
+      "a name starting with a dash would be read as an option by the runner",
+    )
   }
 
   @Test

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -283,6 +283,11 @@ class ArbigentReplayScriptWriterTest {
     val failed = runCatching { ArbigentReplayScriptWriter.writeAtomically(target, "content") }
     assertTrue(failed.isFailure, "replacing a directory should not succeed")
     assertEquals(listOf("blocked.jsonl"), dir.list().orEmpty().toList(), "the staging file must be cleaned up")
+    // The atomic attempt is what a reader of the stack trace needs to understand the fallback.
+    assertTrue(
+      failed.exceptionOrNull()?.suppressed?.isNotEmpty() == true,
+      "the atomic move failure must survive as a suppressed exception",
+    )
   }
 
   @Test

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -241,7 +241,7 @@ class ArbigentReplayScriptWriterTest {
   }
 
   @Test
-  fun `writes the log with a file-safe name`() {
+  fun `writes the log and the runner, with a file-safe name`() {
     val dir = Files.createTempDirectory("replay-scripts").toFile()
     ArbigentReplayScriptWriter(dir).write(
       scenarioId = "open settings/main",
@@ -260,6 +260,9 @@ class ArbigentReplayScriptWriterTest {
       ArbigentReplayScriptWriter.fileBaseName("a/b") != ArbigentReplayScriptWriter.fileBaseName("a b"),
     )
     assertTrue(dir.listFiles().orEmpty().none { it.name.endsWith(".tmp") }, "temp file left behind")
+    val runner = File(dir, "replay.sh")
+    assertTrue(runner.isFile)
+    assertTrue(runner.canExecute(), "the runner has to be runnable without chmod")
 
     val lines = log.readLines().filter { it.isNotBlank() }
     assertEquals("scenario_start", lineType(lines.first()))
@@ -355,6 +358,7 @@ class ArbigentReplayScriptExecutorTest {
     advanceUntilIdle()
 
     assertTrue(File(dir, "settings-scenario.jsonl").isFile)
+    assertTrue(File(dir, "replay.sh").isFile)
   }
 
   @OptIn(ExperimentalStdlibApi::class)

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -274,6 +274,18 @@ class ArbigentReplayScriptWriterTest {
   }
 
   @Test
+  fun `a write that cannot finish leaves no staging file behind`() {
+    val dir = Files.createTempDirectory("replay-scripts-torn").toFile()
+    // A non-empty directory in the target's place makes both the atomic and the plain move fail
+    // (an empty one would be replaced).
+    val target = File(dir, "blocked.jsonl").apply { mkdirs() }
+    File(target, "inner.txt").writeText("occupied")
+    val failed = runCatching { ArbigentReplayScriptWriter.writeAtomically(target, "content") }
+    assertTrue(failed.isFailure, "replacing a directory should not succeed")
+    assertEquals(listOf("blocked.jsonl"), dir.list().orEmpty().toList(), "the staging file must be cleaned up")
+  }
+
+  @Test
   fun `a run that sent nothing writes no files`() {
     val dir = Files.createTempDirectory("replay-scripts").toFile()
     ArbigentReplayScriptWriter(dir).write(
@@ -292,6 +304,7 @@ class ArbigentReplayScriptWriterTest {
 /** A device that reports what it was asked to do, the way MaestroDevice does. */
 private class RecordingFakeDevice(
   private val os: io.github.takahirom.arbigent.ArbigentDeviceOs = io.github.takahirom.arbigent.ArbigentDeviceOs.Android,
+  private var refusedRegistrations: Int = 0,
 ) : io.github.takahirom.arbigent.ArbigentDevice by FakeDevice() {
   private val listeners = mutableListOf<io.github.takahirom.arbigent.ArbigentDeviceEventListener>()
   private val delegate = FakeDevice()
@@ -299,6 +312,10 @@ private class RecordingFakeDevice(
   override fun os(): io.github.takahirom.arbigent.ArbigentDeviceOs = os
 
   override fun addDeviceEventListener(listener: io.github.takahirom.arbigent.ArbigentDeviceEventListener) {
+    if (refusedRegistrations > 0) {
+      refusedRegistrations--
+      throw IllegalStateException("device refused the listener")
+    }
     if (!listeners.contains(listener)) listeners.add(listener)
   }
 
@@ -333,6 +350,28 @@ class ArbigentReplayScriptExecutorTest {
     advanceUntilIdle()
 
     assertTrue(File(dir, "settings-scenario.jsonl").isFile)
+  }
+
+  @OptIn(ExperimentalStdlibApi::class)
+  @Test
+  fun `a task whose events could not be recorded costs the scenario its script`() = runTest {
+    val dispatcher = coroutineContext[kotlinx.coroutines.CoroutineDispatcher]!!
+    val dir = Files.createTempDirectory("replay-scripts-unrecorded").toFile()
+    // One device serves both tasks; it refuses the first task's listener and accepts the second's.
+    val device = RecordingFakeDevice(refusedRegistrations = 1)
+    val agentConfig = io.github.takahirom.arbigent.AgentConfig {
+      deviceFactory { device }
+      aiFactory { FakeAi() }
+    }
+    io.github.takahirom.arbigent.ArbigentScenarioExecutor(dispatcher).execute(
+      scenario(agentConfig, dir, goals = listOf("Open the settings screen", "Open the account page")),
+      MCPClient(),
+    )
+    advanceUntilIdle()
+
+    // The second task recorded fine, but a log without the first task's actions would replay from a
+    // screen the recording never showed how to reach.
+    assertEquals(emptyList(), dir.listFiles()?.toList().orEmpty())
   }
 
   @OptIn(ExperimentalStdlibApi::class)
@@ -380,9 +419,12 @@ class ArbigentReplayScriptExecutorTest {
   private fun scenario(
     agentConfig: io.github.takahirom.arbigent.AgentConfig,
     dir: File,
+    goals: List<String> = listOf("Open the settings screen"),
   ) = io.github.takahirom.arbigent.ArbigentScenario(
     id = "settings-scenario",
-    agentTasks = listOf(io.github.takahirom.arbigent.ArbigentAgentTask("task1", "Open the settings screen", agentConfig)),
+    agentTasks = goals.mapIndexed { index, goal ->
+      io.github.takahirom.arbigent.ArbigentAgentTask("task${index + 1}", goal, agentConfig)
+    },
     maxStepCount = 10,
     tags = emptySet(),
     isLeaf = true,

--- a/arbigent-core/src/test/java/ReplayScriptRunnerTest.kt
+++ b/arbigent-core/src/test/java/ReplayScriptRunnerTest.kt
@@ -1,0 +1,167 @@
+package io.github.takahirom.arbigent.sample.test
+
+import java.io.File
+import java.nio.file.Files
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * Checks the python runner shipped as a resource, because a syntax error in it would otherwise only
+ * surface on the machine someone tries to replay on.
+ */
+class ReplayScriptRunnerTest {
+  private val fixture = "replay-scripts/sample-scenario.jsonl"
+
+  @Test
+  fun `the runner is valid python for the interpreter a machine is likely to have`() {
+    val dir = Files.createTempDirectory("replay-runner").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val (code, output) = run(dir, listOf("python3", "-m", "py_compile", script.absolutePath))
+    assertEquals(0, code, "python3 -m py_compile failed:\n$output")
+  }
+
+  @Test
+  fun `--show lists the steps without needing a device`() {
+    val dir = Files.createTempDirectory("replay-runner-show").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val log = File(dir, "sample-scenario.jsonl")
+    log.writeText(readResource(fixture))
+
+    val (code, output) = run(
+      dir,
+      listOf("python3", script.absolutePath, log.absolutePath, "--show", "--with-init"),
+    )
+    assertEquals(0, code, "--show failed:\n$output")
+    assertTrue(output.contains("goal: Open the settings screen"), output)
+    assertTrue(output.contains("1. Press the down key 3 times"), output)
+    assertTrue(output.contains("KEYCODE_DPAD_DOWN x3"), output)
+    assertTrue(output.contains("target: text='Settings'"), output)
+    assertTrue(output.contains("screen: text='Settings', resourceId='com.example.app:id/settings_tab'"), output)
+    assertTrue(output.contains("launch(com.example.app, clearState, debug_menu=true, entry=\"settings\")"), output)
+    assertTrue(output.contains("expect: resource ids"), output)
+  }
+
+  @Test
+  fun `a range selects only those steps`() {
+    val dir = Files.createTempDirectory("replay-runner-range").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val log = File(dir, "sample-scenario.jsonl")
+    log.writeText(readResource(fixture))
+
+    val (code, output) = run(
+      dir,
+      listOf("python3", script.absolutePath, log.absolutePath, "--show", "--from", "2"),
+    )
+    assertEquals(0, code, output)
+    assertTrue(output.contains("2. Press the center key"), output)
+    assertTrue(!output.contains("1. Press the down key"), output)
+  }
+
+  @Test
+  fun `--show reports the center coordinates the md points a human at`() {
+    val dir = Files.createTempDirectory("replay-runner-center").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val log = File(dir, "sample-scenario.jsonl")
+    log.writeText(readResource(fixture))
+
+    val (code, output) = run(
+      dir,
+      listOf("python3", script.absolutePath, log.absolutePath, "--show", "--backend", "maestro"),
+    )
+    // --backend is parsed but no hierarchy is read, so the unimplemented backend must not be hit.
+    assertEquals(0, code, output)
+    assertTrue(output.contains("center=(200,230)"), output)
+  }
+
+  @Test
+  fun `an unknown backend is a usage error`() {
+    val dir = Files.createTempDirectory("replay-runner-backend").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val log = File(dir, "sample-scenario.jsonl")
+    log.writeText(readResource(fixture))
+
+    val (code, output) = run(
+      dir,
+      listOf("python3", script.absolutePath, log.absolutePath, "--backend", "nope"),
+    )
+    assertEquals(1, code, output)
+    assertTrue(output.contains("--backend must be one of"), output)
+  }
+
+  @Test
+  fun `matching relaxes attributes, spans both resource id forms and both geometry shapes`() {
+    val dir = Files.createTempDirectory("replay-runner-match").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val probe = File(dir, "probe.py")
+    probe.writeText(
+      """
+      import json, runpy
+      module = runpy.run_path(SCRIPT_PATH, run_name="replay_runner")
+      find_match = module["find_match"]
+      resolvable = module["identity_is_resolvable"]
+      normalize = module["normalize"]
+      target = {"text": "Settings", "resourceId": "com.example.app:id/tab", "occurrence": 0}
+      strict = [{"text": "Settings", "resourceId": "com.example.app:id/tab"}]
+      split = [{"text": None, "resourceId": "com.example.app:id/tab"}]
+      compose = [{"text": None, "resourceId": None, "accessibilityId": None}]
+      # The `android` CLI prints a resource id without its package prefix.
+      short = [{"text": None, "resourceId": "tab"}]
+      other = [{"text": None, "resourceId": "com.example.other:id/tab"}]
+      print(json.dumps({
+          "strict": find_match(strict, target) is not None,
+          "relaxed": find_match(split, target) is not None,
+          "missing": find_match(compose, target) is None,
+          "shortId": find_match(short, target) is not None,
+          "otherPackage": find_match(other, target) is None,
+          "resolvableStrict": resolvable(strict, target),
+          "resolvableCompose": resolvable(compose, target),
+          "androidCenter": normalize({"center": "[12,34]"})["center"],
+          "uiautomatorCenter": normalize({"bounds": "[0,0][100,50]"})["center"],
+      }))
+      """.trimIndent().replace("SCRIPT_PATH", "\"" + script.absolutePath + "\"")
+    )
+
+    val (code, output) = run(dir, listOf("python3", probe.absolutePath))
+    assertEquals(0, code, output)
+    assertTrue(output.contains("\"strict\": true"), output)
+    assertTrue(output.contains("\"relaxed\": true"), output)
+    assertTrue(output.contains("\"missing\": true"), output)
+    assertTrue(output.contains("\"resolvableStrict\": true"), output)
+    assertTrue(output.contains("\"resolvableCompose\": false"), output)
+    assertTrue(output.contains("\"shortId\": true"), output)
+    assertTrue(output.contains("\"otherPackage\": true"), output)
+    assertTrue(output.contains("\"x\": 12"), output)
+    assertTrue(output.contains("\"x\": 50"), output)
+  }
+
+  /** The shell wrapper feeds the runner to python on stdin, so the test needs the same slice. */
+  private fun extractPython(): String {
+    val source = readResource("replay.sh")
+    val start = source.indexOf("<<'PY'\n") + "<<'PY'\n".length
+    val end = source.indexOf("\nPY\n", start)
+    assertTrue(start > 0 && end > start, "replay.sh no longer wraps the runner in a PY heredoc")
+    return source.substring(start, end)
+  }
+
+  private fun readResource(name: String): String =
+    checkNotNull(javaClass.classLoader.getResourceAsStream(name)) { "missing resource $name" }
+      .use { it.readBytes().decodeToString() }
+
+  private fun run(workingDir: File, command: List<String>): Pair<Int, String> {
+    val process = ProcessBuilder(command)
+      .directory(workingDir)
+      .redirectErrorStream(true)
+      .start()
+    val output = process.inputStream.bufferedReader().readText()
+    process.waitFor(60, TimeUnit.SECONDS)
+    return process.exitValue() to output
+  }
+}

--- a/arbigent-core/src/test/java/ReplayScriptRunnerTest.kt
+++ b/arbigent-core/src/test/java/ReplayScriptRunnerTest.kt
@@ -190,6 +190,53 @@ class ReplayScriptRunnerTest {
   }
 
   @Test
+  fun `step numbers below one and inverted ranges are usage errors`() {
+    val dir = Files.createTempDirectory("replay-runner-range").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val log = File(dir, "sample-scenario.jsonl")
+    log.writeText(readResource(fixture))
+
+    listOf(listOf("--from", "0"), listOf("--step", "-1"), listOf("--until", "0"), listOf("--from", "3", "--until", "2"))
+      .forEach { flags ->
+        val (code, output) = run(dir, listOf("python3", script.absolutePath, log.absolutePath, "--show") + flags)
+        assertEquals(1, code, "$flags: $output")
+        assertTrue(output.contains("replay.sh:"), "$flags: $output")
+        assertTrue(!output.contains("nothing to replay"), "$flags should be rejected as an argument, not an empty range: $output")
+      }
+  }
+
+  @Test
+  fun `a log that cannot be read is a usage error rather than a traceback`() {
+    val dir = Files.createTempDirectory("replay-runner-unreadable").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val log = File(dir, "sample-scenario.jsonl")
+    log.writeBytes(byteArrayOf(0xff.toByte(), 0xfe.toByte(), '{'.code.toByte()))
+
+    val (code, output) = run(dir, listOf("python3", script.absolutePath, log.absolutePath, "--show"))
+    assertEquals(1, code, output)
+    assertTrue(output.contains("could not read event log"), output)
+    assertTrue(!output.contains("Traceback"), output)
+  }
+
+  @Test
+  fun `the wrapper refuses to run without python3 instead of exiting 127`() {
+    val dir = Files.createTempDirectory("replay-runner-nopython").toFile()
+    val script = File(dir, "replay.sh")
+    script.writeText(readResource("replay.sh"))
+    val process = ProcessBuilder("/bin/sh", script.absolutePath, "whatever.jsonl")
+      .directory(dir)
+      .redirectErrorStream(true)
+    process.environment()["PATH"] = dir.absolutePath
+    val started = process.start()
+    val output = started.inputStream.bufferedReader().readText()
+    started.waitFor(60, TimeUnit.SECONDS)
+    assertEquals(1, started.exitValue(), output)
+    assertTrue(output.contains("python3 is required"), output)
+  }
+
+  @Test
   fun `--show on an empty range is a usage error`() {
     val dir = Files.createTempDirectory("replay-runner-empty").toFile()
     val script = File(dir, "runner.py")

--- a/arbigent-core/src/test/java/ReplayScriptRunnerTest.kt
+++ b/arbigent-core/src/test/java/ReplayScriptRunnerTest.kt
@@ -6,6 +6,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.fail
 
 /**
  * Checks the python runner shipped as a resource, because a syntax error in it would otherwise only
@@ -237,6 +238,32 @@ class ReplayScriptRunnerTest {
   }
 
   @Test
+  fun `--step with --with-init replays the launch and the setup that prepared that step`() {
+    val dir = Files.createTempDirectory("replay-runner-step-init").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val log = File(dir, "sample-scenario.jsonl")
+    log.writeText(readResource(fixture))
+
+    // Step 2 needs only the launch; step 3 also owns the relaunch recorded right after it.
+    val (code, output) = run(
+      dir,
+      listOf("python3", script.absolutePath, log.absolutePath, "--show", "--with-init", "--step", "2"),
+    )
+    assertEquals(0, code, output)
+    assertEquals(1, output.lines().count { it.startsWith("0. setup") }, "--step must not drop --with-init:\n$output")
+    assertTrue(output.contains("2. Press the center key"), output)
+    assertTrue(!output.contains("1. Press the down key"), output)
+
+    val (lastCode, lastOutput) = run(
+      dir,
+      listOf("python3", script.absolutePath, log.absolutePath, "--show", "--with-init", "--step", "3"),
+    )
+    assertEquals(0, lastCode, lastOutput)
+    assertEquals(2, lastOutput.lines().count { it.startsWith("0. setup") }, lastOutput)
+  }
+
+  @Test
   fun `--show on an empty range is a usage error`() {
     val dir = Files.createTempDirectory("replay-runner-empty").toFile()
     val script = File(dir, "runner.py")
@@ -398,13 +425,21 @@ class ReplayScriptRunnerTest {
     checkNotNull(javaClass.classLoader.getResourceAsStream(name)) { "missing resource $name" }
       .use { it.readBytes().decodeToString() }
 
+  /**
+   * Output goes to a file so the time limit applies before anything is read: a hung runner keeps
+   * its stdout open, and reading the pipe first would wait on it forever.
+   */
   private fun run(workingDir: File, command: List<String>): Pair<Int, String> {
+    val outputFile = File.createTempFile("replay-runner-output", ".txt", workingDir)
     val process = ProcessBuilder(command)
       .directory(workingDir)
       .redirectErrorStream(true)
+      .redirectOutput(outputFile)
       .start()
-    val output = process.inputStream.bufferedReader().readText()
-    process.waitFor(60, TimeUnit.SECONDS)
-    return process.exitValue() to output
+    if (!process.waitFor(60, TimeUnit.SECONDS)) {
+      process.destroyForcibly().waitFor()
+      fail("the runner did not finish within 60 seconds:\n${outputFile.readText()}")
+    }
+    return process.exitValue() to outputFile.readText()
   }
 }

--- a/arbigent-core/src/test/java/ReplayScriptRunnerTest.kt
+++ b/arbigent-core/src/test/java/ReplayScriptRunnerTest.kt
@@ -163,6 +163,106 @@ class ReplayScriptRunnerTest {
   }
 
   @Test
+  fun `a setup block is replayed only with the step it prepared for`() {
+    val dir = Files.createTempDirectory("replay-runner-init-range").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val log = File(dir, "sample-scenario.jsonl")
+    log.writeText(readResource(fixture))
+
+    // The relaunch after step 3 is not needed when the replay stops at step 2, but the launch
+    // before step 1 is: it is how the app gets on screen at all.
+    val (untilCode, untilOutput) = run(
+      dir,
+      listOf("python3", script.absolutePath, log.absolutePath, "--show", "--with-init", "--until", "2"),
+    )
+    assertEquals(0, untilCode, untilOutput)
+    assertEquals(1, untilOutput.lines().count { it.startsWith("0. setup") }, untilOutput)
+    assertTrue(untilOutput.lines().first { it.startsWith("0. setup") }.isNotEmpty())
+
+    val (fromCode, fromOutput) = run(
+      dir,
+      listOf("python3", script.absolutePath, log.absolutePath, "--show", "--with-init", "--from", "3"),
+    )
+    assertEquals(0, fromCode, fromOutput)
+    assertEquals(2, fromOutput.lines().count { it.startsWith("0. setup") }, fromOutput)
+    assertTrue(!fromOutput.contains("1. Press the down key"), fromOutput)
+  }
+
+  @Test
+  fun `--show on an empty range is a usage error`() {
+    val dir = Files.createTempDirectory("replay-runner-empty").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val log = File(dir, "sample-scenario.jsonl")
+    log.writeText(readResource(fixture))
+
+    val (code, output) = run(
+      dir,
+      listOf("python3", script.absolutePath, log.absolutePath, "--show", "--from", "9"),
+    )
+    assertEquals(1, code, output)
+    assertTrue(output.contains("nothing to replay"), output)
+  }
+
+  @Test
+  fun `a dump that adb could not take at all is a device failure, not an empty screen`() {
+    val dir = Files.createTempDirectory("replay-runner-dump").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val probe = File(dir, "probe.py")
+    probe.writeText(
+      """
+      import json, runpy
+      module = runpy.run_path(SCRIPT_PATH, run_name="replay_runner")
+      Options = module["Options"]
+      DeviceCommandFailed = module["DeviceCommandFailed"]
+      Diverged = module["Diverged"]
+      module["time"].sleep = lambda seconds: None
+      calls = []
+
+      def fake_adb(kind):
+          def adb(options, args, capture=False):
+              calls.append(args)
+              if args[:2] == ["shell", "rm"]:
+                  return 0, b"", b""
+              if kind == "no-device":
+                  return 1, b"", b"adb: device 'bogus' not found"
+              if kind == "busy":
+                  return 0, b"ERROR: could not get idle state.", b""
+              return 0, b"", b""
+          return adb
+
+      options = Options()
+      options.backend = "uiautomator"
+      result = {}
+      module["adb"] = fake_adb("no-device")
+      module["dump_tree_uiautomator"].__globals__["adb"] = module["adb"]
+      try:
+          module["dump_tree"](options)
+          result["noDevice"] = "returned"
+      except DeviceCommandFailed as error:
+          result["noDevice"] = "failed: %s" % error
+      module["dump_tree_uiautomator"].__globals__["adb"] = fake_adb("busy")
+      result["busy"] = module["dump_tree"](options)
+      try:
+          module["send_event"](options, {"type": "input_text", "text": "50%s off"}, {}, [])
+          result["percent"] = "sent"
+      except Diverged as error:
+          result["percent"] = "diverged"
+      print(json.dumps(result))
+      """.trimIndent().replace("SCRIPT_PATH", "\"" + script.absolutePath + "\"")
+    )
+
+    val (code, output) = run(dir, listOf("python3", probe.absolutePath))
+    assertEquals(0, code, output)
+    assertTrue(output.contains("\"noDevice\": \"failed: uiautomator dump failed: adb: device 'bogus' not found\""), output)
+    // A screen that is merely still animating is not a device failure.
+    assertTrue(output.contains("\"busy\": []"), output)
+    assertTrue(output.contains("\"percent\": \"diverged\""), output)
+  }
+
+  @Test
   fun `a log without a successful end is refused`() {
     val dir = Files.createTempDirectory("replay-runner-torn").toFile()
     val script = File(dir, "runner.py")

--- a/arbigent-core/src/test/java/ReplayScriptRunnerTest.kt
+++ b/arbigent-core/src/test/java/ReplayScriptRunnerTest.kt
@@ -142,6 +142,102 @@ class ReplayScriptRunnerTest {
     assertTrue(output.contains("\"x\": 50"), output)
   }
 
+  @Test
+  fun `setup that ran after a step stays after it`() {
+    val dir = Files.createTempDirectory("replay-runner-order").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val log = File(dir, "sample-scenario.jsonl")
+    log.writeText(readResource(fixture))
+
+    val (code, output) = run(
+      dir,
+      listOf("python3", script.absolutePath, log.absolutePath, "--show", "--with-init"),
+    )
+    assertEquals(0, code, output)
+    val setups = output.lines().withIndex().filter { it.value.startsWith("0. setup") }.map { it.index }
+    val lastStep = output.lines().indexOfFirst { it.startsWith("3. ") }
+    assertEquals(2, setups.size, "a task that launched the app again must show two setup blocks:\n$output")
+    assertTrue(setups[0] < lastStep && lastStep < setups[1], "the second setup must follow step 3:\n$output")
+    assertTrue(output.contains("tap(text='Account')"), output)
+  }
+
+  @Test
+  fun `a log without a successful end is refused`() {
+    val dir = Files.createTempDirectory("replay-runner-torn").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val torn = File(dir, "torn.jsonl")
+    torn.writeText(readResource(fixture).lines().filter { !it.contains("scenario_end") }.joinToString("\n"))
+    val (code, output) = run(dir, listOf("python3", script.absolutePath, torn.absolutePath, "--show"))
+    assertEquals(1, code, output)
+    assertTrue(output.contains("does not end with a successful scenario_end"), output)
+
+    val broken = File(dir, "broken.jsonl")
+    broken.writeText(readResource(fixture) + "{not json\n")
+    val (brokenCode, brokenOutput) = run(dir, listOf("python3", script.absolutePath, broken.absolutePath, "--show"))
+    assertEquals(1, brokenCode, brokenOutput)
+    assertTrue(brokenOutput.contains("is not JSON"), brokenOutput)
+  }
+
+  @Test
+  fun `a timeout that could never elapse is a usage error`() {
+    val dir = Files.createTempDirectory("replay-runner-timeout").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val log = File(dir, "sample-scenario.jsonl")
+    log.writeText(readResource(fixture))
+    for (value in listOf("nan", "inf", "0", "-3")) {
+      val (code, output) = run(
+        dir,
+        listOf("python3", script.absolutePath, log.absolutePath, "--show", "--timeout", value),
+      )
+      assertEquals(1, code, "--timeout $value should be refused:\n$output")
+      assertTrue(output.contains("positive number of seconds"), output)
+    }
+  }
+
+  @Test
+  fun `remote arguments are quoted for the device shell and element taps resolve like maestro`() {
+    val dir = Files.createTempDirectory("replay-runner-quote").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val probe = File(dir, "probe.py")
+    probe.writeText(
+      """
+      import json, runpy
+      module = runpy.run_path(SCRIPT_PATH, run_name="replay_runner")
+      adb_command = module["adb_command"]
+      escape_text = module["escape_text"]
+      resolve = module["resolve_element"]
+      nodes = [
+          {"text": "Account", "resourceId": "com.example.app:id/row", "accessibilityId": None},
+          {"text": "account settings", "resourceId": "com.example.app:id/row", "accessibilityId": None},
+          {"text": None, "resourceId": "settings_tab", "accessibilityId": "Open menu"},
+      ]
+      print(json.dumps({
+          "shell": adb_command(["shell", "am", "start", "--es", "entry", "a b; rm -rf /"]),
+          "text": escape_text("100% sure"),
+          "exact": resolve(nodes, {"textRegex": "account", "index": 0})["text"],
+          "second": resolve(nodes, {"textRegex": ".*account.*", "index": 1})["text"],
+          "shortId": resolve(nodes, {"idRegex": "com.example.app:id/settings_tab"})["accessibilityId"],
+          "label": resolve(nodes, {"textRegex": "Open Menu"})["resourceId"],
+          "none": resolve(nodes, {"textRegex": "Nowhere"}) is None,
+      }))
+      """.trimIndent().replace("SCRIPT_PATH", "\"" + script.absolutePath + "\"")
+    )
+
+    val (code, output) = run(dir, listOf("python3", probe.absolutePath))
+    assertEquals(0, code, output)
+    assertTrue(output.contains("\"shell\": [\"adb\", \"shell\", \"am start --es entry 'a b; rm -rf /'\"]"), output)
+    assertTrue(output.contains("\"text\": \"100%%ssure\""), output)
+    assertTrue(output.contains("\"exact\": \"Account\""), output)
+    assertTrue(output.contains("\"second\": \"account settings\""), output)
+    assertTrue(output.contains("\"shortId\": \"Open menu\""), output)
+    assertTrue(output.contains("\"label\": \"settings_tab\""), output)
+    assertTrue(output.contains("\"none\": true"), output)
+  }
+
   /** The shell wrapper feeds the runner to python on stdin, so the test needs the same slice. */
   private fun extractPython(): String {
     val source = readResource("replay.sh")

--- a/arbigent-core/src/test/java/ReplayScriptRunnerTest.kt
+++ b/arbigent-core/src/test/java/ReplayScriptRunnerTest.kt
@@ -355,6 +355,74 @@ class ReplayScriptRunnerTest {
   }
 
   @Test
+  fun `a log that is more than one finished run is refused`() {
+    val dir = Files.createTempDirectory("replay-runner-shape").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val lines = readResource(fixture).lines().filter { it.isNotBlank() }
+    val deviceLine = lines.first { it.contains("\"type\":\"device\"") || it.contains("\"type\": \"device\"") }
+    val startLine = lines.first { it.contains("scenario_start") }
+
+    fun refuse(name: String, content: List<String>, expected: String) {
+      val log = File(dir, name)
+      log.writeText(content.joinToString("\n"))
+      val (code, output) = run(dir, listOf("python3", script.absolutePath, log.absolutePath, "--show"))
+      assertEquals(1, code, output)
+      assertTrue(output.contains(expected), output)
+    }
+
+    // A device line appended after the successful end is not part of the run that succeeded.
+    refuse("appended.jsonl", lines + deviceLine, "does not end with a successful scenario_end")
+    // Two runs concatenated into one file.
+    refuse("doubled.jsonl", lines + lines, "more than one scenario_start")
+    refuse("restarted.jsonl", listOf(startLine) + lines, "more than one scenario_start")
+    refuse("headless.jsonl", lines.drop(1), "does not start with a scenario_start")
+    // A line from another scenario spliced into the middle.
+    val foreign = deviceLine.replace("\"open-settings\"", "\"other-scenario\"")
+    assertTrue(foreign != deviceLine)
+    refuse("mixed.jsonl", lines.dropLast(1) + foreign + lines.last(), "mixes lines from scenarios")
+  }
+
+  @Test
+  fun `a failed setup block points the resume hint at the step it prepared`() {
+    val dir = Files.createTempDirectory("replay-runner-resume").toFile()
+    val script = File(dir, "runner.py")
+    script.writeText(extractPython())
+    val probe = File(dir, "probe.py")
+    probe.writeText(
+      """
+      import io, json, runpy
+      module = runpy.run_path(SCRIPT_PATH, run_name="replay_runner")
+      options = module["Options"]()
+      options.log = "open settings.jsonl"
+
+      def step(number):
+          return {"number": number, "isInit": number == 0}
+
+      def hint(current, remaining):
+          out = io.StringIO()
+          module["write_resume_hint"](out, options, current, remaining)
+          return out.getvalue().strip()
+
+      print(json.dumps({
+          "normal": hint(step(2), [step(3)]),
+          "firstSetup": hint(step(0), [step(1), step(2)]),
+          "laterSetup": hint(step(0), [step(3)]),
+          "trailingSetup": hint(step(0), []),
+      }))
+      """.trimIndent().replace("SCRIPT_PATH", "\"" + script.absolutePath + "\"")
+    )
+
+    val (code, output) = run(dir, listOf("python3", probe.absolutePath))
+    assertEquals(0, code, output)
+    assertTrue(output.contains("\"normal\": \"resume with: ./replay.sh 'open settings.jsonl' --from 2\""), output)
+    // Step zero is not a valid --from, so the setup is replayed through --with-init on the next step.
+    assertTrue(output.contains("\"firstSetup\": \"resume with: ./replay.sh 'open settings.jsonl' --with-init --from 1\""), output)
+    assertTrue(output.contains("\"laterSetup\": \"resume with: ./replay.sh 'open settings.jsonl' --with-init --from 3\""), output)
+    assertTrue(output.contains("\"trailingSetup\": \"\""), output)
+  }
+
+  @Test
   fun `a timeout that could never elapse is a usage error`() {
     val dir = Files.createTempDirectory("replay-runner-timeout").toFile()
     val script = File(dir, "runner.py")

--- a/arbigent-core/src/test/java/ReplayScriptRunnerTest.kt
+++ b/arbigent-core/src/test/java/ReplayScriptRunnerTest.kt
@@ -226,14 +226,11 @@ class ReplayScriptRunnerTest {
     val dir = Files.createTempDirectory("replay-runner-nopython").toFile()
     val script = File(dir, "replay.sh")
     script.writeText(readResource("replay.sh"))
-    val process = ProcessBuilder("/bin/sh", script.absolutePath, "whatever.jsonl")
-      .directory(dir)
-      .redirectErrorStream(true)
-    process.environment()["PATH"] = dir.absolutePath
-    val started = process.start()
-    val output = started.inputStream.bufferedReader().readText()
-    started.waitFor(60, TimeUnit.SECONDS)
-    assertEquals(1, started.exitValue(), output)
+    val (code, output) = run(
+      dir, listOf("/bin/sh", script.absolutePath, "whatever.jsonl"),
+      environment = mapOf("PATH" to dir.absolutePath),
+    )
+    assertEquals(1, code, output)
     assertTrue(output.contains("python3 is required"), output)
   }
 
@@ -497,13 +494,18 @@ class ReplayScriptRunnerTest {
    * Output goes to a file so the time limit applies before anything is read: a hung runner keeps
    * its stdout open, and reading the pipe first would wait on it forever.
    */
-  private fun run(workingDir: File, command: List<String>): Pair<Int, String> {
+  private fun run(
+    workingDir: File,
+    command: List<String>,
+    environment: Map<String, String> = emptyMap(),
+  ): Pair<Int, String> {
     val outputFile = File.createTempFile("replay-runner-output", ".txt", workingDir)
-    val process = ProcessBuilder(command)
+    val builder = ProcessBuilder(command)
       .directory(workingDir)
       .redirectErrorStream(true)
       .redirectOutput(outputFile)
-      .start()
+    builder.environment().putAll(environment)
+    val process = builder.start()
     if (!process.waitFor(60, TimeUnit.SECONDS)) {
       process.destroyForcibly().waitFor()
       fail("the runner did not finish within 60 seconds:\n${outputFile.readText()}")

--- a/arbigent-core/src/test/resources/replay-scripts/sample-scenario.jsonl
+++ b/arbigent-core/src/test/resources/replay-scripts/sample-scenario.jsonl
@@ -1,0 +1,10 @@
+{"type":"scenario_start","task":"open-settings","taskIndex":0,"step":0,"ts":1000,"goal":"Open the settings screen","appId":"com.example.app","width":1920,"height":1080}
+{"type":"init","task":"open-settings","taskIndex":0,"step":0,"ts":1001,"event":{"type":"launch_app","appId":"com.example.app","clearState":true,"launchArguments":{"debug_menu":true,"entry":"settings"},"timestamp":1001}}
+{"type":"decision","task":"open-settings","taskIndex":0,"step":1,"ts":1100,"action":"DpadDownAgentAction","log":"Press the down key 3 times","goal":"Open the settings screen","memo":"Move focus to the settings tab","screenshot":"step1.png"}
+{"type":"target","task":"open-settings","taskIndex":0,"step":1,"ts":1100,"text":"Settings","resourceId":"com.example.app:id/settings_tab","occurrence":0,"bounds":"[100,200][300,260]","center":{"x":200,"y":230}}
+{"type":"device","task":"open-settings","taskIndex":0,"step":1,"ts":1101,"event":{"type":"key_press","keyName":"KEYCODE_DPAD_DOWN","timestamp":1101}}
+{"type":"device","task":"open-settings","taskIndex":0,"step":1,"ts":1102,"event":{"type":"key_press","keyName":"KEYCODE_DPAD_DOWN","timestamp":1102}}
+{"type":"device","task":"open-settings","taskIndex":0,"step":1,"ts":1103,"event":{"type":"key_press","keyName":"KEYCODE_DPAD_DOWN","timestamp":1103}}
+{"type":"decision","task":"open-settings","taskIndex":0,"step":2,"ts":1200,"action":"DpadCenterAgentAction","log":"Press the center key","goal":"Open the settings screen","screenshot":"step2.png","screen":[{"text":"Settings"},{"resourceId":"com.example.app:id/settings_tab"}]}
+{"type":"device","task":"open-settings","taskIndex":0,"step":2,"ts":1201,"event":{"type":"key_press","keyName":"KEYCODE_DPAD_CENTER","timestamp":1201}}
+{"type":"scenario_end","task":"open-settings","taskIndex":0,"step":2,"ts":1300,"status":"success","signature":["com.example.app:id/settings_title","com.example.app:id/settings_list"]}

--- a/arbigent-core/src/test/resources/replay-scripts/sample-scenario.jsonl
+++ b/arbigent-core/src/test/resources/replay-scripts/sample-scenario.jsonl
@@ -7,4 +7,8 @@
 {"type":"device","task":"open-settings","taskIndex":0,"step":1,"ts":1103,"event":{"type":"key_press","keyName":"KEYCODE_DPAD_DOWN","timestamp":1103}}
 {"type":"decision","task":"open-settings","taskIndex":0,"step":2,"ts":1200,"action":"DpadCenterAgentAction","log":"Press the center key","goal":"Open the settings screen","screenshot":"step2.png","screen":[{"text":"Settings"},{"resourceId":"com.example.app:id/settings_tab"}]}
 {"type":"device","task":"open-settings","taskIndex":0,"step":2,"ts":1201,"event":{"type":"key_press","keyName":"KEYCODE_DPAD_CENTER","timestamp":1201}}
-{"type":"scenario_end","task":"open-settings","taskIndex":0,"step":2,"ts":1300,"status":"success","signature":["com.example.app:id/settings_title","com.example.app:id/settings_list"]}
+{"type":"decision","task":"open-settings","taskIndex":0,"step":3,"ts":1250,"action":"ClickWithTextAgentAction","log":"Click on text: Account","goal":"Open the settings screen","screenshot":"step3.png"}
+{"type":"target","task":"open-settings","taskIndex":0,"step":3,"ts":1250,"text":"Account","resourceId":"com.example.app:id/account_row","occurrence":0,"bounds":"[100,400][900,460]","center":{"x":500,"y":430}}
+{"type":"device","task":"open-settings","taskIndex":0,"step":3,"ts":1251,"event":{"type":"tap_element","textRegex":"Account","index":0,"timestamp":1251}}
+{"type":"init","task":"open-settings","taskIndex":0,"step":0,"ts":1260,"event":{"type":"launch_app","appId":"com.example.app","clearState":false,"stopApp":true,"launchArguments":{},"timestamp":1260}}
+{"type":"scenario_end","task":"open-settings","taskIndex":0,"step":3,"ts":1300,"status":"success","signature":["com.example.app:id/settings_title","com.example.app:id/settings_list"]}


### PR DESCRIPTION
Part 4 of the replay-scripts stack (on top of the recorder PR).

Copies `replay.sh` beside every log it writes. The runner is a `sh` wrapper around a python3 stdlib script, so it works wherever `adb` does, with no Arbigent, Maestro, or AI on the machine.

```
./replay.sh <scenario>.jsonl [--with-init] [--step N | --from N --until N]
            [--device SERIAL] [--timeout SEC] [--no-wait]
            [--backend auto|android|uiautomator|maestro] [--show]
```

- Reads the hierarchy through `uiautomator dump` first (works on release builds), or the `android layout` CLI when asked; the maestro backend is a documented stub.
- Waits, up to `--timeout`, for each step's recorded target before sending, matching strictly first and then relaxing attributes. A target that never appears exits 2 so an agent knows to fall back to the AI. A target-less step waits for any of its screen hints instead (advisory).
- Launches through the resolved launcher activity with `am start` so recorded extras (`--ez/--ei/--ef/--es`) are honored, falling back to `monkey` without them.
- At the end, compares the recorded resource-id signature with the screen and reports PASS/WARN.
- `--show` lists the steps and their centers without a device.
- Every remote argument is shell-quoted for the device, every adb call is time-bounded, and a failed command (a rejected `pm clear`, `am start` error) stops the replay with exit 3 instead of carrying on. An element tap is resolved against the current hierarchy with Maestro's regex rules (full match, case-insensitive), falling back to the recorded position; no match exits 2.
- A log that does not parse or does not end with a successful `scenario_end` is refused (exit 1). Setup blocks that ran after a step (a fallback re-launch) stay in that order.

Tests run the script under python3 (compile, `--show`, range selection, matching rules) so a broken runner fails in CI rather than on someone's laptop.

Verified end to end on an Android TV emulator: a recorded 4-step scenario replayed from `pm clear` to a matching end screen, an element tap resolved and landed on the live screen, a `pm clear` of a missing package exited 3, and an unmatched element selector exited 2.

After a target or screen hint matches, the runner rechecks it on the settled hierarchy and keeps waiting if it vanished mid-transition. A setup block in the middle of a run is replayed only when the step after it is selected (the leading one is always included with `--with-init`). A hierarchy that adb could not read at all (no device, wrong serial, hang) is exit 3 rather than an empty screen, `android layout` gets `--device` explicitly because it ignores `ANDROID_SERIAL`, a literal `%s` in typed text is a divergence, and `--show` on an empty range is a usage error.