### PR TITLE
Add a readable summary beside each replay log

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -270,7 +270,7 @@ public data class ArbigentProjectSettings(
 
 /**
  * Emits a replay script per scenario after a successful run: an event log of what was sent to the
- * device, so the same screens can be reached again without the AI.
+ * device, a readable step summary, and a runner that replays them with `adb` alone.
  *
  * Absent from the project file means the feature is off, so an existing project keeps writing
  * nothing until it opts in.

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
@@ -22,7 +22,7 @@ internal fun renderReplayScriptMarkdown(
   if (goals.size == 1) {
     appendLine(goals.single())
   } else {
-    goals.forEachIndexed { index, goal -> appendLine("${index + 1}. $goal") }
+    goals.forEachIndexed { index, goal -> appendLine("${index + 1}. ${goal.escapedForOneLine()}") }
   }
   appendLine()
   appendLine("## Steps")
@@ -31,15 +31,16 @@ internal fun renderReplayScriptMarkdown(
   steps.forEach { step ->
     if (goals.size > 1 && step.taskIndex != lastTaskIndex) {
       lastTaskIndex = step.taskIndex
-      appendLine("### Task ${step.taskIndex + 1}: ${tasks.firstOrNull { it.taskIndex == step.taskIndex }?.goal.orEmpty()}")
+      val goal = tasks.firstOrNull { it.taskIndex == step.taskIndex }?.goal.orEmpty()
+      appendLine("### Task ${step.taskIndex + 1}: ${goal.escapedForOneLine()}")
       appendLine()
     }
     if (step.isInit) {
       appendLine("0. setup")
     } else {
-      appendLine("${step.number}. ${step.actionLog ?: step.actionName ?: "step"}")
+      appendLine("${step.number}. ${(step.actionLog ?: step.actionName ?: "step").escapedForOneLine()}")
     }
-    step.target?.let { appendLine("   - target: ${it.description()}") }
+    step.target?.let { appendLine("   - target: ${it.oneLineDescription()}") }
     // Maestro sees attributes an adb-side dump may miss, so the coordinates are spelled out for a
     // reader who has to tap by hand.
     step.targetBounds?.let {
@@ -48,11 +49,11 @@ internal fun renderReplayScriptMarkdown(
     if (step.screen.isNotEmpty()) {
       appendLine("   - screen: ${step.screen.joinToString(", ") { it.label() }}")
     }
-    step.memo?.takeIf { it.isNotBlank() }?.let { appendLine("   - memo: ${it.replace("\n", " ")}") }
+    step.memo?.takeIf { it.isNotBlank() }?.let { appendLine("   - memo: ${it.escapedForOneLine()}") }
     appendLine("   - device: ${summarizeEvents(step.events)}")
     step.target?.let { target ->
       val fallback = step.targetBounds?.let { " (or tap ${it.centerX},${it.centerY})" }.orEmpty()
-      appendLine("   - wait for: ${target.description()}$fallback")
+      appendLine("   - wait for: ${target.oneLineDescription()}$fallback")
     }
     // The exact command for this one step, so an agent driving the app a step at a time can copy it
     // instead of working the number out from the option list.
@@ -91,6 +92,13 @@ internal fun renderReplayScriptMarkdown(
   appendLine("`./arbigentw` downloads the matching arbigent on first use; `arbigent replay` is the")
   appendLine("same command for an arbigent that is already installed.")
 }
+
+/**
+ * `description()` writes the attributes raw, which is right for a log line but not for a bullet a
+ * reader scans: a value carrying a newline would end the bullet and leave its remainder as prose.
+ */
+private fun ArbigentElementIdentity.oneLineDescription(): String =
+  label() + " (occurrence $occurrence)"
 
 /** The identity without its occurrence, which means nothing for a screen-level hint. */
 private fun ArbigentElementIdentity.label(): String = listOfNotNull(

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
@@ -22,7 +22,7 @@ internal fun renderReplayScriptMarkdown(
   if (goals.size == 1) {
     appendLine(goals.single())
   } else {
-    goals.forEachIndexed { index, goal -> appendLine("${index + 1}. ${goal.escapedForOneLine()}") }
+    goals.forEachIndexed { index, goal -> appendLine("${index + 1}. ${goal.collapsedToOneLine()}") }
   }
   appendLine()
   appendLine("## Steps")
@@ -32,13 +32,13 @@ internal fun renderReplayScriptMarkdown(
     if (goals.size > 1 && step.taskIndex != lastTaskIndex) {
       lastTaskIndex = step.taskIndex
       val goal = tasks.firstOrNull { it.taskIndex == step.taskIndex }?.goal.orEmpty()
-      appendLine("### Task ${step.taskIndex + 1}: ${goal.escapedForOneLine()}")
+      appendLine("### Task ${step.taskIndex + 1}: ${goal.collapsedToOneLine()}")
       appendLine()
     }
     if (step.isInit) {
       appendLine("0. setup")
     } else {
-      appendLine("${step.number}. ${(step.actionLog ?: step.actionName ?: "step").escapedForOneLine()}")
+      appendLine("${step.number}. ${(step.actionLog ?: step.actionName ?: "step").collapsedToOneLine()}")
     }
     step.target?.let { appendLine("   - target: ${it.oneLineDescription()}") }
     // Maestro sees attributes an adb-side dump may miss, so the coordinates are spelled out for a
@@ -49,7 +49,7 @@ internal fun renderReplayScriptMarkdown(
     if (step.screen.isNotEmpty()) {
       appendLine("   - screen: ${step.screen.joinToString(", ") { it.label() }}")
     }
-    step.memo?.takeIf { it.isNotBlank() }?.let { appendLine("   - memo: ${it.escapedForOneLine()}") }
+    step.memo?.takeIf { it.isNotBlank() }?.let { appendLine("   - memo: ${it.collapsedToOneLine()}") }
     appendLine("   - device: ${summarizeEvents(step.events)}")
     step.target?.let { target ->
       val fallback = step.targetBounds?.let { " (or tap ${it.centerX},${it.centerY})" }.orEmpty()
@@ -92,6 +92,13 @@ internal fun renderReplayScriptMarkdown(
   appendLine("`./arbigentw` downloads the matching arbigent on first use; `arbigent replay` is the")
   appendLine("same command for an arbigent that is already installed.")
 }
+
+/**
+ * A goal, an action log or a memo is prose, so a line break in it is worth nothing to keep: folding
+ * it into a space reads as written, where an escape would show a `\n` and double every backslash the
+ * text happened to contain. A selector value is the opposite — it has to survive being copied out.
+ */
+private fun String.collapsedToOneLine(): String = replace(Regex("""\s*\R\s*"""), " ").trim()
 
 /**
  * `description()` writes the attributes raw, which is right for a log line but not for a bullet a

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
@@ -20,7 +20,7 @@ internal fun renderReplayScriptMarkdown(
   appendLine("## Goal")
   appendLine()
   if (goals.size == 1) {
-    appendLine(goals.single())
+    appendLine(goals.single().collapsedToOneLine())
   } else {
     goals.forEachIndexed { index, goal -> appendLine("${index + 1}. ${goal.collapsedToOneLine()}") }
   }
@@ -175,6 +175,10 @@ private fun String.escapedForOneLine(): String = replace("\\", "\\\\")
 
 /**
  * A value rendered inside `'…'` also has to keep its own quotes from closing the field. `\'` is a
- * legal escape in a regex too, so a reader who copies the value out gets the same matching.
+ * legal escape in a regex too, so a reader who copies the value out gets the same matching. The
+ * backslashes already in the value are left alone rather than doubled: a selector is often a regex,
+ * and `\d+` doubled into `\\d+` stops matching digits the moment it is copied back out.
  */
-private fun String.escapedForSingleQuotedOneLine(): String = escapedForOneLine().replace("'", "\\'")
+private fun String.escapedForSingleQuotedOneLine(): String = replace("\r", "\\r")
+  .replace("\n", "\\n")
+  .replace("'", "\\'")

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
@@ -1,0 +1,145 @@
+package io.github.takahirom.arbigent
+
+/**
+ * Renders the human- and agent-readable summary that sits beside the event log.
+ *
+ * The log says exactly what was sent; this says what each step was trying to do and what was on
+ * screen when it did. A reader who has only `adb` can follow it by hand, and an agent given the
+ * file can tell whether the screen it is looking at is the one the step expected.
+ */
+internal fun renderReplayScriptMarkdown(
+  scenarioId: String,
+  baseName: String,
+  goals: List<String>,
+  tasks: List<ArbigentReplayScriptRecorder.RecordedTask>,
+  steps: List<ArbigentReplayScriptStep>,
+  signature: List<String>,
+): String = buildString {
+  appendLine("# $scenarioId")
+  appendLine()
+  appendLine("## Goal")
+  appendLine()
+  if (goals.size == 1) {
+    appendLine(goals.single())
+  } else {
+    goals.forEachIndexed { index, goal -> appendLine("${index + 1}. $goal") }
+  }
+  appendLine()
+  appendLine("## Steps")
+  appendLine()
+  var lastTaskIndex = -1
+  steps.forEach { step ->
+    if (goals.size > 1 && step.taskIndex != lastTaskIndex) {
+      lastTaskIndex = step.taskIndex
+      appendLine("### Task ${step.taskIndex + 1}: ${tasks.firstOrNull { it.taskIndex == step.taskIndex }?.goal.orEmpty()}")
+      appendLine()
+    }
+    if (step.isInit) {
+      appendLine("0. setup")
+    } else {
+      appendLine("${step.number}. ${step.actionLog ?: step.actionName ?: "step"}")
+    }
+    step.target?.let { appendLine("   - target: ${it.description()}") }
+    // Maestro sees attributes an adb-side dump may miss, so the coordinates are spelled out for a
+    // reader who has to tap by hand.
+    step.targetBounds?.let {
+      appendLine("   - center: (${it.centerX}, ${it.centerY}), bounds: [${it.left},${it.top}][${it.right},${it.bottom}]")
+    }
+    if (step.screen.isNotEmpty()) {
+      appendLine("   - screen: ${step.screen.joinToString(", ") { it.label() }}")
+    }
+    step.memo?.takeIf { it.isNotBlank() }?.let { appendLine("   - memo: ${it.replace("\n", " ")}") }
+    appendLine("   - device: ${summarizeEvents(step.events)}")
+    step.target?.let { target ->
+      val fallback = step.targetBounds?.let { " (or tap ${it.centerX},${it.centerY})" }.orEmpty()
+      appendLine("   - wait for: ${target.description()}$fallback")
+    }
+    // The exact command for this one step, so an agent driving the app a step at a time can copy it
+    // instead of working the number out from the option list.
+    if (!step.isInit) {
+      appendLine("   - replay: `./arbigentw replay $baseName.jsonl --step ${step.number}`")
+    }
+    appendLine()
+  }
+  if (signature.isNotEmpty()) {
+    appendLine("## Expected end state")
+    appendLine()
+    appendLine("expect: resource ids ${signature.joinToString(", ")}")
+    appendLine()
+  }
+  appendLine("## Replay")
+  appendLine()
+  appendLine("From a fresh device, setup included:")
+  appendLine()
+  appendLine("```")
+  appendLine("./arbigentw replay $baseName.jsonl --with-init")
+  appendLine("```")
+  appendLine()
+  appendLine("With the app already on the screen the recording started from:")
+  appendLine()
+  appendLine("```")
+  appendLine("./arbigentw replay $baseName.jsonl")
+  appendLine("```")
+  appendLine()
+  appendLine("Options:")
+  appendLine()
+  appendLine("- `--show` prints the steps without touching a device.")
+  appendLine("- `--step N` replays a single step, `--from N` / `--until N` a range.")
+  appendLine("- `--with-init` also replays the setup phase (app launch, state clear).")
+  appendLine("- `--no-wait` skips waiting for targets and screen hints.")
+  appendLine()
+  appendLine("`./arbigentw` downloads the matching arbigent on first use; `arbigent replay` is the")
+  appendLine("same command for an arbigent that is already installed.")
+}
+
+/** The identity without its occurrence, which means nothing for a screen-level hint. */
+private fun ArbigentElementIdentity.label(): String = listOfNotNull(
+  text?.let { "text='$it'" },
+  resourceId?.let { "resourceId='$it'" },
+  accessibilityId?.let { "accessibilityId='$it'" },
+).joinToString(", ")
+
+/** `KEYCODE_DPAD_DOWN x3, tap(120,340)`: consecutive identical events collapse into a count. */
+private fun summarizeEvents(events: List<ArbigentDeviceEvent>): String {
+  if (events.isEmpty()) return "none"
+  val parts = mutableListOf<Pair<String, Int>>()
+  events.forEach { event ->
+    val label = event.describe()
+    val last = parts.lastOrNull()
+    if (last != null && last.first == label) {
+      parts[parts.size - 1] = label to last.second + 1
+    } else {
+      parts += label to 1
+    }
+  }
+  return parts.joinToString(", ") { (label, count) -> if (count > 1) "$label x$count" else label }
+}
+
+private fun ArbigentDeviceEvent.describe(): String = when (this) {
+  is ArbigentDeviceEvent.Tap -> "tap($x,$y)"
+  is ArbigentDeviceEvent.TapElement -> buildString {
+    append("tap(")
+    val parts = listOfNotNull(
+      textRegex?.let { "text='$it'" },
+      idRegex?.let { "id='$it'" },
+      index.takeIf { it > 0 }?.let { "index=$it" },
+    )
+    append(parts.joinToString(", ").ifEmpty { "element" })
+    append(')')
+  }
+  is ArbigentDeviceEvent.KeyPress -> keyName
+  is ArbigentDeviceEvent.InputText -> "text(\"$text\")"
+  is ArbigentDeviceEvent.Swipe -> "swipe($startX,$startY -> $endX,$endY, ${durationMs}ms)"
+  is ArbigentDeviceEvent.LaunchApp -> buildString {
+    append("launch(").append(appId)
+    if (clearState) append(", clearState")
+    if (!stopApp) append(", keepRunning")
+    launchArguments.forEach { (key, value) -> append(", ").append(key).append('=').append(value.toString()) }
+    append(')')
+  }
+  is ArbigentDeviceEvent.StopApp -> "stop($appId)"
+  is ArbigentDeviceEvent.ClearState -> "clearState($appId)"
+  is ArbigentDeviceEvent.Wait -> "wait(${millis}ms)"
+  is ArbigentDeviceEvent.OpenLink -> "openLink($url)"
+  is ArbigentDeviceEvent.Unsupported -> "unsupported($command)"
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
@@ -120,8 +120,8 @@ private fun ArbigentDeviceEvent.describe(): String = when (this) {
   is ArbigentDeviceEvent.TapElement -> buildString {
     append("tap(")
     val parts = listOfNotNull(
-      textRegex?.let { "text='$it'" },
-      idRegex?.let { "id='$it'" },
+      textRegex?.let { "text='${it.escapedForOneLine()}'" },
+      idRegex?.let { "id='${it.escapedForOneLine()}'" },
       // Only a later match is worth naming: index 0 and no index both read as the first one.
       index?.takeIf { it > 0 }?.let { "index=$it" },
     )
@@ -129,7 +129,7 @@ private fun ArbigentDeviceEvent.describe(): String = when (this) {
     append(')')
   }
   is ArbigentDeviceEvent.KeyPress -> keyName
-  is ArbigentDeviceEvent.InputText -> "text(\"$text\")"
+  is ArbigentDeviceEvent.InputText -> "text(\"${text.escapedForOneLine().replace("\"", "\\\"")}\")"
   is ArbigentDeviceEvent.Swipe -> "swipe($startX,$startY -> $endX,$endY, ${durationMs}ms)"
   is ArbigentDeviceEvent.LaunchApp -> buildString {
     append("launch(").append(appId)
@@ -148,3 +148,12 @@ private fun ArbigentDeviceEvent.describe(): String = when (this) {
   is ArbigentDeviceEvent.OpenLink -> "openLink($url)"
   is ArbigentDeviceEvent.Unsupported -> "unsupported($command)"
 }
+
+/**
+ * The summary gives every event a line of its own, so a recorded value carrying its own newline
+ * would split that line and turn the rest of the event into prose. Backslashes go first, so an
+ * escape this writes cannot be mistaken for one that was already in the value.
+ */
+private fun String.escapedForOneLine(): String = replace("\\", "\\\\")
+  .replace("\r", "\\r")
+  .replace("\n", "\\n")

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
@@ -135,6 +135,10 @@ private fun ArbigentDeviceEvent.describe(): String = when (this) {
     append("launch(").append(appId)
     if (clearState) append(", clearState")
     if (!stopApp) append(", keepRunning")
+    if (clearKeychain == true) append(", clearKeychain")
+    // Only when the recording asked for something other than maestro's own default, which is what
+    // a launch that recorded no permissions replays with.
+    permissions?.forEach { (name, mode) -> append(", ").append(name).append('=').append(mode) }
     launchArguments.forEach { (key, value) -> append(", ").append(key).append('=').append(value.toString()) }
     append(')')
   }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
@@ -122,7 +122,8 @@ private fun ArbigentDeviceEvent.describe(): String = when (this) {
     val parts = listOfNotNull(
       textRegex?.let { "text='$it'" },
       idRegex?.let { "id='$it'" },
-      index.takeIf { it > 0 }?.let { "index=$it" },
+      // Only a later match is worth naming: index 0 and no index both read as the first one.
+      index?.takeIf { it > 0 }?.let { "index=$it" },
     )
     append(parts.joinToString(", ").ifEmpty { "element" })
     append(')')

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptMarkdown.kt
@@ -94,9 +94,9 @@ internal fun renderReplayScriptMarkdown(
 
 /** The identity without its occurrence, which means nothing for a screen-level hint. */
 private fun ArbigentElementIdentity.label(): String = listOfNotNull(
-  text?.let { "text='$it'" },
-  resourceId?.let { "resourceId='$it'" },
-  accessibilityId?.let { "accessibilityId='$it'" },
+  text?.let { "text='${it.escapedForSingleQuotedOneLine()}'" },
+  resourceId?.let { "resourceId='${it.escapedForSingleQuotedOneLine()}'" },
+  accessibilityId?.let { "accessibilityId='${it.escapedForSingleQuotedOneLine()}'" },
 ).joinToString(", ")
 
 /** `KEYCODE_DPAD_DOWN x3, tap(120,340)`: consecutive identical events collapse into a count. */
@@ -120,8 +120,8 @@ private fun ArbigentDeviceEvent.describe(): String = when (this) {
   is ArbigentDeviceEvent.TapElement -> buildString {
     append("tap(")
     val parts = listOfNotNull(
-      textRegex?.let { "text='${it.escapedForOneLine()}'" },
-      idRegex?.let { "id='${it.escapedForOneLine()}'" },
+      textRegex?.let { "text='${it.escapedForSingleQuotedOneLine()}'" },
+      idRegex?.let { "id='${it.escapedForSingleQuotedOneLine()}'" },
       // Only a later match is worth naming: index 0 and no index both read as the first one.
       index?.takeIf { it > 0 }?.let { "index=$it" },
     )
@@ -157,3 +157,9 @@ private fun ArbigentDeviceEvent.describe(): String = when (this) {
 private fun String.escapedForOneLine(): String = replace("\\", "\\\\")
   .replace("\r", "\\r")
   .replace("\n", "\\n")
+
+/**
+ * A value rendered inside `'…'` also has to keep its own quotes from closing the field. `\'` is a
+ * legal escape in a regex too, so a reader who copies the value out gets the same matching.
+ */
+private fun String.escapedForSingleQuotedOneLine(): String = escapedForOneLine().replace("'", "\\'")

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -64,16 +64,33 @@ internal class ArbigentReplayScriptWriter(
     outputDir.mkdirs()
     val baseName = fileBaseName(scenarioId)
     val logFile = File(outputDir, "$baseName.jsonl")
-    // The summary lands before the log so a log that exists is always already described.
-    writeAtomically(
-      File(outputDir, "$baseName.md"),
+    val markdownFile = File(outputDir, "$baseName.md")
+    // Both files are staged before either is published, so a failure part way through leaves the
+    // previous pair in place instead of a summary standing beside a log from a different run.
+    val stagedMarkdown = stage(
+      markdownFile,
       renderReplayScriptMarkdown(scenarioId, baseName, goals, tasks, steps, signature),
     )
-    writeAtomically(
-      logFile,
-      jsonLines(scenarioId, goals, tasks, steps, signature, platform, screenWidth, screenHeight)
-        .joinToString(separator = "\n", postfix = "\n"),
-    )
+    val stagedLog = try {
+      stage(
+        logFile,
+        jsonLines(scenarioId, goals, tasks, steps, signature, platform, screenWidth, screenHeight)
+          .joinToString(separator = "\n", postfix = "\n"),
+      )
+    } catch (failure: Throwable) {
+      stagedMarkdown.delete()
+      throw failure
+    }
+    try {
+      // The log is published first because it is the artifact a replay actually runs: if the second
+      // rename fails, an old summary beside the new log is less misleading than a new summary
+      // beside a log from another run.
+      publish(stagedLog, logFile)
+      publish(stagedMarkdown, markdownFile)
+    } finally {
+      stagedMarkdown.delete()
+      stagedLog.delete()
+    }
     arbigentInfoLog("Wrote replay script for scenario $scenarioId to ${logFile.absolutePath}")
   }
 
@@ -230,37 +247,48 @@ internal class ArbigentReplayScriptWriter(
      * runner started on the previous script) never sees a half-written file and two writers (two
      * arbigent processes sharing an output dir) never stage into the same temp file.
      */
-    fun writeAtomically(target: File, text: String, executable: Boolean = false) {
+    fun writeAtomically(target: File, text: String) {
+      val temp = stage(target, text)
+      try {
+        publish(temp, target)
+      } finally {
+        temp.delete()
+      }
+    }
+
+    /** Writes [text] into a uniquely named temp file beside [target], ready to be renamed over it. */
+    private fun stage(target: File, text: String): File {
       val temp = File(target.parentFile, "${target.name}.${ProcessHandle.current().pid()}.${System.nanoTime()}.tmp")
       try {
         temp.writeText(text)
-        // A runner nobody can execute is worse than no runner: fail before it replaces the old one.
-        if (executable && !temp.setExecutable(true, false)) {
-          throw java.io.IOException("Could not make ${temp.name} executable")
-        }
+      } catch (failure: Throwable) {
+        // A failed write must not leave staging files next to the logs CI uploads.
+        temp.delete()
+        throw failure
+      }
+      return temp
+    }
+
+    private fun publish(temp: File, target: File) {
+      try {
+        java.nio.file.Files.move(
+          temp.toPath(), target.toPath(),
+          java.nio.file.StandardCopyOption.REPLACE_EXISTING,
+          java.nio.file.StandardCopyOption.ATOMIC_MOVE,
+        )
+      } catch (atomicFailure: java.io.IOException) {
+        // Filesystems that cannot rename atomically, or cannot replace an existing file that way,
+        // still get the finished content in one step; only the replacement is no longer atomic.
         try {
           java.nio.file.Files.move(
             temp.toPath(), target.toPath(),
             java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-            java.nio.file.StandardCopyOption.ATOMIC_MOVE,
           )
-        } catch (atomicFailure: java.io.IOException) {
-          // Filesystems that cannot rename atomically, or cannot replace an existing file that way,
-          // still get the finished content in one step; only the replacement is no longer atomic.
-          try {
-            java.nio.file.Files.move(
-              temp.toPath(), target.toPath(),
-              java.nio.file.StandardCopyOption.REPLACE_EXISTING,
-            )
-          } catch (fallbackFailure: java.io.IOException) {
-            // Why the atomic move failed is what explains the fallback's failure, so keep both.
-            fallbackFailure.addSuppressed(atomicFailure)
-            throw fallbackFailure
-          }
+        } catch (fallbackFailure: java.io.IOException) {
+          // Why the atomic move failed is what explains the fallback's failure, so keep both.
+          fallbackFailure.addSuppressed(atomicFailure)
+          throw fallbackFailure
         }
-      } finally {
-        // A failed write or move must not leave staging files next to the logs CI uploads.
-        temp.delete()
       }
     }
   }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayScriptWriter.kt
@@ -17,8 +17,8 @@ internal const val ReplayLogSchemaVersion: Int = 1
 /**
  * One recorded step of a scenario, after task-local recordings have been flattened and numbered.
  *
- * Every artifact written for a run is rendered from this shape, so they cannot disagree about which
- * step is which.
+ * The event log and the markdown summary are two views of the same run, so both are written from
+ * this shape and cannot disagree about which step is which.
  */
 internal data class ArbigentReplayScriptStep(
   val taskIndex: Int,
@@ -37,7 +37,8 @@ internal data class ArbigentReplayScriptStep(
 )
 
 /**
- * Writes the replay event log for one successful scenario.
+ * Writes the replay artifacts for one successful scenario: the event log and the readable summary
+ * beside it.
  *
  * Only successful runs are written. A failed scenario leaves whatever was written before untouched,
  * because a half-finished log replays to a screen the scenario never reached, which is worse than
@@ -63,6 +64,11 @@ internal class ArbigentReplayScriptWriter(
     outputDir.mkdirs()
     val baseName = fileBaseName(scenarioId)
     val logFile = File(outputDir, "$baseName.jsonl")
+    // The summary lands before the log so a log that exists is always already described.
+    writeAtomically(
+      File(outputDir, "$baseName.md"),
+      renderReplayScriptMarkdown(scenarioId, baseName, goals, tasks, steps, signature),
+    )
     writeAtomically(
       logFile,
       jsonLines(scenarioId, goals, tasks, steps, signature, platform, screenWidth, screenHeight)

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -467,12 +467,13 @@ class ArbigentReplayScriptWriterTest {
 
     val markdown = File(dir, "open-settings.md").readText()
     // Every field the app or the AI supplies text to, since a raw newline in any of them ends the
-    // bullet and leaves the rest of the value as prose under the step.
+    // bullet and leaves the rest of the value as prose under the step. Prose folds into a space; a
+    // selector value is escaped, because a reader copies that one back out.
     listOf(
-      """1. Tapped O'Reilly\nBooks""",
+      """1. Tapped O'Reilly Books""",
       """   - target: text='O\'Reilly\nBooks' (occurrence 0)""",
       """   - screen: text='O\'Reilly\nBooks'""",
-      """   - memo: noted\nsomething""",
+      """   - memo: noted something""",
       """   - wait for: text='O\'Reilly\nBooks' (occurrence 0)""",
     ).forEach { line ->
       assertTrue(markdown.lines().contains(line), "expected the line `$line` in:\n$markdown")

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -221,6 +221,9 @@ class ArbigentReplayScriptWriterTest {
     assertTrue(log.contains("\"bounds\":\"[0,0][100,100]\""), log)
     assertTrue(log.contains("\"center\":{\"x\":50,\"y\":50}"), log)
     assertTrue(log.contains("\"screen\":[{\"text\":\"text\""), log)
+
+    val markdown = File(dir, "open-settings.md").readText()
+    assertTrue(markdown.contains("center: (50, 50)"), markdown)
   }
 
   @Test
@@ -260,7 +263,7 @@ class ArbigentReplayScriptWriterTest {
   }
 
   @Test
-  fun `writes the log with a file-safe name`() {
+  fun `writes the log and the summary, with a file-safe name`() {
     val dir = Files.createTempDirectory("replay-scripts").toFile()
     ArbigentReplayScriptWriter(dir).write(
       scenarioId = "open settings/main",
@@ -280,6 +283,7 @@ class ArbigentReplayScriptWriterTest {
       ArbigentReplayScriptWriter.fileBaseName("a/b") != ArbigentReplayScriptWriter.fileBaseName("a b"),
     )
     assertTrue(dir.listFiles().orEmpty().none { it.name.endsWith(".tmp") }, "temp file left behind")
+    assertTrue(File(dir, log.name.removeSuffix(".jsonl") + ".md").isFile)
 
     val lines = log.readLines().filter { it.isNotBlank() }
     assertEquals("scenario_start", lineType(lines.first()))
@@ -321,6 +325,45 @@ class ArbigentReplayScriptWriterTest {
       platform = ArbigentDeviceOs.Android,
     )
     assertEquals(emptyList(), dir.listFiles()?.toList().orEmpty())
+  }
+
+  @Test
+  fun `the markdown names the steps, the target and the way to replay them`() {
+    val dir = Files.createTempDirectory("replay-scripts").toFile()
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open-settings",
+      goals = listOf("Open the settings screen"),
+      tasks = recordedRun(),
+      signature = listOf("com.example.app:id/settings_title"),
+      platform = ArbigentDeviceOs.Android,
+    )
+    val markdown = File(dir, "open-settings.md").readText()
+    assertTrue(markdown.startsWith("# open-settings"))
+    assertTrue(markdown.contains("launch(com.example.app, clearState)"))
+    assertTrue(markdown.contains("./arbigentw replay open-settings.jsonl --with-init"))
+    assertTrue(!markdown.contains("--step 0"), "setup is not a numbered step and has no single-step command")
+    assertTrue(
+      markdown.indexOf("--with-init") < markdown.indexOf("./arbigentw replay open-settings.jsonl\n"),
+      "the command that replays the setup too comes first, since that is the one a fresh device needs",
+    )
+    assertTrue(markdown.contains("com.example.app:id/settings_title"))
+  }
+
+  @Test
+  fun `each numbered step in the markdown carries its own single-step replay command`() = runTest {
+    val dir = Files.createTempDirectory("replay-scripts-step-command").toFile()
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open-settings",
+      goals = listOf("Open the settings screen"),
+      tasks = recordedRunWithTarget(),
+      signature = emptyList(),
+      platform = ArbigentDeviceOs.Android,
+    )
+    val markdown = File(dir, "open-settings.md").readText()
+    assertTrue(
+      markdown.contains("- replay: `./arbigentw replay open-settings.jsonl --step 1`"),
+      "an agent driving one step at a time copies this instead of working the number out:\n$markdown",
+    )
   }
 
   private fun lineType(line: String): String =
@@ -376,6 +419,7 @@ class ArbigentReplayScriptExecutorTest {
     advanceUntilIdle()
 
     assertTrue(File(dir, "settings-scenario.jsonl").isFile)
+    assertTrue(File(dir, "settings-scenario.md").isFile)
   }
 
   @OptIn(ExperimentalStdlibApi::class)

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -200,6 +200,18 @@ class ArbigentReplayScriptWriterTest {
         ArbigentAgent.ExecuteActionsOutput()
       },
     )
+    // A second numbered step: with only one, a renderer that names every step "1", or that stops
+    // after the first, would still pass.
+    recorder.intercept(
+      executeActionsInput(
+        ArbigentContextHolder("Open the settings screen", 10),
+        ArbigentElementIdentity(text = "text", occurrence = 2),
+      ),
+      ArbigentExecuteActionsInterceptor.Chain {
+        recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_BACK", timestamp = 3))
+        ArbigentAgent.ExecuteActionsOutput()
+      },
+    )
     return recorder.recordedTasks()
   }
 
@@ -387,10 +399,16 @@ class ArbigentReplayScriptWriterTest {
       platform = ArbigentDeviceOs.Android,
     )
     val markdown = File(dir, "open-settings.md").readText()
-    assertTrue(
-      markdown.contains("- replay: `./arbigentw replay open-settings.jsonl --step 1`"),
-      "an agent driving one step at a time copies this instead of working the number out:\n$markdown",
-    )
+    listOf(
+      "device: KEYCODE_DPAD_CENTER" to 1,
+      "device: KEYCODE_BACK" to 2,
+    ).forEach { (command, step) ->
+      assertTrue(markdown.contains(command), "step $step is missing from the summary:\n$markdown")
+      assertTrue(
+        markdown.contains("- replay: `./arbigentw replay open-settings.jsonl --step $step`"),
+        "an agent driving one step at a time copies this instead of working the number out:\n$markdown",
+      )
+    }
   }
 
   private fun lineType(line: String): String =

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -315,6 +315,33 @@ class ArbigentReplayScriptWriterTest {
   }
 
   @Test
+  fun `a log that cannot be published leaves the previous pair of artifacts alone`() {
+    val dir = Files.createTempDirectory("replay-scripts-partial").toFile()
+    val markdown = File(dir, "open-settings.md").apply { writeText("previous summary") }
+    // A non-empty directory in the log's place makes both the atomic and the plain move fail.
+    File(dir, "open-settings.jsonl").apply { mkdirs() }.let { File(it, "inner.txt").writeText("occupied") }
+
+    val failed = runCatching {
+      ArbigentReplayScriptWriter(dir).write(
+        scenarioId = "open-settings",
+        goals = listOf("Open the settings screen"),
+        tasks = recordedRun(),
+        signature = emptyList(),
+        platform = ArbigentDeviceOs.Android,
+      )
+    }
+
+    assertTrue(failed.isFailure, "replacing a directory should not succeed")
+    // The summary must not advertise a run whose log was never written, and no staging file may
+    // be left beside the artifacts CI uploads.
+    assertEquals("previous summary", markdown.readText())
+    assertEquals(
+      listOf("open-settings.jsonl", "open-settings.md"),
+      dir.list().orEmpty().sorted(),
+    )
+  }
+
+  @Test
   fun `a run that sent nothing writes no files`() {
     val dir = Files.createTempDirectory("replay-scripts").toFile()
     ArbigentReplayScriptWriter(dir).write(

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -418,6 +418,28 @@ class ArbigentReplayScriptWriterTest {
   }
 
   @Test
+  fun `a quoted selector value keeps the field it is written in`() {
+    val dir = Files.createTempDirectory("replay-scripts-quotes").toFile()
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open the settings screen", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.TapElement(textRegex = "O'Reilly\nBooks", timestamp = 1))
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open-settings",
+      goals = listOf("Open the settings screen"),
+      tasks = recorder.recordedTasks(),
+      signature = emptyList(),
+      platform = ArbigentDeviceOs.Android,
+    )
+
+    val markdown = File(dir, "open-settings.md").readText()
+    assertTrue(
+      markdown.contains("""tap(text='O\'Reilly\nBooks')"""),
+      "a quote of its own would end the field early and leave the rest of the value as prose: " +
+        markdown,
+    )
+  }
+
+  @Test
   fun `each numbered step in the markdown carries its own single-step replay command`() = runTest {
     val dir = Files.createTempDirectory("replay-scripts-step-command").toFile()
     ArbigentReplayScriptWriter(dir).write(

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -389,6 +389,35 @@ class ArbigentReplayScriptWriterTest {
   }
 
   @Test
+  fun `the markdown names the permissions and keychain reset a launch asked for`() {
+    val dir = Files.createTempDirectory("replay-scripts-permissions").toFile()
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open the settings screen", discardPrevious = true)
+    recorder.onDeviceEvent(
+      ArbigentDeviceEvent.LaunchApp(
+        "com.example.app",
+        permissions = mapOf("all" to "deny"),
+        clearKeychain = true,
+        timestamp = 1,
+      ),
+    )
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open-settings",
+      goals = listOf("Open the settings screen"),
+      tasks = recorder.recordedTasks(),
+      signature = emptyList(),
+      platform = ArbigentDeviceOs.Android,
+    )
+
+    val markdown = File(dir, "open-settings.md").readText()
+    assertTrue(
+      markdown.contains("launch(com.example.app, clearKeychain, all=deny)"),
+      "a launch that denies a permission starts the app in a different state, so the summary has " +
+        "to say so: $markdown",
+    )
+  }
+
+  @Test
   fun `each numbered step in the markdown carries its own single-step replay command`() = runTest {
     val dir = Files.createTempDirectory("replay-scripts-step-command").toFile()
     ArbigentReplayScriptWriter(dir).write(

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -481,6 +481,76 @@ class ArbigentReplayScriptWriterTest {
   }
 
   @Test
+  fun `a single goal carrying a newline stays on its own line`() {
+    val dir = Files.createTempDirectory("replay-scripts-single-goal").toFile()
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open-settings",
+      goals = listOf("Open the settings screen\nand read the version"),
+      tasks = listOf(
+        ArbigentReplayScriptRecorder.RecordedTask(
+          taskIndex = 0,
+          goal = "Open the settings screen",
+          steps = mutableListOf(
+            ArbigentReplayScriptRecorder.RecordedStep(
+              isInit = false,
+              actionLog = "Tapped settings",
+              events = mutableListOf(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_CENTER", timestamp = 1)),
+            ),
+          ),
+        ),
+      ),
+      signature = emptyList(),
+      platform = ArbigentDeviceOs.Android,
+    )
+
+    val markdown = File(dir, "open-settings.md").readText()
+    // The lone goal is rendered without a number, which is no reason to leave its newline in: the
+    // second half would read as a paragraph of the document rather than as part of the goal.
+    assertTrue(
+      markdown.lines().contains("Open the settings screen and read the version"),
+      "expected the folded goal in:\n$markdown",
+    )
+  }
+
+  @Test
+  fun `a selector regex keeps the backslashes it was recorded with`() {
+    val dir = Files.createTempDirectory("replay-scripts-regex").toFile()
+    val identity = ArbigentElementIdentity(text = """Episode \d+""", occurrence = 0)
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open-settings",
+      goals = listOf("Open the settings screen"),
+      tasks = listOf(
+        ArbigentReplayScriptRecorder.RecordedTask(
+          taskIndex = 0,
+          goal = "Open the settings screen",
+          steps = mutableListOf(
+            ArbigentReplayScriptRecorder.RecordedStep(
+              isInit = false,
+              actionLog = "Tapped an episode",
+              target = identity,
+              events = mutableListOf(
+                ArbigentDeviceEvent.TapElement(textRegex = """Episode \d+""", timestamp = 1),
+              ),
+            ),
+          ),
+        ),
+      ),
+      signature = emptyList(),
+      platform = ArbigentDeviceOs.Android,
+    )
+
+    val markdown = File(dir, "open-settings.md").readText()
+    // A selector is often a regex, and a doubled backslash stops matching digits the moment the
+    // value is copied back out of the document.
+    listOf(
+      """   - target: text='Episode \d+' (occurrence 0)""",
+      """   - device: tap(text='Episode \d+')""",
+    ).forEach { line ->
+      assertTrue(markdown.lines().contains(line), "expected the line `$line` in:\n$markdown")
+    }
+  }
+
+  @Test
   fun `each numbered step in the markdown carries its own single-step replay command`() = runTest {
     val dir = Files.createTempDirectory("replay-scripts-step-command").toFile()
     ArbigentReplayScriptWriter(dir).write(

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -428,16 +428,53 @@ class ArbigentReplayScriptWriterTest {
       platform = ArbigentDeviceOs.Android,
     )
     val markdown = File(dir, "open-settings.md").readText()
+    // Each step's own block, so a command printed under the wrong step is caught: searching the
+    // whole document would pass just as happily with the two numbers swapped.
+    val blocks = markdown.split("\n\n").associateBy { it.trimStart().substringBefore(". ") }
     listOf(
       "device: KEYCODE_DPAD_CENTER" to 1,
       "device: KEYCODE_BACK" to 2,
     ).forEach { (command, step) ->
-      assertTrue(markdown.contains(command), "step $step is missing from the summary:\n$markdown")
+      val block = blocks["$step"]
+      assertTrue(block != null, "step $step is missing from the summary:\n$markdown")
+      assertTrue(block!!.contains(command), "step $step acted on something else:\n$block")
       assertTrue(
-        markdown.contains("- replay: `./arbigentw replay open-settings.jsonl --step $step`"),
-        "an agent driving one step at a time copies this instead of working the number out:\n$markdown",
+        block.contains("- replay: `./arbigentw replay open-settings.jsonl --step $step`"),
+        "an agent driving one step at a time copies this instead of working the number out:\n$block",
       )
     }
+  }
+
+  @Test
+  fun `typed text with its own newline stays on the event's line`() = runTest {
+    val dir = Files.createTempDirectory("replay-scripts-typed-text").toFile()
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Write a note", discardPrevious = true)
+    recorder.intercept(
+      executeActionsInput(
+        ArbigentContextHolder("Write a note", 10),
+        ArbigentElementIdentity(text = "note", occurrence = 1),
+      ),
+      ArbigentExecuteActionsInterceptor.Chain {
+        recorder.onDeviceEvent(ArbigentDeviceEvent.InputText("first\nsecond \"quoted\"", timestamp = 2))
+        ArbigentAgent.ExecuteActionsOutput()
+      },
+    )
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "write-note",
+      goals = listOf("Write a note"),
+      tasks = recorder.recordedTasks(),
+      signature = emptyList(),
+      platform = ArbigentDeviceOs.Android,
+    )
+
+    val markdown = File(dir, "write-note.md").readText()
+    // The summary is read a line at a time, so a newline the app was told to type must not end the
+    // event's line and leave the rest of the typed text standing as prose.
+    assertTrue(
+      markdown.lines().any { it.contains("""device: text("first\nsecond \"quoted\"")""") },
+      "typed text has to survive as one line:\n$markdown",
+    )
   }
 
   private fun lineType(line: String): String =

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -440,6 +440,46 @@ class ArbigentReplayScriptWriterTest {
   }
 
   @Test
+  fun `a value carrying a newline stays inside the field it is written in`() {
+    val dir = Files.createTempDirectory("replay-scripts-one-line").toFile()
+    val identity = ArbigentElementIdentity(text = "O'Reilly\nBooks", occurrence = 0)
+    val task = ArbigentReplayScriptRecorder.RecordedTask(
+      taskIndex = 0,
+      goal = "Open the settings screen",
+      steps = mutableListOf(
+        ArbigentReplayScriptRecorder.RecordedStep(
+          isInit = false,
+          actionLog = "Tapped O'Reilly\nBooks",
+          memo = "noted\nsomething",
+          target = identity,
+          screen = listOf(identity),
+          events = mutableListOf(ArbigentDeviceEvent.KeyPress("KEYCODE_DPAD_CENTER", timestamp = 1)),
+        ),
+      ),
+    )
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open-settings",
+      goals = listOf("Open the settings screen"),
+      tasks = listOf(task),
+      signature = emptyList(),
+      platform = ArbigentDeviceOs.Android,
+    )
+
+    val markdown = File(dir, "open-settings.md").readText()
+    // Every field the app or the AI supplies text to, since a raw newline in any of them ends the
+    // bullet and leaves the rest of the value as prose under the step.
+    listOf(
+      """1. Tapped O'Reilly\nBooks""",
+      """   - target: text='O\'Reilly\nBooks' (occurrence 0)""",
+      """   - screen: text='O\'Reilly\nBooks'""",
+      """   - memo: noted\nsomething""",
+      """   - wait for: text='O\'Reilly\nBooks' (occurrence 0)""",
+    ).forEach { line ->
+      assertTrue(markdown.lines().contains(line), "expected the line `$line` in:\n$markdown")
+    }
+  }
+
+  @Test
   fun `each numbered step in the markdown carries its own single-step replay command`() = runTest {
     val dir = Files.createTempDirectory("replay-scripts-step-command").toFile()
     ArbigentReplayScriptWriter(dir).write(


### PR DESCRIPTION
Writes a readable `<id>.md` beside each `<id>.jsonl` replay log.

The log says exactly what was sent; the summary says what each step was trying to do and what was on screen when it did it. A person who has only `adb` can follow it by hand, and an agent handed the file can tell whether the screen in front of it is the one a step expected, without reading the jsonl.

Each numbered step carries the single-step command that replays it:

```
- replay: `./arbigentw replay open-settings.jsonl --step 3`
```

and the Replay section leads with the setup-inclusive command, since that is the one a fresh device needs:

```
./arbigentw replay open-settings.jsonl --with-init
```

Both files are written atomically. The log is published first, so an interrupted write leaves a replayable log without its summary rather than a summary that describes a log nobody can replay.

Rebased onto #432: the commands in the summary now name `arbigentw replay` (#431 adds the wrapper, #432 the subcommand) instead of the generated `replay.sh`, whose PR is closed.



The summary names the `permissions` and `clearKeychain` a launch asked for, since a launch that denies a permission starts the app in a different state.
