### PR TITLE
Add an arbigent replay subcommand for recorded logs

### DIFF
--- a/arbigent-cli/src/main/kotlin/ReplayCommand.kt
+++ b/arbigent-cli/src/main/kotlin/ReplayCommand.kt
@@ -1,0 +1,127 @@
+@file:OptIn(ArbigentInternalApi::class)
+
+package io.github.takahirom.arbigent.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.CliktError
+import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.parameters.arguments.argument
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.types.int
+import io.github.takahirom.arbigent.ArbigentInternalApi
+import io.github.takahirom.arbigent.ArbigentReplayLog
+import io.github.takahirom.arbigent.ArbigentReplayLogException
+import io.github.takahirom.arbigent.ArbigentReplayRunner
+import kotlinx.coroutines.runBlocking
+import java.io.File
+
+/**
+ * Replays a recorded scenario log against a device without asking an AI anything.
+ *
+ * This is how a person or another tool gets to a screen a scenario already reached: the log holds
+ * the device events of a successful run, so replaying them is both cheaper and more repeatable than
+ * asking the agent to find its way there again. No API key is needed, because no model is called.
+ *
+ * The exit code says what happened, so a caller can branch on it: 0 replayed and arrived, 1 the log
+ * or the range cannot be replayed at all, 2 the screen was not the one the recording acted on, 3 the
+ * device could not be driven.
+ */
+class ArbigentReplayCommand : CliktCommand(name = "replay") {
+  override fun help(context: com.github.ajalt.clikt.core.Context): String =
+    "Replay a recorded scenario log on a device, without using AI"
+
+  private val logPath by argument(
+    name = "log",
+    help = "Path to the .jsonl replay log written for a successful scenario",
+  )
+
+  private val step by defaultOption(
+    "--step",
+    help = "Replay only this step number",
+  ).int()
+
+  private val from by defaultOption(
+    "--from",
+    help = "Start at this step number",
+  ).int()
+
+  private val until by defaultOption(
+    "--until",
+    help = "Stop after this step number",
+  ).int()
+
+  private val withInit by defaultOption(
+    "--with-init",
+    help = "Also replay the setup blocks (app launch, state reset) that prepared the chosen steps",
+  ).flag()
+
+  private val noWait by defaultOption(
+    "--no-wait",
+    help = "Do not wait for each step's target or screen hints, just send the events",
+  ).flag()
+
+  private val show by defaultOption(
+    "--show",
+    help = "Print what would be replayed and exit, without connecting to a device",
+  ).flag()
+
+  internal val iosAppleTeamId by defaultOption(
+    "--ios-xctest-apple-team-id",
+    help = "Apple developer team id used to sign the XCTest runner for a physical iPhone.",
+  )
+
+  internal val iosRealDeviceId by defaultOption(
+    "--ios-real-device-id",
+    help = "Hardware UDID selecting a specific physical iPhone.",
+  )
+
+  internal val iosRealDevicePort by defaultOption(
+    "--ios-real-device-port",
+    help = "Local port used to reach the XCTest runner on a physical iPhone.",
+  )
+
+  override fun run() {
+    val log = try {
+      ArbigentReplayLog.read(File(logPath))
+    } catch (exception: ArbigentReplayLogException) {
+      throw CliktError(exception.message ?: "the replay log cannot be read")
+    }
+    val selected = try {
+      log.select(step = step, from = from, until = until, withInit = withInit)
+    } catch (exception: ArbigentReplayLogException) {
+      throw CliktError(exception.message ?: "the given range cannot be replayed")
+    }
+    if (show) {
+      // Built up and echoed rather than streamed, so the listing goes through Clikt's own output.
+      val listing = StringBuilder()
+      ArbigentReplayRunner.show(log, selected, listing)
+      echo(listing.toString().trimEnd())
+      return
+    }
+    // Neither an empty range nor an unreproducible command needs a device to be refused, so they
+    // are checked before a driver is started.
+    ArbigentReplayRunner.verifySelection(selected)?.let { reason -> throw CliktError(reason) }
+    // The log says which kind of device it was recorded on, and a log only replays on that kind, so
+    // the platform is read from the log rather than asked for again.
+    val device = connectDevice(
+      os = log.platform.name.lowercase(),
+      iosAppleTeamId = iosAppleTeamId,
+      iosRealDeviceId = iosRealDeviceId,
+      iosRealDevicePort = parseIosRealDevicePort(iosRealDevicePort),
+    )
+    try {
+      val runner = ArbigentReplayRunner(
+        log = log,
+        device = device,
+        out = System.out,
+        err = System.err,
+        waitForScreens = !noWait,
+      )
+      runner.verifyReplayable(selected)?.let { reason -> throw CliktError(reason) }
+      val exitCode = runBlocking { runner.run(selected) }
+      if (exitCode != ArbigentReplayRunner.EXIT_OK) throw ProgramResult(exitCode)
+    } finally {
+      device.close()
+    }
+  }
+}

--- a/arbigent-cli/src/main/kotlin/ReplayCommand.kt
+++ b/arbigent-cli/src/main/kotlin/ReplayCommand.kt
@@ -14,6 +14,7 @@ import io.github.takahirom.arbigent.ArbigentReplayLogException
 import io.github.takahirom.arbigent.ArbigentReplayRunner
 import kotlinx.coroutines.runBlocking
 import java.io.File
+import kotlin.system.exitProcess
 
 /**
  * Replays a recorded scenario log against a device without asking an AI anything.
@@ -117,7 +118,7 @@ class ArbigentReplayCommand : CliktCommand(name = "replay") {
       System.err.println("could not connect to a ${log.platform.name.lowercase()} device: $exception")
       throw ProgramResult(ArbigentReplayRunner.EXIT_DEVICE)
     }
-    try {
+    val exitCode = try {
       val runner = ArbigentReplayRunner(
         log = log,
         device = device,
@@ -126,10 +127,16 @@ class ArbigentReplayCommand : CliktCommand(name = "replay") {
         waitForScreens = !noWait,
       )
       runner.verifyReplayable(selected)?.let { reason -> throw CliktError(reason) }
-      val exitCode = runBlocking { runner.run(selected) }
-      if (exitCode != ArbigentReplayRunner.EXIT_OK) throw ProgramResult(exitCode)
+      runBlocking { runner.run(selected) }
     } finally {
       device.close()
     }
+    // The drivers Maestro starts leave non-daemon threads behind that closing the device does not
+    // join - a scheduled executor from the iOS XCTest client is the one that shows up - so the JVM
+    // never reaches the end on its own once the work is done. The failing exit codes go out through
+    // ProgramResult, which the CLI framework turns into its own exit, but a successful replay would
+    // hang here and never hand its exit code back to the caller, which is the whole contract of the
+    // command. RunCommand exits explicitly for the same reason.
+    exitProcess(exitCode)
   }
 }

--- a/arbigent-cli/src/main/kotlin/ReplayCommand.kt
+++ b/arbigent-cli/src/main/kotlin/ReplayCommand.kt
@@ -103,12 +103,20 @@ class ArbigentReplayCommand : CliktCommand(name = "replay") {
     ArbigentReplayRunner.verifySelection(selected)?.let { reason -> throw CliktError(reason) }
     // The log says which kind of device it was recorded on, and a log only replays on that kind, so
     // the platform is read from the log rather than asked for again.
-    val device = connectDevice(
-      os = log.platform.name.lowercase(),
-      iosAppleTeamId = iosAppleTeamId,
-      iosRealDeviceId = iosRealDeviceId,
-      iosRealDevicePort = parseIosRealDevicePort(iosRealDevicePort),
-    )
+    val resolvedIosRealDevicePort = parseIosRealDevicePort(iosRealDevicePort)
+    val device = try {
+      connectDevice(
+        os = log.platform.name.lowercase(),
+        iosAppleTeamId = iosAppleTeamId,
+        iosRealDeviceId = iosRealDeviceId,
+        iosRealDevicePort = resolvedIosRealDevicePort,
+      )
+    } catch (exception: Exception) {
+      // No device to drive is a device failure, not a broken log: the caller can retry the same
+      // command once a device is attached.
+      System.err.println("could not connect to a ${log.platform.name.lowercase()} device: $exception")
+      throw ProgramResult(ArbigentReplayRunner.EXIT_DEVICE)
+    }
     try {
       val runner = ArbigentReplayRunner(
         log = log,

--- a/arbigent-cli/src/main/kotlin/ReplayCommand.kt
+++ b/arbigent-cli/src/main/kotlin/ReplayCommand.kt
@@ -132,11 +132,12 @@ class ArbigentReplayCommand : CliktCommand(name = "replay") {
       device.close()
     }
     // The drivers Maestro starts leave non-daemon threads behind that closing the device does not
-    // join - a scheduled executor from the iOS XCTest client is the one that shows up - so the JVM
-    // never reaches the end on its own once the work is done. The failing exit codes go out through
-    // ProgramResult, which the CLI framework turns into its own exit, but a successful replay would
-    // hang here and never hand its exit code back to the caller, which is the whole contract of the
-    // command. RunCommand exits explicitly for the same reason.
+    // join - on iOS the scheduled executor its local device opens for the view-hierarchy timeout
+    // warning outlives close() - so the JVM never reaches the end on its own once the work is done.
+    // The failing exit codes go out through ProgramResult, which the CLI framework turns into its
+    // own exit, but a successful replay would hang here and never hand its exit code back to the
+    // caller, which is the whole contract of the command. RunCommand exits explicitly for the same
+    // reason.
     exitProcess(exitCode)
   }
 }

--- a/arbigent-cli/src/main/kotlin/main.kt
+++ b/arbigent-cli/src/main/kotlin/main.kt
@@ -78,6 +78,7 @@ fun arbigentCli(): ArbigentCli = ArbigentCli()
     ArbigentTagsCommand(),
     ArbigentGraphCommand(),
     ArbigentInstructionCommand(),
+    ArbigentReplayCommand(),
     ArbigentGuideCommand(),
     ArbigentWrapperCommand(),
   )

--- a/arbigent-cli/src/test/kotlin/ReplayCommandTest.kt
+++ b/arbigent-cli/src/test/kotlin/ReplayCommandTest.kt
@@ -80,6 +80,19 @@ class ReplayCommandTest {
     assertContains(result.output, "is not a file")
   }
 
+  @Test
+  fun `a log that cannot be read is rejected the same way as an unparsable one`() {
+    val file = logFile()
+    file.setReadable(false, false)
+    // A user that reads anything anyway (root in some containers) leaves nothing to test here.
+    if (file.canRead()) return
+
+    val result = arbigentCli().test("replay ${file.path} --show")
+
+    assertEquals(1, result.statusCode, result.output)
+    assertContains(result.output, "cannot be read")
+  }
+
   private fun logFile(): File {
     val file = File.createTempFile("replay", ".jsonl")
     file.deleteOnExit()

--- a/arbigent-cli/src/test/kotlin/ReplayCommandTest.kt
+++ b/arbigent-cli/src/test/kotlin/ReplayCommandTest.kt
@@ -52,6 +52,15 @@ class ReplayCommandTest {
   }
 
   @Test
+  fun `a range that selects only setup is rejected`() {
+    // Otherwise --with-init would launch the app, report success and never reach step 99.
+    val result = arbigentCli().test("replay ${logFile().path} --show --step 99 --with-init")
+
+    assertEquals(1, result.statusCode, result.output)
+    assertContains(result.output, "--step 99 selects no step")
+  }
+
+  @Test
   fun `a log that is not one finished run is rejected`() {
     val file = File.createTempFile("replay-truncated", ".jsonl")
     file.deleteOnExit()

--- a/arbigent-cli/src/test/kotlin/ReplayCommandTest.kt
+++ b/arbigent-cli/src/test/kotlin/ReplayCommandTest.kt
@@ -1,0 +1,92 @@
+package io.github.takahirom.arbigent.cli
+
+import com.github.ajalt.clikt.testing.test
+import java.io.File
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+
+/**
+ * The replay subcommand reads its range from the command line, so these tests drive it through
+ * `--show`, which is the whole command minus the device: the log is read, the range is applied, and
+ * what would be sent is printed.
+ */
+class ReplayCommandTest {
+  @Test
+  fun `showing a log prints every step and what it would send`() {
+    val result = arbigentCli().test("replay ${logFile().path} --show --with-init")
+
+    assertEquals(0, result.statusCode, result.output)
+    assertContains(result.output, "launch app.id")
+    assertContains(result.output, "step 1: tap sign in")
+    assertContains(result.output, "tap on text='Sign in'")
+    assertContains(result.output, "step 2: press back")
+    assertContains(result.output, "expect: resource ids home")
+  }
+
+  @Test
+  fun `a single step shows only that step`() {
+    val result = arbigentCli().test("replay ${logFile().path} --show --step 2")
+
+    assertEquals(0, result.statusCode, result.output)
+    assertContains(result.output, "step 2: press back")
+    assertFalse(result.output.contains("step 1:"), result.output)
+    assertFalse(result.output.contains("launch app.id"), result.output)
+  }
+
+  @Test
+  fun `a step number below one is rejected`() {
+    val result = arbigentCli().test("replay ${logFile().path} --show --step 0")
+
+    assertEquals(1, result.statusCode, result.output)
+    assertContains(result.output, "--step must be 1 or more")
+  }
+
+  @Test
+  fun `an inverted range is rejected`() {
+    val result = arbigentCli().test("replay ${logFile().path} --show --from 2 --until 1")
+
+    assertEquals(1, result.statusCode, result.output)
+    assertContains(result.output, "--from 2 is after --until 1")
+  }
+
+  @Test
+  fun `a log that is not one finished run is rejected`() {
+    val file = File.createTempFile("replay-truncated", ".jsonl")
+    file.deleteOnExit()
+    file.writeText(replayLog.lineSequence().filter { it.isNotBlank() }.toList().dropLast(1).joinToString("\n"))
+
+    val result = arbigentCli().test("replay ${file.path} --show")
+
+    assertEquals(1, result.statusCode, result.output)
+    assertContains(result.output, "does not end with a successful scenario_end")
+  }
+
+  @Test
+  fun `a log that is not there is rejected`() {
+    val result = arbigentCli().test("replay /no/such/replay.jsonl --show")
+
+    assertEquals(1, result.statusCode, result.output)
+    assertContains(result.output, "is not a file")
+  }
+
+  private fun logFile(): File {
+    val file = File.createTempFile("replay", ".jsonl")
+    file.deleteOnExit()
+    file.writeText(replayLog)
+    return file
+  }
+}
+
+/** A two-step successful run, written the way the recorder writes one. */
+private val replayLog = """
+{"type":"scenario_start","task":"s","taskIndex":0,"step":0,"ts":1,"schemaVersion":1,"platform":"android","goal":"reach the home screen","appId":"app.id"}
+{"type":"init","task":"s","taskIndex":0,"step":0,"ts":1,"event":{"type":"launch_app","appId":"app.id","clearState":false,"stopApp":true,"timestamp":1}}
+{"type":"decision","task":"s","taskIndex":0,"step":1,"ts":2,"action":"Click","log":"tap sign in","goal":"reach the home screen"}
+{"type":"target","task":"s","taskIndex":0,"step":1,"ts":2,"text":"Sign in","occurrence":0}
+{"type":"device","task":"s","taskIndex":0,"step":1,"ts":2,"event":{"type":"tap_element","textRegex":"Sign in","index":0,"timestamp":2}}
+{"type":"decision","task":"s","taskIndex":0,"step":2,"ts":3,"action":"BackPress","log":"press back","goal":"reach the home screen"}
+{"type":"device","task":"s","taskIndex":0,"step":2,"ts":3,"event":{"type":"key_press","keyName":"BACK","timestamp":3}}
+{"type":"scenario_end","task":"s","taskIndex":0,"step":2,"ts":9,"status":"success","signature":["home"]}
+""".trimIndent() + "\n"

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
@@ -1,0 +1,329 @@
+package io.github.takahirom.arbigent
+
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.int
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import java.io.File
+
+/**
+ * A replay log that cannot be replayed, with the reason. Thrown while reading rather than returned,
+ * because every caller has to stop: half of a log replays to a screen the scenario never reached.
+ */
+@ArbigentInternalApi
+public class ArbigentReplayLogException(message: String) : Exception(message)
+
+/** One step of a replay log, with the device events it sent, in the order they were sent. */
+@ArbigentInternalApi
+public data class ArbigentReplayLogStep(
+  /** Globally numbered across tasks, from 1. Zero means a task's `init` phase. */
+  public val number: Int,
+  public val taskIndex: Int,
+  public val isInit: Boolean,
+  public val action: String,
+  public val log: String,
+  public val memo: String?,
+  public val goal: String,
+  /** What the recorded decision was looking at. A step with no [target] waits for one of these. */
+  public val screen: List<ArbigentElementIdentity>,
+  public val target: ArbigentReplayLogTarget?,
+  public val timestamp: Long,
+  public val events: List<ArbigentDeviceEvent>,
+) {
+  /** What to print for this step: the recorded log line, else the action name, else "setup". */
+  public fun label(): String = when {
+    isInit -> "setup"
+    log.isNotBlank() -> log
+    action.isNotBlank() -> action
+    else -> "(no action recorded)"
+  }
+}
+
+/** The element a recorded step acted on, and where it was at the time. */
+@ArbigentInternalApi
+public data class ArbigentReplayLogTarget(
+  public val identity: ArbigentElementIdentity,
+  public val centerX: Int? = null,
+  public val centerY: Int? = null,
+)
+
+/**
+ * One successful scenario run, read back from the jsonl log
+ * [ArbigentReplayScriptWriter] wrote.
+ */
+@ArbigentInternalApi
+public data class ArbigentReplayLog(
+  public val scenarioId: String,
+  public val schemaVersion: Int,
+  public val platform: ArbigentDeviceOs,
+  public val goal: String,
+  public val appId: String?,
+  /** The device's size while recording, when it reported one; used to replay taps proportionally. */
+  public val screenWidth: Int?,
+  public val screenHeight: Int?,
+  /** Resource ids the last task left on screen. Advisory: what "arrived" is checked against. */
+  public val signature: List<String>,
+  public val steps: List<ArbigentReplayLogStep>,
+) {
+  /** The highest numbered (non-init) step, or null when the log holds only setup blocks. */
+  public fun lastStepNumber(): Int? = steps.filter { !it.isInit }.maxOfOrNull { it.number }
+
+  /**
+   * The steps a range asks for, with the setup blocks that belong to them.
+   *
+   * A setup block rides with the step that came after it: a relaunch in the middle of a run is only
+   * needed when the step it prepared for is replayed. The block before the first step is the
+   * exception and is always included with [withInit], because it is how the app gets launched at
+   * all. A block at the very end rides with the step before it. [step] follows the same rule, so
+   * `--step N --with-init` launches the app and replays the setup that prepared step N.
+   */
+  public fun select(
+    step: Int? = null,
+    from: Int? = null,
+    until: Int? = null,
+    withInit: Boolean = false,
+  ): List<ArbigentReplayLogStep> {
+    if (step != null && step < 1) throw ArbigentReplayLogException("--step must be 1 or more but was $step")
+    if (from != null && from < 1) throw ArbigentReplayLogException("--from must be 1 or more but was $from")
+    if (until != null && until < 1) throw ArbigentReplayLogException("--until must be 1 or more but was $until")
+    if (from != null && until != null && from > until) {
+      throw ArbigentReplayLogException("--from $from is after --until $until")
+    }
+    val selected = mutableListOf<ArbigentReplayLogStep>()
+    var pending = mutableListOf<ArbigentReplayLogStep>()
+    var seenStep = false
+    var lastWanted = false
+    steps.forEach { candidate ->
+      if (candidate.isInit) {
+        if (withInit) pending += candidate
+        return@forEach
+      }
+      lastWanted = candidate.isWanted(step, from, until)
+      if (lastWanted) {
+        selected += pending
+        selected += candidate
+      } else if (!seenStep) {
+        selected += pending
+      }
+      pending = mutableListOf()
+      seenStep = true
+    }
+    if (pending.isNotEmpty() && (lastWanted || !seenStep)) selected += pending
+    return selected
+  }
+
+  private fun ArbigentReplayLogStep.isWanted(step: Int?, from: Int?, until: Int?): Boolean {
+    if (step != null && number != step) return false
+    if (from != null && number < from) return false
+    if (until != null && number > until) return false
+    return true
+  }
+
+  @ArbigentInternalApi
+  public companion object {
+    private val json = Json { ignoreUnknownKeys = true }
+
+    public fun read(file: File): ArbigentReplayLog {
+      if (!file.isFile) throw ArbigentReplayLogException("${file.path} is not a file")
+      return parse(file.readText(), file.path)
+    }
+
+    public fun parse(text: String, source: String): ArbigentReplayLog {
+      val records = text.lineSequence()
+        .filter { it.isNotBlank() }
+        .mapIndexed { index, line ->
+          runCatching { json.parseToJsonElement(line).jsonObject }
+            .getOrElse {
+              throw ArbigentReplayLogException("$source line ${index + 1} is not a JSON object: $it")
+            }
+        }
+        .toList()
+      requireOneFinishedRun(records, source)
+      return build(records, source)
+    }
+
+    /**
+     * A replay log is one finished run: a `scenario_start` first, a successful `scenario_end` last.
+     *
+     * Anything else (a missing or failed end, lines after the end, a second start, or lines from
+     * another scenario) means the file is not the record of one successful run, and replaying part
+     * of it would not be a replay.
+     */
+    private fun requireOneFinishedRun(records: List<JsonObject>, source: String) {
+      val first = records.firstOrNull()
+        ?: throw ArbigentReplayLogException("$source is empty")
+      if (first.string("type") != "scenario_start") {
+        throw ArbigentReplayLogException("$source does not start with a scenario_start line")
+      }
+      if (records.count { it.string("type") == "scenario_start" } > 1) {
+        throw ArbigentReplayLogException(
+          "$source has more than one scenario_start line; a replay log holds a single run",
+        )
+      }
+      val last = records.last()
+      if (last.string("type") != "scenario_end" || last.string("status") != "success") {
+        throw ArbigentReplayLogException(
+          "$source does not end with a successful scenario_end " +
+            "(the run was cut short or failed, or lines were appended after it)",
+        )
+      }
+      if (records.dropLast(1).any { it.string("type") == "scenario_end" }) {
+        throw ArbigentReplayLogException("$source has a scenario_end line before the end of the file")
+      }
+      val scenarioId = first.string("task")
+      records.forEach { record ->
+        val task = record.string("task") ?: return@forEach
+        if (task != scenarioId) {
+          throw ArbigentReplayLogException("$source mixes lines from scenarios '$scenarioId' and '$task'")
+        }
+      }
+      val schemaVersion = first.int("schemaVersion")
+        ?: throw ArbigentReplayLogException("$source does not declare a schemaVersion")
+      if (schemaVersion != ReplayLogSchemaVersion) {
+        throw ArbigentReplayLogException(
+          "$source declares schema version $schemaVersion, but this arbigent reads version " +
+            "$ReplayLogSchemaVersion. Re-record the scenario with this arbigent.",
+        )
+      }
+    }
+
+    private fun build(records: List<JsonObject>, source: String): ArbigentReplayLog {
+      val header = records.first()
+      val platformName = header.string("platform")
+        ?: throw ArbigentReplayLogException("$source does not declare a platform")
+      val platform = ArbigentDeviceOs.entries.firstOrNull { it.name.equals(platformName, ignoreCase = true) }
+        ?: throw ArbigentReplayLogException(
+          "$source was recorded on platform '$platformName', which this arbigent does not know",
+        )
+      val steps = mutableListOf<MutableStep>()
+      var previousKey: Pair<Int, Int>? = null
+      var signature = emptyList<String>()
+      records.forEach { record ->
+        when (record.string("type")) {
+          "scenario_start" -> return@forEach
+          "scenario_end" -> {
+            signature = record["signature"]?.jsonArray?.mapNotNull { it.jsonPrimitive.contentOrNull }
+              ?: emptyList()
+            return@forEach
+          }
+        }
+        val number = record.int("step") ?: 0
+        val taskIndex = record.int("taskIndex") ?: 0
+        val key = taskIndex to number
+        // Groups are consecutive runs of the same key, not one group per key: a task that fell back
+        // to the AI launches the app again after the steps it had already replayed, and that second
+        // setup block has to stay where it happened rather than merge into the first.
+        val step = if (key != previousKey) {
+          previousKey = key
+          MutableStep(number = number, taskIndex = taskIndex, timestamp = record.long("ts") ?: 0L)
+            .also { steps += it }
+        } else {
+          steps.last()
+        }
+        when (record.string("type")) {
+          "decision" -> {
+            step.action = record.string("action").orEmpty()
+            step.log = record.string("log").orEmpty()
+            step.memo = record.string("memo")
+            step.goal = record.string("goal").orEmpty()
+            step.screen = record["screen"]?.jsonArray
+              ?.mapNotNull { it.jsonObject.toIdentityOrNull() }
+              ?: emptyList()
+            step.timestamp = record.long("ts") ?: step.timestamp
+          }
+
+          "target" -> {
+            val identity = record.toIdentityOrNull() ?: return@forEach
+            val center = record["center"]?.jsonObject
+            step.target = ArbigentReplayLogTarget(
+              identity = identity.copy(occurrence = record.int("occurrence") ?: 0),
+              centerX = center?.int("x"),
+              centerY = center?.int("y"),
+            )
+          }
+
+          "device", "init" -> {
+            val event = record["event"] ?: return@forEach
+            step.events += runCatching {
+              json.decodeFromJsonElement(ArbigentDeviceEvent.serializer(), event)
+            }.getOrElse {
+              throw ArbigentReplayLogException(
+                "$source step $number carries an event this arbigent cannot read: $it",
+              )
+            }
+          }
+        }
+      }
+      return ArbigentReplayLog(
+        scenarioId = header.string("task").orEmpty(),
+        schemaVersion = ReplayLogSchemaVersion,
+        platform = platform,
+        goal = header.string("goal").orEmpty(),
+        appId = header.string("appId"),
+        screenWidth = header.int("width")?.takeIf { it > 0 },
+        screenHeight = header.int("height")?.takeIf { it > 0 },
+        signature = signature,
+        // A step that sent nothing to the device has nothing to replay.
+        steps = steps.filter { it.events.isNotEmpty() }.map { it.toStep() },
+      )
+    }
+
+    private class MutableStep(
+      val number: Int,
+      val taskIndex: Int,
+      var timestamp: Long,
+    ) {
+      var action: String = ""
+      var log: String = ""
+      var memo: String? = null
+      var goal: String = ""
+      var screen: List<ArbigentElementIdentity> = emptyList()
+      var target: ArbigentReplayLogTarget? = null
+      val events: MutableList<ArbigentDeviceEvent> = mutableListOf()
+
+      fun toStep(): ArbigentReplayLogStep = ArbigentReplayLogStep(
+        number = number,
+        taskIndex = taskIndex,
+        isInit = number == 0,
+        action = action,
+        log = log,
+        memo = memo,
+        goal = goal,
+        screen = screen,
+        target = target,
+        timestamp = timestamp,
+        events = events.toList(),
+      )
+    }
+
+    private fun JsonObject.string(key: String): String? =
+      this[key]?.jsonPrimitive?.contentOrNull
+
+    private fun JsonObject.int(key: String): Int? =
+      runCatching { this[key]?.jsonPrimitive?.int }.getOrNull()
+
+    private fun JsonObject.long(key: String): Long? =
+      runCatching { this[key]?.jsonPrimitive?.long }.getOrNull()
+
+    /**
+     * The identity a `target` line or a `screen` hint names, or null when it names nothing an
+     * element can be looked up by. [ArbigentElementIdentity] refuses to be built from no
+     * attributes, so an empty hint is dropped rather than allowed to throw here.
+     */
+    private fun JsonObject.toIdentityOrNull(): ArbigentElementIdentity? {
+      val text = string("text")?.takeIf { it.isNotEmpty() }
+      val resourceId = string("resourceId")?.takeIf { it.isNotEmpty() }
+      val accessibilityId = string("accessibilityId")?.takeIf { it.isNotEmpty() }
+      if (text == null && resourceId == null && accessibilityId == null) return null
+      return ArbigentElementIdentity(
+        text = text,
+        resourceId = resourceId,
+        accessibilityId = accessibilityId,
+      )
+    }
+  }
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
@@ -262,6 +262,8 @@ public data class ArbigentReplayLog(
           }
 
           "target" -> {
+            // An element with no text, resource id or accessibility id is unidentifiable rather
+            // than corrupt, and only weakens the divergence check, so it is skipped, not refused.
             val identity = record.toIdentityOrNull() ?: return@forEach
             val center = record["center"]?.jsonObject
             step.target = ArbigentReplayLogTarget(
@@ -272,7 +274,12 @@ public data class ArbigentReplayLog(
           }
 
           "device", "init" -> {
-            val event = record["event"] ?: return@forEach
+            // The writer emits `event` on every device record, so a record without one is a
+            // truncated or hand-edited log. Dropping it would replay the surrounding steps with a
+            // gap in the middle and still report success, so the whole log is refused instead.
+            val event = record["event"] ?: throw ArbigentReplayLogException(
+              "$source step $number has a ${record.string("type")} record without an event",
+            )
             step.events += runCatching {
               json.decodeFromJsonElement(ArbigentDeviceEvent.serializer(), event)
             }.getOrElse {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
@@ -259,8 +259,12 @@ public data class ArbigentReplayLog(
             return@forEach
           }
         }
-        val number = record.int("step") ?: 0
-        val taskIndex = record.int("taskIndex") ?: 0
+        // The writer stamps both on every line, so a line without them is a truncated or hand-made
+        // log rather than an older one, and defaulting to 0 would file it as a setup step.
+        val number = record.int("step")
+          ?: throw ArbigentReplayLogException("$source has a record without a step")
+        val taskIndex = record.int("taskIndex")
+          ?: throw ArbigentReplayLogException("$source step $number has a record without a taskIndex")
         val key = taskIndex to number
         // Groups are consecutive runs of the same key, not one group per key: a task that fell back
         // to the AI launches the app again after the steps it had already replayed, and that second

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
@@ -118,7 +118,20 @@ public data class ArbigentReplayLog(
     if (pending.isNotEmpty() && (lastWanted || !seenStep)) selected += pending
     // Setup alone is not a replay: with --with-init it would clear state, launch the app and report
     // success without ever reaching the step that was asked for.
+    //
+    // The exception is a run whose setup was the whole run -- the app launched straight onto the
+    // goal screen and the AI declared success without acting -- which records init steps and
+    // nothing else. Replaying all of that log is then exactly what was asked for, so refusing it
+    // would refuse the command the log's own markdown prints.
+    val recordsOnlyInit = steps.isNotEmpty() && steps.none { !it.isInit }
+    val wholeLogRequested = step == null && from == null && until == null
+    if (recordsOnlyInit && wholeLogRequested && withInit) return selected
     if (selected.none { !it.isInit }) {
+      if (recordsOnlyInit && wholeLogRequested) {
+        throw ArbigentReplayLogException(
+          "this log records only setup, which is replayed with --with-init",
+        )
+      }
       val requested = when {
         step != null -> "--step $step"
         from != null && until != null -> "--from $from --until $until"

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
@@ -15,7 +15,10 @@ import java.io.File
  * because every caller has to stop: half of a log replays to a screen the scenario never reached.
  */
 @ArbigentInternalApi
-public class ArbigentReplayLogException(message: String) : Exception(message)
+public class ArbigentReplayLogException(
+  message: String,
+  cause: Throwable? = null,
+) : Exception(message, cause)
 
 /** One step of a replay log, with the device events it sent, in the order they were sent. */
 @ArbigentInternalApi
@@ -145,7 +148,14 @@ public data class ArbigentReplayLog(
 
     public fun read(file: File): ArbigentReplayLog {
       if (!file.isFile) throw ArbigentReplayLogException("${file.path} is not a file")
-      return parse(file.readText(), file.path)
+      // An unreadable file is as useless to a replay as an unparsable one, and the caller reports
+      // both the same way, so it must not reach it as a different kind of failure.
+      val text = try {
+        file.readText()
+      } catch (failure: Exception) {
+        throw ArbigentReplayLogException("${file.path} cannot be read (${failure.message})", failure)
+      }
+      return parse(text, file.path)
     }
 
     public fun parse(text: String, source: String): ArbigentReplayLog {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
@@ -113,6 +113,22 @@ public data class ArbigentReplayLog(
       seenStep = true
     }
     if (pending.isNotEmpty() && (lastWanted || !seenStep)) selected += pending
+    // Setup alone is not a replay: with --with-init it would clear state, launch the app and report
+    // success without ever reaching the step that was asked for.
+    if (selected.none { !it.isInit }) {
+      val requested = when {
+        step != null -> "--step $step"
+        from != null && until != null -> "--from $from --until $until"
+        from != null -> "--from $from"
+        until != null -> "--until $until"
+        else -> "this log"
+      }
+      val numbers = steps.filter { !it.isInit }.map { it.number }
+      throw ArbigentReplayLogException(
+        if (numbers.isEmpty()) "$requested selects no step: this log records no replayable step"
+        else "$requested selects no step: steps run ${numbers.min()}..${numbers.max()}",
+      )
+    }
     return selected
   }
 
@@ -143,7 +159,16 @@ public data class ArbigentReplayLog(
         }
         .toList()
       requireOneFinishedRun(records, source)
-      return build(records, source)
+      return try {
+        build(records, source)
+      } catch (exception: ArbigentReplayLogException) {
+        throw exception
+      } catch (exception: Exception) {
+        // A field of the wrong shape ("signature": {}) reaches kotlinx.serialization as a raw
+        // IllegalArgumentException, which callers would report as a crash rather than as the
+        // unreadable log it is.
+        throw ArbigentReplayLogException("$source is not a replay log this arbigent can read: $exception")
+      }
     }
 
     /**

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
@@ -253,8 +253,9 @@ public data class ArbigentReplayLog(
       records.forEach { record ->
         // The writer stamps both on every line, including the two framing ones, so a line without
         // them is a truncated or hand-made log rather than an older one, and defaulting to 0 would
-        // file it as a setup step. A negative step is the same kind of damage: it is not step 0, so
-        // it would replay as a normal step of a task that never had one.
+        // file it as a setup step. A negative step or task index is the same kind of damage: neither
+        // is 0, so the record would replay as a normal step of a task that never had one, and the
+        // pair of them is the grouping key, so a negative index also splits a task off on its own.
         val number = record.int("step")
           ?: throw ArbigentReplayLogException("$source has a record without a step")
         if (number < 0) {
@@ -262,6 +263,11 @@ public data class ArbigentReplayLog(
         }
         val taskIndex = record.int("taskIndex")
           ?: throw ArbigentReplayLogException("$source step $number has a record without a taskIndex")
+        if (taskIndex < 0) {
+          throw ArbigentReplayLogException(
+            "$source step $number has a record with a negative taskIndex $taskIndex",
+          )
+        }
         when (record.string("type")) {
           "scenario_start" -> return@forEach
           "scenario_end" -> {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayLog.kt
@@ -251,6 +251,17 @@ public data class ArbigentReplayLog(
       var previousKey: Pair<Int, Int>? = null
       var signature = emptyList<String>()
       records.forEach { record ->
+        // The writer stamps both on every line, including the two framing ones, so a line without
+        // them is a truncated or hand-made log rather than an older one, and defaulting to 0 would
+        // file it as a setup step. A negative step is the same kind of damage: it is not step 0, so
+        // it would replay as a normal step of a task that never had one.
+        val number = record.int("step")
+          ?: throw ArbigentReplayLogException("$source has a record without a step")
+        if (number < 0) {
+          throw ArbigentReplayLogException("$source has a record with a negative step $number")
+        }
+        val taskIndex = record.int("taskIndex")
+          ?: throw ArbigentReplayLogException("$source step $number has a record without a taskIndex")
         when (record.string("type")) {
           "scenario_start" -> return@forEach
           "scenario_end" -> {
@@ -259,12 +270,6 @@ public data class ArbigentReplayLog(
             return@forEach
           }
         }
-        // The writer stamps both on every line, so a line without them is a truncated or hand-made
-        // log rather than an older one, and defaulting to 0 would file it as a setup step.
-        val number = record.int("step")
-          ?: throw ArbigentReplayLogException("$source has a record without a step")
-        val taskIndex = record.int("taskIndex")
-          ?: throw ArbigentReplayLogException("$source step $number has a record without a taskIndex")
         val key = taskIndex to number
         // Groups are consecutive runs of the same key, not one group per key: a task that fell back
         // to the AI launches the app again after the steps it had already replayed, and that second

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayRunner.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayRunner.kt
@@ -216,7 +216,7 @@ public class ArbigentReplayRunner(
         selector = ElementSelector(
           textRegex = event.textRegex,
           idRegex = event.idRegex,
-          index = event.index.takeIf { it > 0 }?.toString(),
+          index = event.index?.toString(),
         ),
       ),
     )
@@ -430,7 +430,8 @@ private fun describeEvent(event: ArbigentDeviceEvent): String = when (event) {
   is ArbigentDeviceEvent.TapElement -> "tap on " + listOfNotNull(
     event.textRegex?.let { "text='$it'" },
     event.idRegex?.let { "id='$it'" },
-    event.index.takeIf { it > 0 }?.let { "index=$it" },
+    // Only a later match is worth naming: index 0 and no index both read as the first one.
+    event.index?.takeIf { it > 0 }?.let { "index=$it" },
   ).joinToString()
 
   is ArbigentDeviceEvent.KeyPress -> "press ${event.keyName}"

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayRunner.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayRunner.kt
@@ -21,7 +21,9 @@ import maestro.orchestra.TapOnPointV2Command
  * The point is reachability: the recorded run already proved these events reach the screen, so the
  * events are sent again in order and the only judgement made is "is the screen the recording acted
  * on here yet". That judgement is the same one the in-run trace replay makes, and it lives in
- * [ArbigentReplayWait] so the two cannot drift apart.
+ * [ArbigentReplayWait] so the two cannot drift apart. Only the budget differs: with no AI to take
+ * over from a screen this stopped on, waits here keep a floor under them
+ * ([ArbigentReplayWait.standaloneBudgetMillis]).
  *
  * Nothing is sent until the whole selection has been checked ([verifyReplayable]): a log that stops
  * halfway leaves the device on a screen nobody asked for, which is worse than refusing up front.
@@ -62,18 +64,18 @@ public class ArbigentReplayRunner(
       out.append("step ${step.number}: ${step.label()}\n")
       if (waitForScreens && !step.isInit) {
         val target = step.target
-        val deadline = ArbigentReplayWait.deadlineMillis(recordedGapMillis(steps, position))
+        val budget = ArbigentReplayWait.standaloneBudgetMillis(recordedGapMillis(steps, position))
         if (target != null) {
-          val result = ArbigentReplayWait.awaitSettled(device, deadline) { elements ->
+          val result = ArbigentReplayWait.awaitReady(device, budget) { elements ->
             target.identity.findMatch(elements) != null
           }
           when (result) {
-            is ArbigentReplayWait.WaitResult.Settled -> Unit
-            ArbigentReplayWait.WaitResult.TimedOut -> {
+            is ArbigentReplayWait.WaitResult.Ready -> Unit
+            ArbigentReplayWait.WaitResult.Exhausted -> {
               reportDivergence(
                 step = step,
                 remaining = steps.drop(position + 1),
-                reason = "the target never appeared within ${deadline}ms",
+                reason = "the target never appeared within ${budget}ms",
               )
               return EXIT_DIVERGED
             }
@@ -88,16 +90,16 @@ public class ArbigentReplayRunner(
           // The hints say which screen the decision was looking at, not what it acted on, so
           // neither running out of time nor an unreadable screen stops the step; a device that
           // really is broken fails on the next event with a reason worth printing.
-          when (ArbigentReplayWait.awaitSettled(device, deadline) { elements ->
+          when (ArbigentReplayWait.awaitReady(device, budget) { elements ->
             step.screen.any { hint -> hint.findMatch(elements) != null }
           }) {
-            is ArbigentReplayWait.WaitResult.Settled -> Unit
-            ArbigentReplayWait.WaitResult.TimedOut -> err.append(
-              "  wait: none of the recorded screen hints appeared within ${deadline}ms, continuing\n",
+            is ArbigentReplayWait.WaitResult.Ready -> Unit
+            ArbigentReplayWait.WaitResult.Exhausted -> err.append(
+              "  wait: none of the recorded screen hints appeared within ${budget}ms, continuing\n",
             )
 
             ArbigentReplayWait.WaitResult.Unreadable -> err.append(
-              "  wait: the screen could not be read within ${deadline}ms, continuing\n",
+              "  wait: the screen could not be read within ${budget}ms, continuing\n",
             )
           }
         }
@@ -135,7 +137,8 @@ public class ArbigentReplayRunner(
       // The last event has only just been sent, so the end screen is usually still arriving. Wait
       // for it the same way every other step is waited for, then look regardless of how the wait
       // ended: an end screen that keeps animating is still the right screen.
-      val result = ArbigentReplayWait.awaitSettled(device, ArbigentReplayWait.deadlineMillis(null)) { elements ->
+      val budget = ArbigentReplayWait.standaloneBudgetMillis(null)
+      val result = ArbigentReplayWait.awaitReady(device, budget) { elements ->
         log.signature.any { resourceId ->
           ArbigentElementIdentity(resourceId = resourceId).findMatch(elements) != null
         }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayRunner.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayRunner.kt
@@ -64,26 +64,40 @@ public class ArbigentReplayRunner(
         val target = step.target
         val deadline = ArbigentReplayWait.deadlineMillis(recordedGapMillis(steps, position))
         if (target != null) {
-          val waited = ArbigentReplayWait.awaitSettled(device, deadline) { elements ->
+          val result = ArbigentReplayWait.awaitSettled(device, deadline) { elements ->
             target.identity.findMatch(elements) != null
           }
-          if (waited == null) {
-            reportDivergence(
-              step = step,
-              remaining = steps.drop(position + 1),
-              reason = "the target never appeared within ${deadline}ms",
-            )
-            return EXIT_DIVERGED
+          when (result) {
+            is ArbigentReplayWait.WaitResult.Settled -> Unit
+            ArbigentReplayWait.WaitResult.TimedOut -> {
+              reportDivergence(
+                step = step,
+                remaining = steps.drop(position + 1),
+                reason = "the target never appeared within ${deadline}ms",
+              )
+              return EXIT_DIVERGED
+            }
+
+            ArbigentReplayWait.WaitResult.Unreadable -> {
+              err.append("\nstep ${step.number}: the screen could not be read while waiting\n")
+              writeResumeHint(step, steps.drop(position + 1))
+              return EXIT_DEVICE
+            }
           }
         } else if (step.screen.isNotEmpty()) {
           // The hints say which screen the decision was looking at, not what it acted on, so
-          // running out of time is reported and the step still goes ahead.
-          val waited = ArbigentReplayWait.awaitSettled(device, deadline) { elements ->
+          // neither running out of time nor an unreadable screen stops the step; a device that
+          // really is broken fails on the next event with a reason worth printing.
+          when (ArbigentReplayWait.awaitSettled(device, deadline) { elements ->
             step.screen.any { hint -> hint.findMatch(elements) != null }
-          }
-          if (waited == null) {
-            err.append(
+          }) {
+            is ArbigentReplayWait.WaitResult.Settled -> Unit
+            ArbigentReplayWait.WaitResult.TimedOut -> err.append(
               "  wait: none of the recorded screen hints appeared within ${deadline}ms, continuing\n",
+            )
+
+            ArbigentReplayWait.WaitResult.Unreadable -> err.append(
+              "  wait: the screen could not be read within ${deadline}ms, continuing\n",
             )
           }
         }
@@ -113,10 +127,24 @@ public class ArbigentReplayRunner(
    * Only asked when the selection ran to the recorded end: a partial replay stops somewhere in the
    * middle by design, and the recorded end screen says nothing about where it stopped.
    */
-  private fun checkArrival(steps: List<ArbigentReplayLogStep>): Int {
+  private suspend fun checkArrival(steps: List<ArbigentReplayLogStep>): Int {
     val lastNumber = log.lastStepNumber() ?: return EXIT_OK
     if (steps.none { !it.isInit && it.number == lastNumber }) return EXIT_OK
     if (log.signature.isEmpty()) return EXIT_OK
+    if (waitForScreens) {
+      // The last event has only just been sent, so the end screen is usually still arriving. Wait
+      // for it the same way every other step is waited for, then look regardless of how the wait
+      // ended: an end screen that keeps animating is still the right screen.
+      val result = ArbigentReplayWait.awaitSettled(device, ArbigentReplayWait.deadlineMillis(null)) { elements ->
+        log.signature.any { resourceId ->
+          ArbigentElementIdentity(resourceId = resourceId).findMatch(elements) != null
+        }
+      }
+      if (result == ArbigentReplayWait.WaitResult.Unreadable) {
+        err.append("\ncould not read the screen to check where the replay arrived\n")
+        return EXIT_DEVICE
+      }
+    }
     val elements = try {
       device.elements()
     } catch (exception: Exception) {
@@ -194,8 +222,9 @@ public class ArbigentReplayRunner(
     )
 
     is ArbigentDeviceEvent.KeyPress -> {
+      // Refused by verifySelection before anything is sent; reaching here means a caller skipped it.
       val code = KeyPressAgentAction.resolveKeyCode(event.keyName)
-        ?: throw ArbigentReplayLogException("the recorded key '${event.keyName}' is not a key this Maestro knows")
+        ?: throw ArbigentReplayLogException(unknownKeyReason(event.keyName))
       MaestroCommand(pressKeyCommand = PressKeyCommand(code))
     }
 
@@ -359,8 +388,24 @@ public class ArbigentReplayRunner(
         return "the recorded run used commands this replay cannot reproduce: " +
           unsupported.joinToString(separator = "; ") { (number, command) -> "step $number: $command" }
       }
+      // A key this Maestro cannot resolve would otherwise only be noticed as the event is sent,
+      // half way through the selection, leaving the device on a screen nobody asked for.
+      val unknownKeys = steps.flatMap { step ->
+        step.events.filterIsInstance<ArbigentDeviceEvent.KeyPress>()
+          .filter { KeyPressAgentAction.resolveKeyCode(it.keyName) == null }
+          .map { step.number to it.keyName }
+      }
+      if (unknownKeys.isNotEmpty()) {
+        return unknownKeys.joinToString(separator = "; ") { (number, keyName) ->
+          "step $number: ${unknownKeyReason(keyName)}"
+        }
+      }
       return null
     }
+
+    /** Said the same way whether a key is refused up front or, impossibly, as it is sent. */
+    private fun unknownKeyReason(keyName: String): String =
+      "the recorded key '$keyName' is not a key this Maestro knows"
 
     public fun show(log: ArbigentReplayLog, steps: List<ArbigentReplayLogStep>, out: Appendable) {
       out.append("scenario: ${log.scenarioId}\n")

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayRunner.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayRunner.kt
@@ -220,7 +220,12 @@ public class ArbigentReplayRunner(
   private fun toMaestroCommand(event: ArbigentDeviceEvent): MaestroCommand = when (event) {
     is ArbigentDeviceEvent.Tap -> {
       val (x, y) = scale(event.x, event.y)
-      MaestroCommand(tapOnPointV2Command = TapOnPointV2Command(point = "$x,$y"))
+      MaestroCommand(
+        tapOnPointV2Command = TapOnPointV2Command(
+          point = "$x,$y",
+          retryIfNoChange = event.retryIfNoChange,
+        ),
+      )
     }
 
     is ArbigentDeviceEvent.TapElement -> MaestroCommand(
@@ -230,6 +235,7 @@ public class ArbigentReplayRunner(
           idRegex = event.idRegex,
           index = event.index?.toString(),
         ),
+        retryIfNoChange = event.retryIfNoChange,
       ),
     )
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayRunner.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayRunner.kt
@@ -1,0 +1,427 @@
+package io.github.takahirom.arbigent
+
+import kotlinx.coroutines.delay
+import maestro.MaestroException
+import maestro.Point
+import maestro.orchestra.ClearStateCommand
+import maestro.orchestra.ElementSelector
+import maestro.orchestra.InputTextCommand
+import maestro.orchestra.LaunchAppCommand
+import maestro.orchestra.MaestroCommand
+import maestro.orchestra.OpenLinkCommand
+import maestro.orchestra.PressKeyCommand
+import maestro.orchestra.StopAppCommand
+import maestro.orchestra.SwipeCommand
+import maestro.orchestra.TapOnElementCommand
+import maestro.orchestra.TapOnPointV2Command
+
+/**
+ * Replays a recorded log against a device, with no AI in the loop.
+ *
+ * The point is reachability: the recorded run already proved these events reach the screen, so the
+ * events are sent again in order and the only judgement made is "is the screen the recording acted
+ * on here yet". That judgement is the same one the in-run trace replay makes, and it lives in
+ * [ArbigentReplayWait] so the two cannot drift apart.
+ *
+ * Nothing is sent until the whole selection has been checked ([verifyReplayable]): a log that stops
+ * halfway leaves the device on a screen nobody asked for, which is worse than refusing up front.
+ */
+@ArbigentInternalApi
+public class ArbigentReplayRunner(
+  private val log: ArbigentReplayLog,
+  private val device: ArbigentDevice,
+  private val out: Appendable,
+  private val err: Appendable,
+  /** When false, every event is sent as fast as the device accepts it. For a settled screen. */
+  private val waitForScreens: Boolean = true,
+) {
+  private var currentScreenSize: Pair<Int, Int>? = null
+
+  /**
+   * Why this selection cannot be replayed on this device, or null when it can.
+   *
+   * Checked before the first event so a refusal leaves the device untouched.
+   */
+  public fun verifyReplayable(steps: List<ArbigentReplayLogStep>): String? {
+    verifySelection(steps)?.let { return it }
+    val deviceOs = device.os()
+    if (deviceOs != log.platform) {
+      return "the log was recorded on ${log.platform.name.lowercase()} but the connected device is " +
+        "${deviceOs.name.lowercase()}"
+    }
+    return null
+  }
+
+  /**
+   * Sends [steps] to the device and returns the process exit code: [EXIT_OK] when every step went
+   * through and the end screen looks like the recorded one, [EXIT_DIVERGED] when the screen was not
+   * what the recording acted on, and [EXIT_DEVICE] when the device itself could not be driven.
+   */
+  public suspend fun run(steps: List<ArbigentReplayLogStep>): Int {
+    steps.forEachIndexed { position, step ->
+      out.append("step ${step.number}: ${step.label()}\n")
+      if (waitForScreens && !step.isInit) {
+        val target = step.target
+        val deadline = ArbigentReplayWait.deadlineMillis(recordedGapMillis(steps, position))
+        if (target != null) {
+          val waited = ArbigentReplayWait.awaitSettled(device, deadline) { elements ->
+            target.identity.findMatch(elements) != null
+          }
+          if (waited == null) {
+            reportDivergence(
+              step = step,
+              remaining = steps.drop(position + 1),
+              reason = "the target never appeared within ${deadline}ms",
+            )
+            return EXIT_DIVERGED
+          }
+        } else if (step.screen.isNotEmpty()) {
+          // The hints say which screen the decision was looking at, not what it acted on, so
+          // running out of time is reported and the step still goes ahead.
+          val waited = ArbigentReplayWait.awaitSettled(device, deadline) { elements ->
+            step.screen.any { hint -> hint.findMatch(elements) != null }
+          }
+          if (waited == null) {
+            err.append(
+              "  wait: none of the recorded screen hints appeared within ${deadline}ms, continuing\n",
+            )
+          }
+        }
+      }
+      step.events.forEach { event ->
+        when (val outcome = send(event)) {
+          SendOutcome.Sent -> Unit
+          is SendOutcome.Diverged -> {
+            reportDivergence(step, steps.drop(position + 1), outcome.reason)
+            return EXIT_DIVERGED
+          }
+
+          is SendOutcome.DeviceFailure -> {
+            err.append("\nstep ${step.number}: ${outcome.reason}\n")
+            writeResumeHint(step, steps.drop(position + 1))
+            return EXIT_DEVICE
+          }
+        }
+      }
+    }
+    return checkArrival(steps)
+  }
+
+  /**
+   * Whether the end screen carries any of the resource ids the recorded run left behind.
+   *
+   * Only asked when the selection ran to the recorded end: a partial replay stops somewhere in the
+   * middle by design, and the recorded end screen says nothing about where it stopped.
+   */
+  private fun checkArrival(steps: List<ArbigentReplayLogStep>): Int {
+    val lastNumber = log.lastStepNumber() ?: return EXIT_OK
+    if (steps.none { !it.isInit && it.number == lastNumber }) return EXIT_OK
+    if (log.signature.isEmpty()) return EXIT_OK
+    val elements = try {
+      device.elements()
+    } catch (exception: Exception) {
+      err.append("\ncould not read the screen to check where the replay arrived: $exception\n")
+      return EXIT_DEVICE
+    }
+    val present = log.signature.filter { resourceId ->
+      ArbigentElementIdentity(resourceId = resourceId).findMatch(elements) != null
+    }
+    if (present.isEmpty()) {
+      err.append("\nDIVERGED\n")
+      err.append("  goal: ${log.goal}\n")
+      err.append("  reason: none of the recorded end-screen ids are present\n")
+      err.append("  expected any of: ${log.signature.joinToString()}\n")
+      appendScreen(err, elements)
+      return EXIT_DIVERGED
+    }
+    out.append("arrived: the end screen carries ${present.size} of ${log.signature.size} recorded ids\n")
+    return EXIT_OK
+  }
+
+  private sealed interface SendOutcome {
+    object Sent : SendOutcome
+    data class Diverged(val reason: String) : SendOutcome
+    data class DeviceFailure(val reason: String) : SendOutcome
+  }
+
+  private suspend fun send(event: ArbigentDeviceEvent): SendOutcome {
+    if (event is ArbigentDeviceEvent.Wait) {
+      delay(event.millis.coerceAtMost(ArbigentReplayWait.MAX_WAIT_MILLIS))
+      return SendOutcome.Sent
+    }
+    val command = try {
+      toMaestroCommand(event)
+    } catch (exception: ArbigentReplayLogException) {
+      return SendOutcome.Diverged(exception.message ?: "the event could not be replayed")
+    }
+    return try {
+      device.executeActions(listOf(command))
+      SendOutcome.Sent
+    } catch (exception: Exception) {
+      // An element the recorded run tapped that is not on screen now is a divergence, not a broken
+      // device: the replay reached a different screen. Anything else means the device could not be
+      // driven at all, and a later step would fail for the same reason.
+      if (exception.hasCause<MaestroException.ElementNotFound>()) {
+        SendOutcome.Diverged("${describeEvent(event)}: the element is not on screen")
+      } else {
+        SendOutcome.DeviceFailure("${describeEvent(event)} failed: $exception")
+      }
+    }
+  }
+
+  /**
+   * The Maestro command that replays [event].
+   *
+   * Coordinates recorded on a differently sized screen are scaled, because a pixel that was inside
+   * a button on the recording device is often outside it here. Percentages would be the obvious
+   * alternative, but Maestro parses a percentage point as a whole number, which on a 1080px screen
+   * rounds to the nearest 11 pixels.
+   */
+  private fun toMaestroCommand(event: ArbigentDeviceEvent): MaestroCommand = when (event) {
+    is ArbigentDeviceEvent.Tap -> {
+      val (x, y) = scale(event.x, event.y)
+      MaestroCommand(tapOnPointV2Command = TapOnPointV2Command(point = "$x,$y"))
+    }
+
+    is ArbigentDeviceEvent.TapElement -> MaestroCommand(
+      tapOnElement = TapOnElementCommand(
+        selector = ElementSelector(
+          textRegex = event.textRegex,
+          idRegex = event.idRegex,
+          index = event.index.takeIf { it > 0 }?.toString(),
+        ),
+      ),
+    )
+
+    is ArbigentDeviceEvent.KeyPress -> {
+      val code = KeyPressAgentAction.resolveKeyCode(event.keyName)
+        ?: throw ArbigentReplayLogException("the recorded key '${event.keyName}' is not a key this Maestro knows")
+      MaestroCommand(pressKeyCommand = PressKeyCommand(code))
+    }
+
+    is ArbigentDeviceEvent.InputText -> MaestroCommand(
+      inputTextCommand = InputTextCommand(text = event.text),
+    )
+
+    is ArbigentDeviceEvent.Swipe -> {
+      val (startX, startY) = scale(event.startX, event.startY)
+      val (endX, endY) = scale(event.endX, event.endY)
+      MaestroCommand(
+        swipeCommand = SwipeCommand(
+          startPoint = Point(startX, startY),
+          endPoint = Point(endX, endY),
+          duration = event.durationMs,
+        ),
+      )
+    }
+
+    is ArbigentDeviceEvent.LaunchApp -> MaestroCommand(
+      launchAppCommand = LaunchAppCommand(
+        appId = event.appId,
+        clearState = event.clearState,
+        stopApp = event.stopApp,
+        launchArguments = event.launchArguments
+          .mapValues { (_, value) -> value.launchArgumentValue() }
+          .takeIf { it.isNotEmpty() },
+      ),
+    )
+
+    is ArbigentDeviceEvent.StopApp -> MaestroCommand(
+      stopAppCommand = StopAppCommand(appId = event.appId),
+    )
+
+    is ArbigentDeviceEvent.ClearState -> MaestroCommand(
+      clearStateCommand = ClearStateCommand(appId = event.appId),
+    )
+
+    is ArbigentDeviceEvent.OpenLink -> MaestroCommand(
+      openLinkCommand = OpenLinkCommand(link = event.url),
+    )
+
+    // Refused by verifyReplayable before anything is sent; reaching here means a caller skipped it.
+    is ArbigentDeviceEvent.Unsupported ->
+      throw ArbigentReplayLogException("the recorded run used ${event.command}, which cannot be replayed")
+
+    is ArbigentDeviceEvent.Wait ->
+      throw ArbigentReplayLogException("a wait is not a device command")
+  }
+
+  /**
+   * [x] and [y] on this screen, given where they were on the recording's screen.
+   *
+   * Left alone when either size is unknown: guessing a scale from one known size would move a tap
+   * further from the element than leaving it where it was recorded.
+   */
+  private fun scale(x: Int, y: Int): Pair<Int, Int> {
+    val recordedWidth = log.screenWidth ?: return x to y
+    val recordedHeight = log.screenHeight ?: return x to y
+    val (currentWidth, currentHeight) = currentScreenSize() ?: return x to y
+    if (currentWidth == recordedWidth && currentHeight == recordedHeight) return x to y
+    return (x.toLong() * currentWidth / recordedWidth).toInt() to
+      (y.toLong() * currentHeight / recordedHeight).toInt()
+  }
+
+  private fun currentScreenSize(): Pair<Int, Int>? {
+    currentScreenSize?.let { return it }
+    val elements = try {
+      device.elements()
+    } catch (exception: Exception) {
+      arbigentDebugLog("Replay: could not read the screen size: $exception")
+      return null
+    }
+    if (elements.screenWidth <= 0 || elements.screenHeight <= 0) return null
+    return (elements.screenWidth to elements.screenHeight).also { currentScreenSize = it }
+  }
+
+  private fun recordedGapMillis(steps: List<ArbigentReplayLogStep>, position: Int): Long? {
+    val previous = steps.getOrNull(position - 1) ?: return null
+    val current = steps[position]
+    return (current.timestamp - previous.timestamp).takeIf { it > 0 }
+  }
+
+  private fun reportDivergence(
+    step: ArbigentReplayLogStep,
+    remaining: List<ArbigentReplayLogStep>,
+    reason: String,
+  ) {
+    err.append("\nDIVERGED\n")
+    err.append("  goal: ${step.goal.ifBlank { log.goal }}\n")
+    err.append("  step ${step.number}: ${step.label()}\n")
+    step.memo?.let { err.append("  memo: ${it.replace("\n", " ")}\n") }
+    err.append("  reason: $reason\n")
+    err.append("  expected: ${step.target?.identity?.description() ?: "(no recorded target)"}\n")
+    val elements = try {
+      device.elements()
+    } catch (exception: Exception) {
+      err.append("  on screen now: (the screen could not be read: $exception)\n")
+      writeResumeHint(step, remaining)
+      return
+    }
+    appendScreen(err, elements)
+    writeResumeHint(step, remaining)
+  }
+
+  private fun appendScreen(sink: Appendable, elements: ArbigentElementList) {
+    sink.append("  on screen now:\n")
+    val shown = elements.elements.asSequence()
+      .mapNotNull { element -> ArbigentElementIdentity.from(element, elements.elements)?.description() }
+      .distinct()
+      .take(MaxShownElements + 1)
+      .toList()
+    shown.take(MaxShownElements).forEach { sink.append("    - $it\n") }
+    if (shown.size > MaxShownElements) sink.append("    ... (more elements not shown)\n")
+  }
+
+  /**
+   * How to carry on from where this stopped.
+   *
+   * Step zero is not a valid `--from`, so a failed setup block points at the first numbered step it
+   * was preparing for instead.
+   */
+  private fun writeResumeHint(step: ArbigentReplayLogStep, remaining: List<ArbigentReplayLogStep>) {
+    val resumeFrom = if (step.isInit) {
+      remaining.firstOrNull { !it.isInit }?.number ?: return
+    } else {
+      step.number
+    }
+    val withInit = if (step.isInit) " --with-init" else ""
+    err.append("  resume with: arbigent replay <log> --from $resumeFrom$withInit\n")
+  }
+
+  @ArbigentInternalApi
+  public companion object {
+    public const val EXIT_OK: Int = 0
+
+    /** The screen was not the one the recording acted on. */
+    public const val EXIT_DIVERGED: Int = 2
+
+    /** The device could not be driven, so nothing is known about where the replay got to. */
+    public const val EXIT_DEVICE: Int = 3
+
+    private const val MaxShownElements = 40
+
+    /**
+     * Prints a selection without touching a device, so a caller can see what a range would do.
+     * Deliberately not a member: showing a log needs no device to be connected first.
+     */
+    /**
+     * Why this selection cannot be replayed at all, or null when only the device is left to check.
+     *
+     * Separate from [verifyReplayable] because neither reason needs a device, and a caller that
+     * refuses here avoids starting a driver only to throw the session away.
+     */
+    public fun verifySelection(steps: List<ArbigentReplayLogStep>): String? {
+      if (steps.isEmpty()) return "nothing to replay for the given range"
+      val unsupported = steps.flatMap { step ->
+        step.events.filterIsInstance<ArbigentDeviceEvent.Unsupported>().map { step.number to it.command }
+      }
+      if (unsupported.isNotEmpty()) {
+        return "the recorded run used commands this replay cannot reproduce: " +
+          unsupported.joinToString(separator = "; ") { (number, command) -> "step $number: $command" }
+      }
+      return null
+    }
+
+    public fun show(log: ArbigentReplayLog, steps: List<ArbigentReplayLogStep>, out: Appendable) {
+      out.append("scenario: ${log.scenarioId}\n")
+      out.append("goal: ${log.goal}\n")
+      log.appId?.let { out.append("app: $it\n") }
+      out.append("platform: ${log.platform.name.lowercase()}\n")
+      steps.forEach { step ->
+        out.append("step ${step.number}: ${step.label()}\n")
+        step.target?.let { out.append("  target: ${it.identity.description()}\n") }
+        step.events.forEach { out.append("  ${describeEvent(it)}\n") }
+      }
+      if (log.signature.isNotEmpty()) {
+        out.append("expect: resource ids ${log.signature.joinToString()}\n")
+      }
+    }
+  }
+}
+
+/** A one-line description of what an event does, for logs a person reads. */
+private fun describeEvent(event: ArbigentDeviceEvent): String = when (event) {
+  is ArbigentDeviceEvent.Tap -> "tap (${event.x}, ${event.y})"
+  is ArbigentDeviceEvent.TapElement -> "tap on " + listOfNotNull(
+    event.textRegex?.let { "text='$it'" },
+    event.idRegex?.let { "id='$it'" },
+    event.index.takeIf { it > 0 }?.let { "index=$it" },
+  ).joinToString()
+
+  is ArbigentDeviceEvent.KeyPress -> "press ${event.keyName}"
+  is ArbigentDeviceEvent.InputText -> "input text"
+  is ArbigentDeviceEvent.Swipe ->
+    "swipe (${event.startX}, ${event.startY}) -> (${event.endX}, ${event.endY})"
+
+  is ArbigentDeviceEvent.LaunchApp -> "launch ${event.appId}"
+  is ArbigentDeviceEvent.StopApp -> "stop ${event.appId}"
+  is ArbigentDeviceEvent.ClearState -> "clear state of ${event.appId}"
+  is ArbigentDeviceEvent.Wait -> "wait ${event.millis}ms"
+  is ArbigentDeviceEvent.OpenLink -> "open ${event.url}"
+  is ArbigentDeviceEvent.Unsupported -> event.command
+}
+
+/** True when [T] is this exception or anywhere in its cause chain. */
+private inline fun <reified T : Throwable> Throwable.hasCause(): Boolean {
+  var current: Throwable? = this
+  val seen = mutableSetOf<Throwable>()
+  while (current != null && seen.add(current)) {
+    if (current is T) return true
+    current = current.cause
+  }
+  return false
+}
+
+/**
+ * The value Maestro wants for a recorded launch argument. Maestro types launch arguments as `Any`
+ * and decides the `am start` flag from the runtime type, so a recorded boolean or number has to go
+ * back as one rather than as its text.
+ */
+private fun kotlinx.serialization.json.JsonPrimitive.launchArgumentValue(): Any {
+  if (isString) return content
+  content.toBooleanStrictOrNull()?.let { return it }
+  content.toIntOrNull()?.let { return it }
+  content.toLongOrNull()?.let { return it }
+  content.toDoubleOrNull()?.let { return it }
+  return content
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayRunner.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayRunner.kt
@@ -107,7 +107,8 @@ public class ArbigentReplayRunner(
           // screen (a canvas, a video surface) records. The recorded gap is still the time the app
           // was given before this action, so it is waited out rather than skipped -- otherwise this
           // one step, of all steps, gets no pacing at all and acts on a screen that is still
-          // loading. This is what the in-run replay does for a step with no target.
+          // loading. The in-run replay waits out its budget the same way for a step with no target;
+          // the difference here is only that the standalone floor applies to it.
           out.append("  wait: nothing recorded to wait for, pacing ${budget}ms\n")
           delay(budget)
         }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayRunner.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayRunner.kt
@@ -102,6 +102,14 @@ public class ArbigentReplayRunner(
               "  wait: the screen could not be read within ${budget}ms, continuing\n",
             )
           }
+        } else {
+          // Nothing recorded to wait *for*: no target and no screen hints, which is what an opaque
+          // screen (a canvas, a video surface) records. The recorded gap is still the time the app
+          // was given before this action, so it is waited out rather than skipped -- otherwise this
+          // one step, of all steps, gets no pacing at all and acts on a screen that is still
+          // loading. This is what the in-run replay does for a step with no target.
+          out.append("  wait: nothing recorded to wait for, pacing ${budget}ms\n")
+          delay(budget)
         }
       }
       step.events.forEach { event ->
@@ -255,6 +263,10 @@ public class ArbigentReplayRunner(
         launchArguments = event.launchArguments
           .mapValues { (_, value) -> value.launchArgumentValue() }
           .takeIf { it.isNotEmpty() },
+        // Left null when the recording did not set them, so Maestro applies its own defaults here
+        // exactly as it did for the recorded launch.
+        permissions = event.permissions,
+        clearKeychain = event.clearKeychain,
       ),
     )
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
@@ -24,21 +24,15 @@ internal class ReplayDivergenceException(
  * and UI tree: replay makes no AI call, so without it the next screen is snapshotted before it has
  * settled and an index-based action resolves against a half-built element list.
  *
- * How long a step may wait is the interval recorded between it and the step before it, minus what
- * replay has already spent executing the previous action. That interval is the recording run's own
- * time from one capture to the next, so it already contains everything the app was given then,
- * including the AI latency the recording paid and any `Wait` the AI itself decided on; replay is
- * therefore never slower than the recording, and never faster than the app needs. A step with no
- * recorded interval — the first step of a task, which has no predecessor in the trace — gets
- * [MIN_WAIT_MILLIS] instead, because there is nothing to derive a budget from and a task that
- * starts by launching an app must not be stepped on at once.
+ * How long a step may wait is [ArbigentReplayWait.inRunBudgetMillis]: the interval recorded between
+ * this step and the one before it, minus what replay has already spent executing the previous
+ * action. A step with no recorded interval — the first step of a task, which has no predecessor in
+ * the trace — gets [ArbigentReplayWait.MIN_WAIT_MILLIS] instead, because there is nothing to derive
+ * a budget from and a task that starts by launching an app must not be stepped on at once.
  *
- * Within that budget a step with a recorded target polls the elements until the target is present,
- * and proceeds the moment it is. Waiting further for the element list to stop changing was tried
- * and dropped: a screen with anything animating or ticking never stops changing, so the wait ran to
- * the budget every time and a screen that was in fact ready was reported as one the target never
- * reached. A step with no target to wait for (reaching the goal, back, scroll, wait, and text
- * actions recorded without an identity) waits its budget out.
+ * Within that budget a step with a recorded target polls the elements until the target is present
+ * and proceeds the moment it is. A step with no target to wait for (reaching the goal, back,
+ * scroll, wait, and text actions recorded without an identity) waits its budget out.
  */
 internal class ArbigentReplayPacingStepInterceptor(
   private val trace: ArbigentReplayTrace,
@@ -65,19 +59,14 @@ internal class ArbigentReplayPacingStepInterceptor(
     return chain.proceed(stepInput)
   }
 
-  /**
-   * How long this step may still wait: what is left of the recorded interval after the time replay
-   * has already spent since the previous step began. The cap is applied to the recorded interval
-   * itself, so a pathological recording does not become a minute of waiting plus whatever the
-   * previous action took.
-   */
   private fun remainingBudgetMillis(replayIndex: Int): Long {
-    val recordedGap = recordedGapMillis(replayIndex) ?: return MIN_WAIT_MILLIS
-    val budget = recordedGap.coerceAtMost(MAX_WAIT_MILLIS)
-    // Nothing measured to subtract: this is the budget in full rather than a guess at what is left.
-    val previousStartedAt = previousStepStartedAtMillis ?: return budget
-    val alreadySpent = TimeProvider.get().currentTimeMillis() - previousStartedAt
-    return (budget - alreadySpent).coerceAtLeast(0)
+    val previousStartedAt = previousStepStartedAtMillis
+    return ArbigentReplayWait.inRunBudgetMillis(
+      recordedGapMillis = recordedGapMillis(replayIndex),
+      alreadySpentMillis = previousStartedAt?.let {
+        TimeProvider.get().currentTimeMillis() - it
+      },
+    )
   }
 
   private fun recordedGapMillis(replayIndex: Int): Long? {
@@ -88,55 +77,35 @@ internal class ArbigentReplayPacingStepInterceptor(
     return (recordedAt - previousRecordedAt).takeIf { it > 0 }
   }
 
-  /**
-   * Polls until the recorded target is present, or until [budgetMillis] is spent. The screen is
-   * read once before the budget is consulted, so a step whose budget is already gone still gets the
-   * chance to find its target on a screen that is in fact ready — and a target that never appears
-   * is left for the decision interceptor to report as a divergence, which is what it is.
-   */
   private suspend fun awaitTarget(
     replayIndex: Int,
     identity: ArbigentElementIdentity,
     device: ArbigentDevice,
     budgetMillis: Long,
   ) {
-    var waitedMillis = 0L
-    while (true) {
-      val readStartedAtMillis = TimeProvider.get().currentTimeMillis()
-      val present = isPresent(device, identity)
-      // Reading the hierarchy is synchronous and can take a while on a busy device. Charge it to
-      // the budget as well, or a slow read adds itself to every poll and the wait outlasts the
-      // recorded interval it is supposed to fit inside.
-      waitedMillis += (TimeProvider.get().currentTimeMillis() - readStartedAtMillis)
-        .coerceAtLeast(0)
-      if (present) {
-        arbigentInfoLog(
-          "Replay wait: target ${identity.description()} found after ${waitedMillis}ms " +
-            "before capturing step ${replayIndex + 1}",
-        )
-        return
-      }
-      if (waitedMillis >= budgetMillis) break
-      val pollMillis = POLL_INTERVAL_MILLIS.coerceAtMost(budgetMillis - waitedMillis)
-      delay(pollMillis)
-      waitedMillis += pollMillis
+    val result = ArbigentReplayWait.awaitReady(device, budgetMillis) { elements ->
+      identity.findMatch(elements) != null
     }
-    arbigentInfoLog(
-      "Replay wait: budget ${budgetMillis}ms spent waiting for target ${identity.description()} " +
-        "before capturing step ${replayIndex + 1}; capturing anyway",
-    )
-  }
+    // Capturing the step anyway is the point of this interceptor: it only paces the run, and the AI
+    // that follows decides what the screen actually is, so neither an exhausted budget nor an
+    // unreadable screen is fatal here. A target that never appears is a divergence, and
+    // [ArbigentReplayDecisionInterceptor] is what reports it as one.
+    when (result) {
+      is ArbigentReplayWait.WaitResult.Ready -> arbigentInfoLog(
+        "Replay wait: target ${identity.description()} found after ${result.waitedMillis}ms " +
+          "before capturing step ${replayIndex + 1}",
+      )
 
-  private fun isPresent(device: ArbigentDevice, identity: ArbigentElementIdentity): Boolean {
-    val elements = try {
-      device.elements()
-    } catch (exception: Exception) {
-      // Reading the hierarchy can fail while the screen is mid-transition, which is exactly the
-      // state this waits out. Treat it as "not there yet".
-      arbigentDebugLog("Replay wait: could not read elements: $exception")
-      return false
+      ArbigentReplayWait.WaitResult.Exhausted -> arbigentInfoLog(
+        "Replay wait: budget ${budgetMillis}ms spent waiting for target " +
+          "${identity.description()} before capturing step ${replayIndex + 1}; capturing anyway",
+      )
+
+      ArbigentReplayWait.WaitResult.Unreadable -> arbigentInfoLog(
+        "Replay wait: the screen could not be read while waiting for target " +
+          "${identity.description()} before capturing step ${replayIndex + 1}; capturing anyway",
+      )
     }
-    return identity.findMatch(elements) != null
   }
 
   private suspend fun waitOutBudget(replayIndex: Int, budgetMillis: Long) {
@@ -147,15 +116,6 @@ internal class ArbigentReplayPacingStepInterceptor(
     delay(budgetMillis)
   }
 
-  private companion object {
-    // A recorded gap can be pathological (a hiccup while recording); do not inherit it unbounded.
-    const val MAX_WAIT_MILLIS = 60_000L
-
-    // Without a recorded interval there is nothing to derive a budget from, and the step this
-    // happens on is the one that starts a task — the launch replay must not step on.
-    const val MIN_WAIT_MILLIS = 10_000L
-    const val POLL_INTERVAL_MILLIS = 500L
-  }
 }
 
 internal class ArbigentReplayDecisionInterceptor(

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
@@ -115,7 +115,6 @@ internal class ArbigentReplayPacingStepInterceptor(
     )
     delay(budgetMillis)
   }
-
 }
 
 internal class ArbigentReplayDecisionInterceptor(

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayWait.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayWait.kt
@@ -1,38 +1,71 @@
 package io.github.takahirom.arbigent
 
 import kotlinx.coroutines.delay
-import kotlinx.coroutines.withTimeoutOrNull
 
 /**
  * Waiting for the screen a recorded step acted on, without asking the AI whether it has arrived.
  *
  * Both replay paths need the same rule — the trace replay inside a scenario run
  * ([ArbigentReplayPacingStepInterceptor]) and `arbigent replay`, which drives a recorded log with no
- * AI at all — so the deadline, the poll interval and what "settled" means live here rather than in
- * either caller.
+ * AI at all — so the poll interval, what counts as arrived, and how long a step may wait for it live
+ * here rather than in either caller.
+ *
+ * What the two paths do not share is how generous the budget is, which is why there are two ways to
+ * ask for one. Inside a run the AI is standing behind replay: a wait that ends too early costs a
+ * fallback, so the budget is exactly what the recording had left ([inRunBudgetMillis]). `arbigent
+ * replay` has nobody behind it and stops the run instead, so it keeps a floor under every wait
+ * ([standaloneBudgetMillis]).
  */
 internal object ArbigentReplayWait {
   /** A recorded gap can be pathological (a hiccup while recording); do not inherit it unbounded. */
   const val MAX_WAIT_MILLIS: Long = 60_000L
 
-  /** A short recorded gap says the recording run was fast, not that the replayed screen will be. */
+  /** Nothing recorded to derive a budget from, and a screen still on its way is the likely case. */
   const val MIN_WAIT_MILLIS: Long = 10_000L
 
   const val POLL_INTERVAL_MILLIS: Long = 500L
 
-  /** How long a wait may take: the recorded gap, never below 10 seconds nor above a minute. */
-  fun deadlineMillis(recordedGapMillis: Long?): Long {
+  /**
+   * How long a step inside a scenario run may wait: what is left of [recordedGapMillis] after
+   * [alreadySpentMillis], the time replay has spent since the previous step began.
+   *
+   * The recorded gap is the recording run's own time from one capture to the next, so it already
+   * contains everything the app was given then, including the AI latency the recording paid and any
+   * `Wait` the AI itself decided on. Replay is therefore never slower than the recording and never
+   * faster than the app needed. The cap is applied to the recorded gap itself, so a pathological
+   * recording does not become a minute of waiting plus whatever the previous action took.
+   *
+   * A null gap or a null elapsed time is what is not known, not zero: with no gap there is nothing
+   * to derive a budget from and the result is [MIN_WAIT_MILLIS]; with no elapsed time there is
+   * nothing to subtract and the result is the gap in full.
+   */
+  fun inRunBudgetMillis(recordedGapMillis: Long?, alreadySpentMillis: Long?): Long {
     val recordedGap = recordedGapMillis ?: return MIN_WAIT_MILLIS
-    return recordedGap.coerceAtMost(MAX_WAIT_MILLIS).coerceAtLeast(MIN_WAIT_MILLIS)
+    val budget = recordedGap.coerceAtMost(MAX_WAIT_MILLIS)
+    val alreadySpent = alreadySpentMillis ?: return budget
+    return (budget - alreadySpent).coerceAtLeast(0)
   }
+
+  /**
+   * How long a step of `arbigent replay` may wait: the recorded gap, never below
+   * [MIN_WAIT_MILLIS] nor above [MAX_WAIT_MILLIS].
+   *
+   * A wait that ends too early here ends the whole replay, and there is no AI to take over from the
+   * screen it stopped on, so a recording that happened to be fast does not get to make the replay
+   * impatient.
+   */
+  fun standaloneBudgetMillis(recordedGapMillis: Long?): Long =
+    (recordedGapMillis ?: MIN_WAIT_MILLIS)
+      .coerceAtMost(MAX_WAIT_MILLIS)
+      .coerceAtLeast(MIN_WAIT_MILLIS)
 
   /** How a wait ended. */
   sealed interface WaitResult {
-    /** [isReady] held and the screen stopped changing, after [waitedMillis]. */
-    data class Settled(val waitedMillis: Long) : WaitResult
+    /** [isReady] held after [waitedMillis]. */
+    data class Ready(val waitedMillis: Long) : WaitResult
 
-    /** The screen was readable throughout but never settled on what was asked for. */
-    object TimedOut : WaitResult
+    /** The screen was readable but never became what was asked for before the budget ran out. */
+    object Exhausted : WaitResult
 
     /**
      * The hierarchy could not be read even once. A screen that is merely mid-transition answers at
@@ -43,48 +76,41 @@ internal object ArbigentReplayWait {
   }
 
   /**
-   * Waits until [isReady] holds for the element list and that list stops changing, which is what
-   * "the screen has settled on the recorded target" means without asking the AI.
+   * Polls until [isReady] holds for the element list, or until [budgetMillis] is spent.
+   *
+   * The screen is read once before the budget is consulted, so a step whose budget is already gone
+   * still gets the chance to find what it is waiting for on a screen that is in fact ready.
+   *
+   * Waiting further for the element list to stop changing was tried and dropped: a screen with
+   * anything animating, ticking or streaming never stops changing, so the wait ran to the budget
+   * every time and a screen that was in fact ready was reported as one the target never reached.
    *
    * Elapsed time is counted in poll intervals rather than read from the clock, so the loop advances
    * with the suspending [delay] instead of spinning against a clock that the caller may be
-   * controlling.
-   *
-   * The deadline is soft by design: it is checked between polls, and a poll is one blocking
-   * [ArbigentDevice.elements] read, so the wait can overrun by at most one hierarchy dump (bounded
-   * by the device's own retry policy). Interrupting a dump midway would leave Maestro's driver in an
+   * controlling. The budget is checked between polls, and a poll is one blocking
+   * [ArbigentDevice.elements] read, so a wait can overrun by at most one hierarchy dump (bounded by
+   * the device's own retry policy). Interrupting a dump midway would leave Maestro's driver in an
    * undefined state, and a step captured a few seconds late is still a correct step.
    */
-  suspend fun awaitSettled(
+  suspend fun awaitReady(
     device: ArbigentDevice,
-    deadlineMillis: Long,
+    budgetMillis: Long,
     isReady: (ArbigentElementList) -> Boolean,
   ): WaitResult {
     var readAtLeastOnce = false
-    val waited = withTimeoutOrNull(deadlineMillis) {
-      var previousSignature: String? = null
-      var waited = 0L
-      while (true) {
-        val elements = readElements(device)
-        if (elements != null) {
-          readAtLeastOnce = true
-          val signature = if (isReady(elements)) signatureOf(elements) else null
-          if (signature != null && signature == previousSignature) break
-          previousSignature = signature
-        } else {
-          // An unreadable poll says nothing about the screen, so the next match has to repeat again.
-          previousSignature = null
-        }
-        delay(POLL_INTERVAL_MILLIS)
-        waited += POLL_INTERVAL_MILLIS
+    var waitedMillis = 0L
+    while (true) {
+      val elements = readElements(device)
+      if (elements != null) {
+        readAtLeastOnce = true
+        if (isReady(elements)) return WaitResult.Ready(waitedMillis)
       }
-      waited
+      if (waitedMillis >= budgetMillis) break
+      val pollMillis = POLL_INTERVAL_MILLIS.coerceAtMost(budgetMillis - waitedMillis)
+      delay(pollMillis)
+      waitedMillis += pollMillis
     }
-    return when {
-      waited != null -> WaitResult.Settled(waited)
-      readAtLeastOnce -> WaitResult.TimedOut
-      else -> WaitResult.Unreadable
-    }
+    return if (readAtLeastOnce) WaitResult.Exhausted else WaitResult.Unreadable
   }
 
   private fun readElements(device: ArbigentDevice): ArbigentElementList? = try {
@@ -95,20 +121,4 @@ internal object ArbigentReplayWait {
     arbigentDebugLog("Replay wait: could not read elements: $exception")
     null
   }
-
-  /**
-   * A cheap stand-in for the current screen. Built from the same element snapshot the readiness
-   * check is made against, because the UI tree string is expensive enough that polling it would
-   * itself slow replay down.
-   *
-   * It covers what an action resolves against: order, text (which Arbigent already reads from the
-   * descendants), resource id, bounds and visibility. A list in which the same elements are still
-   * sliding into place therefore reads as unsettled, while a repaint that changes nothing an action
-   * could see does not hold the replay up.
-   */
-  private fun signatureOf(elements: ArbigentElementList): String =
-    elements.elements.joinToString(separator = "|", prefix = "${elements.elements.size}#") {
-      "${it.rawText}/${it.treeNode.attributes["resource-id"].orEmpty()}" +
-        "@${it.x},${it.y},${it.width},${it.height},${it.isVisible}"
-    }
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayWait.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayWait.kt
@@ -100,7 +100,13 @@ internal object ArbigentReplayWait {
     var readAtLeastOnce = false
     var waitedMillis = 0L
     while (true) {
+      val readStartedAtMillis = TimeProvider.get().currentTimeMillis()
       val elements = readElements(device)
+      // Reading the hierarchy is synchronous and can take a while on a busy device. Charge it to
+      // the budget as well, or a slow read adds itself to every poll and the wait outlasts the
+      // budget it is supposed to fit inside.
+      waitedMillis += (TimeProvider.get().currentTimeMillis() - readStartedAtMillis)
+        .coerceAtLeast(0)
       if (elements != null) {
         readAtLeastOnce = true
         if (isReady(elements)) return WaitResult.Ready(waitedMillis)

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayWait.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayWait.kt
@@ -26,10 +26,25 @@ internal object ArbigentReplayWait {
     return recordedGap.coerceAtMost(MAX_WAIT_MILLIS).coerceAtLeast(MIN_WAIT_MILLIS)
   }
 
+  /** How a wait ended. */
+  sealed interface WaitResult {
+    /** [isReady] held and the screen stopped changing, after [waitedMillis]. */
+    data class Settled(val waitedMillis: Long) : WaitResult
+
+    /** The screen was readable throughout but never settled on what was asked for. */
+    object TimedOut : WaitResult
+
+    /**
+     * The hierarchy could not be read even once. A screen that is merely mid-transition answers at
+     * least one poll, so this says the device could not be driven rather than that the target is
+     * absent, and callers report it as a device failure instead of a divergence.
+     */
+    object Unreadable : WaitResult
+  }
+
   /**
    * Waits until [isReady] holds for the element list and that list stops changing, which is what
-   * "the screen has settled on the recorded target" means without asking the AI. Returns how long
-   * it waited, or null when [deadlineMillis] passed first.
+   * "the screen has settled on the recorded target" means without asking the AI.
    *
    * Elapsed time is counted in poll intervals rather than read from the clock, so the loop advances
    * with the suspending [delay] instead of spinning against a clock that the caller may be
@@ -44,45 +59,56 @@ internal object ArbigentReplayWait {
     device: ArbigentDevice,
     deadlineMillis: Long,
     isReady: (ArbigentElementList) -> Boolean,
-  ): Long? = withTimeoutOrNull(deadlineMillis) {
-    var previousSignature: String? = null
-    var waited = 0L
-    while (true) {
-      val signature = readySignature(device, isReady)
-      if (signature != null && signature == previousSignature) break
-      previousSignature = signature
-      delay(POLL_INTERVAL_MILLIS)
-      waited += POLL_INTERVAL_MILLIS
+  ): WaitResult {
+    var readAtLeastOnce = false
+    val waited = withTimeoutOrNull(deadlineMillis) {
+      var previousSignature: String? = null
+      var waited = 0L
+      while (true) {
+        val elements = readElements(device)
+        if (elements != null) {
+          readAtLeastOnce = true
+          val signature = if (isReady(elements)) signatureOf(elements) else null
+          if (signature != null && signature == previousSignature) break
+          previousSignature = signature
+        } else {
+          // An unreadable poll says nothing about the screen, so the next match has to repeat again.
+          previousSignature = null
+        }
+        delay(POLL_INTERVAL_MILLIS)
+        waited += POLL_INTERVAL_MILLIS
+      }
+      waited
     }
-    waited
+    return when {
+      waited != null -> WaitResult.Settled(waited)
+      readAtLeastOnce -> WaitResult.TimedOut
+      else -> WaitResult.Unreadable
+    }
+  }
+
+  private fun readElements(device: ArbigentDevice): ArbigentElementList? = try {
+    device.elements()
+  } catch (exception: Exception) {
+    // Reading the hierarchy can fail while the screen is mid-transition, which is exactly the state
+    // this waits out. Only a wait in which every single poll failed is treated as a broken device.
+    arbigentDebugLog("Replay wait: could not read elements: $exception")
+    null
   }
 
   /**
-   * A cheap stand-in for the current screen, or null while [isReady] does not hold. Built from the
-   * same element snapshot the readiness check is made against, because the UI tree string is
-   * expensive enough that polling it would itself slow replay down.
+   * A cheap stand-in for the current screen. Built from the same element snapshot the readiness
+   * check is made against, because the UI tree string is expensive enough that polling it would
+   * itself slow replay down.
    *
    * It covers what an action resolves against: order, text (which Arbigent already reads from the
    * descendants), resource id, bounds and visibility. A list in which the same elements are still
    * sliding into place therefore reads as unsettled, while a repaint that changes nothing an action
    * could see does not hold the replay up.
    */
-  private fun readySignature(
-    device: ArbigentDevice,
-    isReady: (ArbigentElementList) -> Boolean,
-  ): String? {
-    val elements = try {
-      device.elements()
-    } catch (exception: Exception) {
-      // Reading the hierarchy can fail while the screen is mid-transition, which is exactly the
-      // state this waits out. Treat it as "not there yet".
-      arbigentDebugLog("Replay wait: could not read elements: $exception")
-      return null
-    }
-    if (!isReady(elements)) return null
-    return elements.elements.joinToString(separator = "|", prefix = "${elements.elements.size}#") {
+  private fun signatureOf(elements: ArbigentElementList): String =
+    elements.elements.joinToString(separator = "|", prefix = "${elements.elements.size}#") {
       "${it.rawText}/${it.treeNode.attributes["resource-id"].orEmpty()}" +
         "@${it.x},${it.y},${it.width},${it.height},${it.isVisible}"
     }
-  }
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayWait.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayWait.kt
@@ -1,0 +1,88 @@
+package io.github.takahirom.arbigent
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.withTimeoutOrNull
+
+/**
+ * Waiting for the screen a recorded step acted on, without asking the AI whether it has arrived.
+ *
+ * Both replay paths need the same rule — the trace replay inside a scenario run
+ * ([ArbigentReplayPacingStepInterceptor]) and `arbigent replay`, which drives a recorded log with no
+ * AI at all — so the deadline, the poll interval and what "settled" means live here rather than in
+ * either caller.
+ */
+internal object ArbigentReplayWait {
+  /** A recorded gap can be pathological (a hiccup while recording); do not inherit it unbounded. */
+  const val MAX_WAIT_MILLIS: Long = 60_000L
+
+  /** A short recorded gap says the recording run was fast, not that the replayed screen will be. */
+  const val MIN_WAIT_MILLIS: Long = 10_000L
+
+  const val POLL_INTERVAL_MILLIS: Long = 500L
+
+  /** How long a wait may take: the recorded gap, never below 10 seconds nor above a minute. */
+  fun deadlineMillis(recordedGapMillis: Long?): Long {
+    val recordedGap = recordedGapMillis ?: return MIN_WAIT_MILLIS
+    return recordedGap.coerceAtMost(MAX_WAIT_MILLIS).coerceAtLeast(MIN_WAIT_MILLIS)
+  }
+
+  /**
+   * Waits until [isReady] holds for the element list and that list stops changing, which is what
+   * "the screen has settled on the recorded target" means without asking the AI. Returns how long
+   * it waited, or null when [deadlineMillis] passed first.
+   *
+   * Elapsed time is counted in poll intervals rather than read from the clock, so the loop advances
+   * with the suspending [delay] instead of spinning against a clock that the caller may be
+   * controlling.
+   *
+   * The deadline is soft by design: it is checked between polls, and a poll is one blocking
+   * [ArbigentDevice.elements] read, so the wait can overrun by at most one hierarchy dump (bounded
+   * by the device's own retry policy). Interrupting a dump midway would leave Maestro's driver in an
+   * undefined state, and a step captured a few seconds late is still a correct step.
+   */
+  suspend fun awaitSettled(
+    device: ArbigentDevice,
+    deadlineMillis: Long,
+    isReady: (ArbigentElementList) -> Boolean,
+  ): Long? = withTimeoutOrNull(deadlineMillis) {
+    var previousSignature: String? = null
+    var waited = 0L
+    while (true) {
+      val signature = readySignature(device, isReady)
+      if (signature != null && signature == previousSignature) break
+      previousSignature = signature
+      delay(POLL_INTERVAL_MILLIS)
+      waited += POLL_INTERVAL_MILLIS
+    }
+    waited
+  }
+
+  /**
+   * A cheap stand-in for the current screen, or null while [isReady] does not hold. Built from the
+   * same element snapshot the readiness check is made against, because the UI tree string is
+   * expensive enough that polling it would itself slow replay down.
+   *
+   * It covers what an action resolves against: order, text (which Arbigent already reads from the
+   * descendants), resource id, bounds and visibility. A list in which the same elements are still
+   * sliding into place therefore reads as unsettled, while a repaint that changes nothing an action
+   * could see does not hold the replay up.
+   */
+  private fun readySignature(
+    device: ArbigentDevice,
+    isReady: (ArbigentElementList) -> Boolean,
+  ): String? {
+    val elements = try {
+      device.elements()
+    } catch (exception: Exception) {
+      // Reading the hierarchy can fail while the screen is mid-transition, which is exactly the
+      // state this waits out. Treat it as "not there yet".
+      arbigentDebugLog("Replay wait: could not read elements: $exception")
+      return null
+    }
+    if (!isReady(elements)) return null
+    return elements.elements.joinToString(separator = "|", prefix = "${elements.elements.size}#") {
+      "${it.rawText}/${it.treeNode.attributes["resource-id"].orEmpty()}" +
+        "@${it.x},${it.y},${it.width},${it.height},${it.isVisible}"
+    }
+  }
+}

--- a/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
@@ -926,6 +926,33 @@ class ArbigentReplayLogTest {
   }
 
   @Test
+  fun `a framing record without a step is refused`() {
+    val text = replayLogText(
+      steps = listOf(TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2)))),
+    ).replace("\"type\":\"scenario_start\",\"task\":\"scenario\",\"taskIndex\":0,\"step\":0,", "\"type\":\"scenario_start\",\"task\":\"scenario\",\"taskIndex\":0,")
+
+    assertRefused(text, "has a record without a step")
+  }
+
+  @Test
+  fun `a framing record without a task index is refused`() {
+    val text = replayLogText(
+      steps = listOf(TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2)))),
+    ).replace("\"type\":\"scenario_end\",\"task\":\"scenario\",\"taskIndex\":0,", "\"type\":\"scenario_end\",\"task\":\"scenario\",")
+
+    assertRefused(text, "step 1 has a record without a taskIndex")
+  }
+
+  @Test
+  fun `a record with a negative step is refused`() {
+    val text = replayLogText(
+      steps = listOf(TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2)))),
+    ).replace("\"type\":\"device\",\"task\":\"scenario\",\"taskIndex\":0,\"step\":1,", "\"type\":\"device\",\"task\":\"scenario\",\"taskIndex\":0,\"step\":-1,")
+
+    assertRefused(text, "has a record with a negative step -1")
+  }
+
+  @Test
   fun `an inverted range is refused`() {
     val log = readLog(
       steps = listOf(

--- a/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
@@ -183,16 +183,75 @@ class ArbigentReplayRunnerTest {
   }
 
   @Test
-  fun `a range that selects nothing is refused`() = runTest {
+  fun `an empty selection is refused before anything is sent`() = runTest {
     val log = readLog(
       steps = listOf(
         TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp = 2))),
       ),
     )
 
-    val reason = runner(log, FakeReplayDevice(listOf(screen()))).verifyReplayable(log.select(step = 9))
+    val reason = runner(log, FakeReplayDevice(listOf(screen()))).verifyReplayable(emptyList())
 
     assertEquals("nothing to replay for the given range", reason)
+  }
+
+  @Test
+  fun `a key this Maestro does not know is refused before anything is sent`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp = 2))),
+        TestStep(number = 2, events = listOf(ArbigentDeviceEvent.KeyPress("NOT_A_KEY", timestamp = 3))),
+      ),
+    )
+    val device = FakeReplayDevice(listOf(screen()))
+
+    val reason = runner(log, device).verifyReplayable(log.select())
+
+    assertNotNull(reason)
+    assertTrue(reason.contains("step 2: the recorded key 'NOT_A_KEY'"), reason)
+    assertEquals(emptyList<String>(), device.commands.map { it.describeForTest() })
+  }
+
+  @Test
+  fun `a screen that can never be read while waiting is a device failure`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(
+          number = 1,
+          target = Attributes(text = "Sign in"),
+          events = listOf(ArbigentDeviceEvent.TapElement(textRegex = "Sign in", timestamp = 2)),
+        ),
+      ),
+    )
+    // Every read throws, so nothing is known about the screen: that is a broken device, not the
+    // recorded target being absent.
+    val device = FakeReplayDevice(listOf(screen()), failElementsAfter = 0)
+
+    val exitCode = runner(log, device).run(log.select())
+
+    assertEquals(ArbigentReplayRunner.EXIT_DEVICE, exitCode)
+    assertEquals(emptyList<String>(), device.commands.map { it.describeForTest() })
+  }
+
+  @Test
+  fun `an end screen that appears late is waited for`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp = 2))),
+      ),
+      signature = listOf("expected-id"),
+    )
+    val device = FakeReplayDevice(
+      listOf(
+        screen(Attributes(resourceId = "somewhere-else")),
+        screen(Attributes(resourceId = "somewhere-else")),
+        screen(Attributes(resourceId = "expected-id")),
+      ),
+    )
+
+    val exitCode = runner(log, device).run(log.select())
+
+    assertEquals(ArbigentReplayRunner.EXIT_OK, exitCode)
   }
 
   @Test
@@ -711,6 +770,27 @@ class ArbigentReplayLogTest {
 
     assertTrue(failure is ArbigentReplayLogException, "$failure")
     assertTrue(failure.message!!.contains("--from 2 is after --until 1"), failure.message!!)
+  }
+
+  @Test
+  fun `a range that selects only setup is refused`() {
+    val log = readLog(steps = threeStepsWithTwoSetups())
+
+    val failure = runCatching { log.select(step = 9, withInit = true) }.exceptionOrNull()
+
+    assertTrue(failure is ArbigentReplayLogException, "$failure")
+    assertTrue(failure.message!!.contains("--step 9 selects no step"), failure.message!!)
+    assertTrue(failure.message!!.contains("steps run 1..3"), failure.message!!)
+  }
+
+  @Test
+  fun `a field of the wrong shape is reported as an unreadable log`() {
+    val text = replayLogText(
+      signature = listOf("expected-id"),
+      steps = listOf(TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2)))),
+    ).replace("\"signature\":[\"expected-id\"]", "\"signature\":{}")
+
+    assertRefused(text, "is not a replay log this arbigent can read")
   }
 
   @Test

--- a/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
@@ -60,6 +60,43 @@ class ArbigentReplayRunnerTest {
   }
 
   @Test
+  fun `a recorded tap index reaches the device exactly as it was recorded`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(
+          number = 1,
+          target = Attributes(text = "Play"),
+          events = listOf(ArbigentDeviceEvent.TapElement(textRegex = "Play", index = 0, timestamp = 2)),
+        ),
+        TestStep(
+          number = 2,
+          target = Attributes(text = "Play"),
+          events = listOf(ArbigentDeviceEvent.TapElement(textRegex = "Play", index = 2, timestamp = 3)),
+        ),
+        TestStep(
+          number = 3,
+          target = Attributes(text = "Play"),
+          events = listOf(ArbigentDeviceEvent.TapElement(textRegex = "Play", timestamp = 4)),
+        ),
+      ),
+      signature = listOf("player"),
+    )
+    val device = FakeReplayDevice(
+      listOf(screen(Attributes(text = "Play"), Attributes(resourceId = "player"))),
+    )
+
+    val exitCode = runner(log, device).run(log.select(withInit = true))
+
+    assertEquals(ArbigentReplayRunner.EXIT_OK, exitCode)
+    // Maestro reads a missing index as "the first clickable match" and any explicit index as a
+    // plain position, so an index of 0 must not be dropped on the way to the device.
+    assertEquals(
+      listOf("0", "2", null),
+      device.commands.map { it.tapOnElement!!.selector.index },
+    )
+  }
+
+  @Test
   fun `a target that appears late is waited for`() = runTest {
     val log = readLog(
       steps = listOf(
@@ -791,6 +828,22 @@ class ArbigentReplayLogTest {
     ).replace("\"signature\":[\"expected-id\"]", "\"signature\":{}")
 
     assertRefused(text, "is not a replay log this arbigent can read")
+  }
+
+  @Test
+  fun `a device record without an event is refused`() {
+    val lines = replayLogText(
+      steps = listOf(
+        TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2))),
+        TestStep(number = 2, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 3))),
+      ),
+    ).trim().lines().toMutableList()
+    val deviceLine = lines.indexOfLast { it.contains("\"type\":\"device\"") }
+    lines[deviceLine] = lines[deviceLine].substringBefore(",\"event\":") + "}"
+
+    // Replaying the surrounding steps and reporting success would leave a hole in the middle of
+    // the run, so the log is refused before anything reaches the device.
+    assertRefused(lines.joinToString(separator = "\n", postfix = "\n"), "step 2 has a device record without an event")
   }
 
   @Test

--- a/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
@@ -99,6 +99,40 @@ class ArbigentReplayRunnerTest {
   }
 
   @Test
+  fun `a recorded tap retry reaches the device exactly as it was recorded`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(
+          number = 1,
+          target = Attributes(text = "Play"),
+          events = listOf(
+            ArbigentDeviceEvent.TapElement(textRegex = "Play", retryIfNoChange = true, timestamp = 2),
+          ),
+        ),
+        TestStep(
+          number = 2,
+          target = Attributes(text = "Play"),
+          events = listOf(ArbigentDeviceEvent.TapElement(textRegex = "Play", timestamp = 3)),
+        ),
+      ),
+      signature = listOf("player"),
+    )
+    val device = FakeReplayDevice(
+      listOf(screen(Attributes(text = "Play"), Attributes(resourceId = "player"))),
+    )
+
+    val exitCode = runner(log, device).run(log.select(withInit = true))
+
+    assertEquals(ArbigentReplayRunner.EXIT_OK, exitCode)
+    // A tap the recording gave two attempts must get two here too, and one that asked for nothing
+    // must stay unset so Maestro applies its own default rather than a frozen copy of it.
+    assertEquals(
+      listOf(true, null),
+      device.commands.map { it.tapOnElement!!.retryIfNoChange },
+    )
+  }
+
+  @Test
   fun `a target that appears late is waited for`() = runTest {
     val log = readLog(
       steps = listOf(

--- a/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
@@ -1,0 +1,774 @@
+package io.github.takahirom.arbigent.sample.test
+
+import io.github.takahirom.arbigent.ArbigentDevice
+import io.github.takahirom.arbigent.ArbigentDeviceEvent
+import io.github.takahirom.arbigent.ArbigentDeviceOs
+import io.github.takahirom.arbigent.ArbigentElement
+import io.github.takahirom.arbigent.ArbigentElementList
+import io.github.takahirom.arbigent.ArbigentReplayLog
+import io.github.takahirom.arbigent.ArbigentReplayLogException
+import io.github.takahirom.arbigent.ArbigentReplayRunner
+import io.github.takahirom.arbigent.result.ArbigentUiTreeStrings
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import maestro.KeyCode
+import maestro.TreeNode
+import maestro.orchestra.MaestroCommand
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * The replay runner drives a recorded log with no AI, so these tests pin the two things a caller
+ * branches on: which commands reach the device, and which exit code comes back.
+ */
+class ArbigentReplayRunnerTest {
+  @Test
+  fun `the recorded events are sent in the order they were recorded`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(number = 0, events = listOf(ArbigentDeviceEvent.LaunchApp("app.id", timestamp = 1))),
+        TestStep(
+          number = 1,
+          target = Attributes(text = "Sign in"),
+          events = listOf(ArbigentDeviceEvent.TapElement(textRegex = "Sign in", timestamp = 2)),
+        ),
+        TestStep(
+          number = 2,
+          target = Attributes(resourceId = "home"),
+          events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.ENTER.name, timestamp = 3)),
+        ),
+      ),
+      signature = listOf("home"),
+    )
+    val device = FakeReplayDevice(listOf(screen(Attributes(text = "Sign in"), Attributes(resourceId = "home"))))
+    val runner = runner(log, device)
+
+    assertNull(runner.verifyReplayable(log.select(withInit = true)))
+    val exitCode = runner.run(log.select(withInit = true))
+
+    assertEquals(ArbigentReplayRunner.EXIT_OK, exitCode)
+    assertEquals(
+      listOf("launch app.id", "tap Sign in", "press ENTER"),
+      device.commands.map { it.describeForTest() },
+    )
+  }
+
+  @Test
+  fun `a target that appears late is waited for`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(
+          number = 1,
+          target = Attributes(text = "Later"),
+          events = listOf(ArbigentDeviceEvent.TapElement(textRegex = "Later", timestamp = 2)),
+        ),
+      ),
+    )
+    val device = FakeReplayDevice(
+      listOf(
+        screen(),
+        screen(),
+        screen(Attributes(text = "Later")),
+        screen(Attributes(text = "Later")),
+      ),
+    )
+
+    val exitCode = runner(log, device).run(log.select())
+
+    assertEquals(ArbigentReplayRunner.EXIT_OK, exitCode)
+    assertEquals(listOf("tap Later"), device.commands.map { it.describeForTest() })
+    assertTrue(device.elementReads >= 4, "expected the runner to poll the screen, read ${device.elementReads} times")
+  }
+
+  @Test
+  fun `a target that never appears diverges without sending the step`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(
+          number = 1,
+          target = Attributes(text = "Never"),
+          events = listOf(ArbigentDeviceEvent.TapElement(textRegex = "Never", timestamp = 2)),
+        ),
+      ),
+    )
+    val device = FakeReplayDevice(listOf(screen(Attributes(text = "Something else"))))
+    val err = StringBuilder()
+
+    val exitCode = runner(log, device, err = err).run(log.select())
+
+    assertEquals(ArbigentReplayRunner.EXIT_DIVERGED, exitCode)
+    assertEquals(emptyList<String>(), device.commands.map { it.describeForTest() })
+    assertTrue(err.contains("DIVERGED"), err.toString())
+    assertTrue(err.contains("the target never appeared"), err.toString())
+    assertTrue(err.contains("resume with: arbigent replay <log> --from 1"), err.toString())
+  }
+
+  @Test
+  fun `an element the recording tapped that is gone diverges`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(
+          number = 1,
+          events = listOf(ArbigentDeviceEvent.TapElement(textRegex = "Gone", timestamp = 2)),
+        ),
+      ),
+    )
+    val device = FakeReplayDevice(
+      listOf(screen()),
+      failExecuteWith = { maestro.MaestroException.ElementNotFound("not found", TreeNode(), "not found") },
+    )
+
+    val exitCode = runner(log, device).run(log.select())
+
+    assertEquals(ArbigentReplayRunner.EXIT_DIVERGED, exitCode)
+  }
+
+  @Test
+  fun `a device that cannot be driven reports a device failure`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp = 2))),
+      ),
+    )
+    val device = FakeReplayDevice(
+      listOf(screen()),
+      failExecuteWith = { java.io.IOException("adb is gone") },
+    )
+    val err = StringBuilder()
+
+    val exitCode = runner(log, device, err = err).run(log.select())
+
+    assertEquals(ArbigentReplayRunner.EXIT_DEVICE, exitCode)
+    assertTrue(err.contains("adb is gone"), err.toString())
+  }
+
+  @Test
+  fun `a log recorded on another platform is refused before anything is sent`() = runTest {
+    val log = readLog(
+      platform = "ios",
+      steps = listOf(
+        TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp = 2))),
+      ),
+    )
+    val device = FakeReplayDevice(listOf(screen()), os = ArbigentDeviceOs.Android)
+
+    val reason = runner(log, device).verifyReplayable(log.select())
+
+    assertNotNull(reason)
+    assertTrue(reason.contains("recorded on ios"), reason)
+    assertEquals(emptyList<String>(), device.commands.map { it.describeForTest() })
+  }
+
+  @Test
+  fun `a command the replay cannot reproduce is refused before anything is sent`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp = 2))),
+        TestStep(number = 2, events = listOf(ArbigentDeviceEvent.Unsupported("hideKeyboard", timestamp = 3))),
+      ),
+    )
+    val device = FakeReplayDevice(listOf(screen()))
+
+    val reason = runner(log, device).verifyReplayable(log.select())
+
+    assertNotNull(reason)
+    assertTrue(reason.contains("step 2: hideKeyboard"), reason)
+    assertEquals(emptyList<String>(), device.commands.map { it.describeForTest() })
+  }
+
+  @Test
+  fun `a range that selects nothing is refused`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp = 2))),
+      ),
+    )
+
+    val reason = runner(log, FakeReplayDevice(listOf(screen()))).verifyReplayable(log.select(step = 9))
+
+    assertEquals("nothing to replay for the given range", reason)
+  }
+
+  @Test
+  fun `a tap recorded on a bigger screen is scaled to this one`() = runTest {
+    val log = readLog(
+      width = 1000,
+      height = 2000,
+      steps = listOf(
+        TestStep(number = 1, events = listOf(ArbigentDeviceEvent.Tap(500, 1000, timestamp = 2))),
+      ),
+    )
+    val device = FakeReplayDevice(listOf(screen(width = 500, height = 1000)))
+
+    val exitCode = runner(log, device).run(log.select())
+
+    assertEquals(ArbigentReplayRunner.EXIT_OK, exitCode)
+    assertEquals(listOf("tap 250,500"), device.commands.map { it.describeForTest() })
+  }
+
+  @Test
+  fun `a tap recorded on this screen size is sent unchanged`() = runTest {
+    val log = readLog(
+      width = 1000,
+      height = 2000,
+      steps = listOf(
+        TestStep(number = 1, events = listOf(ArbigentDeviceEvent.Tap(500, 1000, timestamp = 2))),
+      ),
+    )
+    val device = FakeReplayDevice(listOf(screen(width = 1000, height = 2000)))
+
+    runner(log, device).run(log.select())
+
+    assertEquals(listOf("tap 500,1000"), device.commands.map { it.describeForTest() })
+  }
+
+  @Test
+  fun `an end screen with none of the recorded ids diverges`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp = 2))),
+      ),
+      signature = listOf("expected-id"),
+    )
+    val device = FakeReplayDevice(listOf(screen(Attributes(resourceId = "somewhere-else"))))
+    val err = StringBuilder()
+
+    val exitCode = runner(log, device, err = err).run(log.select())
+
+    assertEquals(ArbigentReplayRunner.EXIT_DIVERGED, exitCode)
+    assertTrue(err.contains("none of the recorded end-screen ids"), err.toString())
+  }
+
+  @Test
+  fun `a partial replay is not judged against the recorded end screen`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp = 2))),
+        TestStep(number = 2, events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.ENTER.name, timestamp = 3))),
+      ),
+      signature = listOf("expected-id"),
+    )
+    val device = FakeReplayDevice(listOf(screen(Attributes(resourceId = "somewhere-else"))))
+
+    val exitCode = runner(log, device).run(log.select(step = 1))
+
+    assertEquals(ArbigentReplayRunner.EXIT_OK, exitCode)
+  }
+
+  @Test
+  fun `a screen that cannot be read at the end is a device failure`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp = 2))),
+      ),
+      signature = listOf("expected-id"),
+    )
+    val device = FakeReplayDevice(listOf(screen()), failElementsAfter = 0)
+
+    val exitCode = runner(log, device).run(log.select())
+
+    assertEquals(ArbigentReplayRunner.EXIT_DEVICE, exitCode)
+  }
+
+  @Test
+  fun `a step without a target waits for one of the recorded screen hints`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(
+          number = 1,
+          screen = listOf(Attributes(text = "Feed"), Attributes(resourceId = "list")),
+          events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp = 2)),
+        ),
+      ),
+    )
+    val device = FakeReplayDevice(
+      listOf(screen(), screen(Attributes(resourceId = "list")), screen(Attributes(resourceId = "list"))),
+    )
+
+    val exitCode = runner(log, device).run(log.select())
+
+    assertEquals(ArbigentReplayRunner.EXIT_OK, exitCode)
+    assertEquals(listOf("press BACK"), device.commands.map { it.describeForTest() })
+  }
+
+  @Test
+  fun `screen hints that never appear only warn`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(
+          number = 1,
+          screen = listOf(Attributes(text = "Feed")),
+          events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp = 2)),
+        ),
+      ),
+    )
+    val device = FakeReplayDevice(listOf(screen(Attributes(text = "Nothing like it"))))
+    val err = StringBuilder()
+
+    val exitCode = runner(log, device, err = err).run(log.select())
+
+    assertEquals(ArbigentReplayRunner.EXIT_OK, exitCode)
+    assertEquals(listOf("press BACK"), device.commands.map { it.describeForTest() })
+    assertTrue(err.contains("none of the recorded screen hints appeared"), err.toString())
+  }
+
+  @Test
+  fun `no-wait sends every step without polling the screen`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(
+          number = 1,
+          target = Attributes(text = "Never"),
+          events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp = 2)),
+        ),
+      ),
+    )
+    val device = FakeReplayDevice(listOf(screen()))
+
+    val exitCode = runner(log, device, waitForScreens = false).run(log.select())
+
+    assertEquals(ArbigentReplayRunner.EXIT_OK, exitCode)
+    assertEquals(listOf("press BACK"), device.commands.map { it.describeForTest() })
+  }
+
+  @Test
+  fun `a recorded wait does not reach the device`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(
+          number = 1,
+          events = listOf(
+            ArbigentDeviceEvent.Wait(2_000, timestamp = 2),
+            ArbigentDeviceEvent.KeyPress(KeyCode.BACK.name, timestamp = 3),
+          ),
+        ),
+      ),
+    )
+    val device = FakeReplayDevice(listOf(screen()))
+
+    runner(log, device).run(log.select())
+
+    assertEquals(listOf("press BACK"), device.commands.map { it.describeForTest() })
+  }
+
+  @Test
+  fun `showing a log needs no device`() {
+    val log = readLog(
+      steps = listOf(
+        TestStep(number = 0, events = listOf(ArbigentDeviceEvent.LaunchApp("app.id", timestamp = 1))),
+        TestStep(
+          number = 1,
+          target = Attributes(text = "Sign in"),
+          events = listOf(ArbigentDeviceEvent.TapElement(textRegex = "Sign in", timestamp = 2)),
+        ),
+      ),
+      signature = listOf("home"),
+    )
+    val out = StringBuilder()
+
+    ArbigentReplayRunner.show(log, log.select(withInit = true), out)
+
+    val text = out.toString()
+    assertTrue(text.contains("launch app.id"), text)
+    assertTrue(text.contains("tap on text='Sign in'"), text)
+    assertTrue(text.contains("expect: resource ids home"), text)
+  }
+
+  @Test
+  fun `launch arguments reach the device with their recorded types`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(
+          number = 0,
+          events = listOf(
+            ArbigentDeviceEvent.LaunchApp(
+              appId = "app.id",
+              launchArguments = mapOf(
+                "flag" to JsonPrimitive(true),
+                "count" to JsonPrimitive(3),
+                "name" to JsonPrimitive("x"),
+              ),
+              timestamp = 1,
+            ),
+          ),
+        ),
+        TestStep(
+          number = 1,
+          target = Attributes(resourceId = "home"),
+          events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.ENTER.name, timestamp = 2)),
+        ),
+      ),
+      signature = listOf("home"),
+    )
+    val device = FakeReplayDevice(listOf(screen(Attributes(resourceId = "home"))))
+
+    val exitCode = runner(log, device).run(log.select(withInit = true))
+
+    assertEquals(ArbigentReplayRunner.EXIT_OK, exitCode)
+    // A boolean has to stay a boolean and a number a number, because an app reading an extra by
+    // type does not see a quoted "true".
+    val launch = device.commands.first().launchAppCommand
+    assertEquals(
+      mapOf("flag" to true, "count" to 3, "name" to "x"),
+      launch?.launchArguments,
+    )
+  }
+
+  private fun runner(
+    log: ArbigentReplayLog,
+    device: ArbigentDevice,
+    out: Appendable = StringBuilder(),
+    err: Appendable = StringBuilder(),
+    waitForScreens: Boolean = true,
+  ) = ArbigentReplayRunner(log, device, out, err, waitForScreens)
+}
+
+/** Element attributes a test cares about: what an identity is matched on. */
+internal data class Attributes(
+  val text: String? = null,
+  val resourceId: String? = null,
+  val accessibilityId: String? = null,
+)
+
+internal data class TestStep(
+  val number: Int,
+  val target: Attributes? = null,
+  val screen: List<Attributes> = emptyList(),
+  val events: List<ArbigentDeviceEvent> = emptyList(),
+) {
+  val isInit: Boolean get() = number == 0
+}
+
+/**
+ * A device whose screens are scripted: [screens] is consumed one entry per read, and the last entry
+ * repeats, so a test says "absent, absent, then there" without counting the runner's polls.
+ */
+internal class FakeReplayDevice(
+  private val screens: List<ArbigentElementList>,
+  private val failExecuteWith: (() -> Throwable)? = null,
+  /** Reads beyond this many throw, for the case where the hierarchy stops being readable. */
+  private val failElementsAfter: Int? = null,
+  private val os: ArbigentDeviceOs = ArbigentDeviceOs.Android,
+) : ArbigentDevice {
+  val commands: MutableList<MaestroCommand> = mutableListOf()
+  var elementReads: Int = 0
+    private set
+
+  override fun executeActions(actions: List<MaestroCommand>) {
+    failExecuteWith?.let { throw it() }
+    commands += actions
+  }
+
+  override fun elements(): ArbigentElementList {
+    elementReads++
+    failElementsAfter?.let { limit ->
+      if (elementReads > limit) throw java.io.IOException("the hierarchy cannot be read")
+    }
+    return screens[minOf(elementReads - 1, screens.size - 1)]
+  }
+
+  override fun os(): ArbigentDeviceOs = os
+  override fun viewTreeString(): ArbigentUiTreeStrings = ArbigentUiTreeStrings("", "")
+  override fun focusedTreeString(): String = ""
+  override fun waitForAppToSettle(appId: String?) = Unit
+  override fun close() = Unit
+  override fun isClosed(): Boolean = false
+}
+
+internal fun screen(
+  vararg elements: Attributes,
+  width: Int = 1000,
+  height: Int = 2000,
+): ArbigentElementList = ArbigentElementList(
+  elements = elements.mapIndexed { index, attributes ->
+    ArbigentElement(
+      index = index,
+      textForAI = attributes.text.orEmpty(),
+      rawText = attributes.text.orEmpty(),
+      identifierData = ArbigentElement.IdentifierData(emptyList(), index),
+      treeNode = TreeNode(
+        attributes = mutableMapOf<String, String>().apply {
+          attributes.text?.let { put("text", it) }
+          attributes.resourceId?.let { put("resource-id", it) }
+          attributes.accessibilityId?.let { put("content-desc", it) }
+        },
+      ),
+      x = 0,
+      y = index * 100,
+      width = 100,
+      height = 100,
+      isVisible = true,
+    )
+  },
+  screenWidth = width,
+  screenHeight = height,
+)
+
+private val testJson = Json { encodeDefaults = true }
+
+/**
+ * The jsonl a recorded run would have written for [steps], read back through the real reader, so a
+ * test exercises the same parsing a replay does.
+ */
+internal fun readLog(
+  scenarioId: String = "scenario",
+  platform: String = "android",
+  schemaVersion: Int = 1,
+  goal: String = "reach the screen",
+  width: Int? = null,
+  height: Int? = null,
+  signature: List<String> = emptyList(),
+  steps: List<TestStep>,
+  status: String = "success",
+  includeEnd: Boolean = true,
+): ArbigentReplayLog = ArbigentReplayLog.parse(
+  replayLogText(scenarioId, platform, schemaVersion, goal, width, height, signature, steps, status, includeEnd),
+  "test.jsonl",
+)
+
+internal fun replayLogText(
+  scenarioId: String = "scenario",
+  platform: String = "android",
+  schemaVersion: Int = 1,
+  goal: String = "reach the screen",
+  width: Int? = null,
+  height: Int? = null,
+  signature: List<String> = emptyList(),
+  steps: List<TestStep> = emptyList(),
+  status: String = "success",
+  includeEnd: Boolean = true,
+): String {
+  val lines = mutableListOf<String>()
+  lines += buildJsonObject {
+    put("type", "scenario_start")
+    put("task", scenarioId)
+    put("taskIndex", 0)
+    put("step", 0)
+    put("ts", 1)
+    put("schemaVersion", schemaVersion)
+    put("platform", platform)
+    put("goal", goal)
+    width?.let { put("width", it) }
+    height?.let { put("height", it) }
+  }.toString()
+  steps.forEach { step ->
+    if (!step.isInit) {
+      lines += buildJsonObject {
+        put("type", "decision")
+        put("task", scenarioId)
+        put("taskIndex", 0)
+        put("step", step.number)
+        put("ts", step.events.firstOrNull()?.timestamp ?: 1L)
+        put("action", "Click")
+        put("log", "step ${step.number}")
+        put("goal", goal)
+        if (step.screen.isNotEmpty()) {
+          put(
+            "screen",
+            kotlinx.serialization.json.buildJsonArray {
+              step.screen.forEach { hint -> add(hint.toJsonObject()) }
+            },
+          )
+        }
+      }.toString()
+      step.target?.let { target ->
+        lines += buildJsonObject {
+          put("type", "target")
+          put("task", scenarioId)
+          put("taskIndex", 0)
+          put("step", step.number)
+          put("ts", step.events.firstOrNull()?.timestamp ?: 1L)
+          target.text?.let { put("text", it) }
+          target.resourceId?.let { put("resourceId", it) }
+          target.accessibilityId?.let { put("accessibilityId", it) }
+          put("occurrence", 0)
+        }.toString()
+      }
+    }
+    step.events.forEach { event ->
+      lines += buildJsonObject {
+        put("type", if (step.isInit) "init" else "device")
+        put("task", scenarioId)
+        put("taskIndex", 0)
+        put("step", step.number)
+        put("ts", event.timestamp)
+        put("event", testJson.encodeToJsonElement(ArbigentDeviceEvent.serializer(), event))
+      }.toString()
+    }
+  }
+  if (includeEnd) {
+    lines += buildJsonObject {
+      put("type", "scenario_end")
+      put("task", scenarioId)
+      put("taskIndex", 0)
+      put("step", steps.lastOrNull()?.number ?: 0)
+      put("ts", 99)
+      put("status", status)
+      put(
+        "signature",
+        kotlinx.serialization.json.buildJsonArray { signature.forEach { add(kotlinx.serialization.json.JsonPrimitive(it)) } },
+      )
+    }.toString()
+  }
+  return lines.joinToString(separator = "\n", postfix = "\n")
+}
+
+private fun Attributes.toJsonObject() = buildJsonObject {
+  text?.let { put("text", it) }
+  resourceId?.let { put("resourceId", it) }
+  accessibilityId?.let { put("accessibilityId", it) }
+}
+
+/** What a command does, in the shortest form a test can assert on. */
+internal fun MaestroCommand.describeForTest(): String = when {
+  launchAppCommand != null -> "launch ${launchAppCommand!!.appId}"
+  stopAppCommand != null -> "stop ${stopAppCommand!!.appId}"
+  clearStateCommand != null -> "clearState ${clearStateCommand!!.appId}"
+  openLinkCommand != null -> "openLink ${openLinkCommand!!.link}"
+  tapOnElement != null -> "tap ${tapOnElement!!.selector.textRegex ?: tapOnElement!!.selector.idRegex}"
+  tapOnPointV2Command != null -> "tap ${tapOnPointV2Command!!.point}"
+  pressKeyCommand != null -> "press ${pressKeyCommand!!.code.name}"
+  inputTextCommand != null -> "inputText ${inputTextCommand!!.text}"
+  swipeCommand != null -> "swipe ${swipeCommand!!.startPoint} -> ${swipeCommand!!.endPoint}"
+  else -> toString()
+}
+
+/** Assertions about which logs the reader refuses, and why. */
+class ArbigentReplayLogTest {
+  @Test
+  fun `a log that does not end with a successful run is refused`() {
+    val text = replayLogText(
+      steps = listOf(TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2)))),
+      includeEnd = false,
+    )
+
+    assertRefused(text, "does not end with a successful scenario_end")
+  }
+
+  @Test
+  fun `a failed run is refused`() {
+    val text = replayLogText(
+      steps = listOf(TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2)))),
+      status = "failed",
+    )
+
+    assertRefused(text, "does not end with a successful scenario_end")
+  }
+
+  @Test
+  fun `two runs in one file are refused`() {
+    val single = replayLogText(
+      steps = listOf(TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2)))),
+    )
+
+    assertRefused(single + single, "more than one scenario_start line")
+  }
+
+  @Test
+  fun `a file mixing two scenarios is refused`() {
+    val text = replayLogText(
+      steps = listOf(TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2)))),
+    ).replace("\"task\":\"scenario\",\"taskIndex\":0,\"step\":1", "\"task\":\"other\",\"taskIndex\":0,\"step\":1")
+
+    assertRefused(text, "mixes lines from scenarios")
+  }
+
+  @Test
+  fun `a log written by a newer schema is refused`() {
+    val text = replayLogText(
+      schemaVersion = 99,
+      steps = listOf(TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2)))),
+    )
+
+    assertRefused(text, "declares schema version 99")
+  }
+
+  @Test
+  fun `a log without a platform is refused`() {
+    val text = replayLogText(
+      steps = listOf(TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2)))),
+    ).replace("\"platform\":\"android\",", "")
+
+    assertRefused(text, "does not declare a platform")
+  }
+
+  @Test
+  fun `an inverted range is refused`() {
+    val log = readLog(
+      steps = listOf(
+        TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2))),
+        TestStep(number = 2, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 3))),
+      ),
+    )
+
+    val failure = runCatching { log.select(from = 2, until = 1) }.exceptionOrNull()
+
+    assertTrue(failure is ArbigentReplayLogException, "$failure")
+    assertTrue(failure.message!!.contains("--from 2 is after --until 1"), failure.message!!)
+  }
+
+  @Test
+  fun `a step number below one is refused`() {
+    val log = readLog(
+      steps = listOf(TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2)))),
+    )
+
+    val failure = runCatching { log.select(step = 0) }.exceptionOrNull()
+
+    assertTrue(failure is ArbigentReplayLogException, "$failure")
+  }
+
+  @Test
+  fun `a single step is selected with the setup that prepared it`() {
+    val log = readLog(steps = threeStepsWithTwoSetups())
+
+    val selected = log.select(step = 2, withInit = true)
+
+    assertEquals(listOf(0, 0, 2), selected.map { it.number })
+  }
+
+  @Test
+  fun `a single step without with-init leaves the setup out`() {
+    val log = readLog(steps = threeStepsWithTwoSetups())
+
+    val selected = log.select(step = 2)
+
+    assertEquals(listOf(2), selected.map { it.number })
+  }
+
+  @Test
+  fun `a from range keeps the setup that preceded the first step it replays`() {
+    val log = readLog(steps = threeStepsWithTwoSetups())
+
+    val selected = log.select(from = 3, withInit = true)
+
+    assertEquals(listOf(0, 3), selected.map { it.number })
+  }
+
+  /**
+   * A run whose second task relaunched the app: two setup blocks, the second in the middle. The
+   * middle block belongs to step 2, which is the step it prepared.
+   */
+  private fun threeStepsWithTwoSetups(): List<TestStep> = listOf(
+    TestStep(number = 0, events = listOf(ArbigentDeviceEvent.LaunchApp("app.id", timestamp = 1))),
+    TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2))),
+    TestStep(number = 0, events = listOf(ArbigentDeviceEvent.LaunchApp("app.id", timestamp = 3))),
+    TestStep(number = 2, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 4))),
+    TestStep(number = 3, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 5))),
+  )
+
+  private fun assertRefused(text: String, expectedMessage: String) {
+    val failure = runCatching { ArbigentReplayLog.parse(text, "test.jsonl") }.exceptionOrNull()
+    assertTrue(failure is ArbigentReplayLogException, "expected a refusal but got $failure")
+    assertTrue(
+      failure.message!!.contains(expectedMessage),
+      "expected '$expectedMessage' in: ${failure.message}",
+    )
+  }
+}

--- a/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
@@ -112,7 +112,6 @@ class ArbigentReplayRunnerTest {
         screen(),
         screen(),
         screen(Attributes(text = "Later")),
-        screen(Attributes(text = "Later")),
       ),
     )
 
@@ -120,7 +119,7 @@ class ArbigentReplayRunnerTest {
 
     assertEquals(ArbigentReplayRunner.EXIT_OK, exitCode)
     assertEquals(listOf("tap Later"), device.commands.map { it.describeForTest() })
-    assertTrue(device.elementReads >= 4, "expected the runner to poll the screen, read ${device.elementReads} times")
+    assertTrue(device.elementReads >= 3, "expected the runner to poll the screen, read ${device.elementReads} times")
   }
 
   @Test

--- a/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
@@ -908,6 +908,24 @@ class ArbigentReplayLogTest {
   }
 
   @Test
+  fun `a record without a step is refused`() {
+    val text = replayLogText(
+      steps = listOf(TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2)))),
+    ).replace("\"type\":\"device\",\"task\":\"scenario\",\"taskIndex\":0,\"step\":1,", "\"type\":\"device\",\"task\":\"scenario\",\"taskIndex\":0,")
+
+    assertRefused(text, "has a record without a step")
+  }
+
+  @Test
+  fun `a record without a task index is refused`() {
+    val text = replayLogText(
+      steps = listOf(TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2)))),
+    ).replace("\"type\":\"device\",\"task\":\"scenario\",\"taskIndex\":0,", "\"type\":\"device\",\"task\":\"scenario\",")
+
+    assertRefused(text, "step 1 has a record without a taskIndex")
+  }
+
+  @Test
   fun `an inverted range is refused`() {
     val log = readLog(
       steps = listOf(

--- a/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
@@ -953,6 +953,15 @@ class ArbigentReplayLogTest {
   }
 
   @Test
+  fun `a record with a negative task index is refused`() {
+    val text = replayLogText(
+      steps = listOf(TestStep(number = 1, events = listOf(ArbigentDeviceEvent.KeyPress("BACK", timestamp = 2)))),
+    ).replace("\"type\":\"device\",\"task\":\"scenario\",\"taskIndex\":0,\"step\":1,", "\"type\":\"device\",\"task\":\"scenario\",\"taskIndex\":-1,\"step\":1,")
+
+    assertRefused(text, "step 1 has a record with a negative taskIndex -1")
+  }
+
+  @Test
   fun `an inverted range is refused`() {
     val log = readLog(
       steps = listOf(

--- a/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayRunnerTest.kt
@@ -17,6 +17,8 @@ import kotlinx.serialization.json.put
 import maestro.KeyCode
 import maestro.TreeNode
 import maestro.orchestra.MaestroCommand
+import kotlin.test.assertFailsWith
+import io.github.takahirom.arbigent.ArbigentReplayWait
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
@@ -450,6 +452,84 @@ class ArbigentReplayRunnerTest {
     runner(log, device).run(log.select())
 
     assertEquals(listOf("press BACK"), device.commands.map { it.describeForTest() })
+  }
+
+  @Test
+  fun `a step with neither a target nor a screen hint is still paced`() = runTest {
+    val scheduler = testScheduler
+    val log = readLog(
+      steps = listOf(
+        TestStep(
+          number = 1,
+          events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.ENTER.name, timestamp = 2)),
+        ),
+      ),
+    )
+    val device = FakeReplayDevice(listOf(screen()))
+    val out = StringBuilder()
+    val startedAt = scheduler.currentTime
+
+    val exitCode = runner(log, device, out = out).run(log.select())
+
+    assertEquals(ArbigentReplayRunner.EXIT_OK, exitCode)
+    // An opaque screen records no target and no hints, and without pacing this one step would be
+    // the only one sent the instant the previous action returned.
+    assertEquals(0, device.elementReads, "there is nothing on the screen to poll for")
+    assertTrue(
+      scheduler.currentTime - startedAt >= ArbigentReplayWait.MIN_WAIT_MILLIS,
+      "the step should have waited out its budget, waited ${scheduler.currentTime - startedAt}ms",
+    )
+    assertTrue(out.contains("nothing recorded to wait for"), out.toString())
+  }
+
+  @Test
+  fun `a launch replays the permissions and keychain reset it recorded`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(
+          number = 0,
+          events = listOf(
+            ArbigentDeviceEvent.LaunchApp(
+              appId = "app.id",
+              permissions = mapOf("all" to "deny"),
+              clearKeychain = true,
+              timestamp = 1,
+            ),
+          ),
+        ),
+        TestStep(
+          number = 1,
+          target = Attributes(resourceId = "home"),
+          events = listOf(ArbigentDeviceEvent.KeyPress(KeyCode.ENTER.name, timestamp = 2)),
+        ),
+      ),
+    )
+    val device = FakeReplayDevice(listOf(screen(Attributes(resourceId = "home"))))
+
+    runner(log, device).run(log.select(withInit = true))
+
+    val launch = device.commands.first().launchAppCommand
+    assertEquals(mapOf("all" to "deny"), launch?.permissions)
+    assertEquals(true, launch?.clearKeychain)
+  }
+
+  @Test
+  fun `a log whose setup was the whole run replays that setup`() = runTest {
+    val log = readLog(
+      steps = listOf(
+        TestStep(number = 0, events = listOf(ArbigentDeviceEvent.LaunchApp("app.id", timestamp = 1))),
+      ),
+    )
+    val device = FakeReplayDevice(listOf(screen()))
+
+    // The app launched straight onto the goal screen, so the run recorded setup and nothing else.
+    // Its own markdown prints `replay <log> --with-init`, which has to work.
+    val exitCode = runner(log, device).run(log.select(withInit = true))
+
+    assertEquals(ArbigentReplayRunner.EXIT_OK, exitCode)
+    assertEquals(listOf("launch app.id"), device.commands.map { it.describeForTest() })
+    val failure = assertFailsWith<ArbigentReplayLogException> { log.select() }
+    assertTrue(failure.message!!.contains("--with-init"), failure.message!!)
   }
 
   @Test

--- a/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
+++ b/arbigent-core/src/test/java/ArbigentReplayScriptTest.kt
@@ -8,6 +8,7 @@ import io.github.takahirom.arbigent.ArbigentDeviceOs
 import io.github.takahirom.arbigent.ArbigentElement
 import io.github.takahirom.arbigent.ArbigentElementIdentity
 import io.github.takahirom.arbigent.ArbigentExecuteActionsInterceptor
+import io.github.takahirom.arbigent.ArbigentReplayLog
 import io.github.takahirom.arbigent.ArbigentReplayScriptRecorder
 import io.github.takahirom.arbigent.ArbigentReplayScriptWriter
 import io.github.takahirom.arbigent.GoalAchievedAgentAction
@@ -463,5 +464,70 @@ class ArbigentReplayScriptExecutorTest {
     override fun decideAgentActions(
       decisionInput: ArbigentAi.DecisionInput,
     ): ArbigentAi.DecisionOutput = createDecisionOutput()
+  }
+}
+
+/**
+ * The recorder writes the jsonl log and `arbigent replay` reads it back, so the two sides agreeing
+ * about key names and nesting is the only thing that makes a recorded run replayable at all. These
+ * drive the real writer and parse its file with the real reader, so a rename on either side fails
+ * here rather than on a device.
+ */
+class ArbigentReplayLogRoundTripTest {
+  @Test
+  fun `a written log reads back with its setup, target and end screen`() = runTest {
+    val recorder = ArbigentReplayScriptRecorder()
+    recorder.beginTask(taskIndex = 0, goal = "Open the settings screen", discardPrevious = true)
+    recorder.onDeviceEvent(ArbigentDeviceEvent.LaunchApp("app.id", timestamp = 1))
+    recorder.intercept(
+      executeActionsInput(
+        ArbigentContextHolder("Open the settings screen", 10),
+        ArbigentElementIdentity(text = "text", occurrence = 2),
+      ),
+      ArbigentExecuteActionsInterceptor.Chain {
+        recorder.onDeviceEvent(
+          ArbigentDeviceEvent.TapElement(textRegex = "text", index = 2, timestamp = 2),
+        )
+        ArbigentAgent.ExecuteActionsOutput()
+      },
+    )
+    recorder.intercept(
+      executeActionsInput(ArbigentContextHolder("Open the settings screen", 10), null),
+      ArbigentExecuteActionsInterceptor.Chain {
+        recorder.onDeviceEvent(ArbigentDeviceEvent.KeyPress("KEYCODE_BACK", timestamp = 3))
+        ArbigentAgent.ExecuteActionsOutput()
+      },
+    )
+    val dir = Files.createTempDirectory("replay-round-trip").toFile()
+    ArbigentReplayScriptWriter(dir).write(
+      scenarioId = "open-settings",
+      goals = listOf("Open the settings screen"),
+      tasks = recorder.recordedTasks(),
+      signature = listOf("settings_root"),
+      platform = ArbigentDeviceOs.Android,
+      screenWidth = 1000,
+      screenHeight = 2000,
+    )
+
+    val log = ArbigentReplayLog.read(File(dir, "open-settings.jsonl"))
+
+    assertEquals(ArbigentDeviceOs.Android, log.platform)
+    assertEquals(1000, log.screenWidth)
+    assertEquals(2000, log.screenHeight)
+    assertEquals(listOf("settings_root"), log.signature)
+    assertEquals("app.id", log.appId)
+    assertEquals(2, log.lastStepNumber())
+
+    val steps = log.select(withInit = true)
+    assertEquals(listOf(0, 1, 2), steps.map { it.number })
+    assertTrue(steps[0].isInit)
+    assertEquals("app.id", (steps[0].events.single() as ArbigentDeviceEvent.LaunchApp).appId)
+    assertEquals("text", steps[1].target?.identity?.text)
+    assertEquals(2, steps[1].target?.identity?.occurrence)
+    assertEquals(50, steps[1].target?.centerX)
+    assertEquals(50, steps[1].target?.centerY)
+    assertTrue(steps[1].screen.isNotEmpty(), "the recorded screen hints should survive the round trip")
+    assertEquals("text", (steps[1].events.single() as ArbigentDeviceEvent.TapElement).textRegex)
+    assertEquals("KEYCODE_BACK", (steps[2].events.single() as ArbigentDeviceEvent.KeyPress).keyName)
   }
 }


### PR DESCRIPTION
Adds `arbigent replay`, which drives a recorded scenario log on a device without asking an AI anything. It replaces the generated `replay.sh` runner: a log written by a successful run holds the device events, so replaying it is cheaper and more repeatable than asking the agent to find its way to the same screen again. No API key is needed, because no model is called.

```
arbigent replay <id>.jsonl [--step N] [--from N] [--until N] [--with-init] [--no-wait] [--show]
```

`--show` prints what would be sent and exits without connecting to a device.

## Exit codes

| code | meaning |
| --- | --- |
| 0 | every step went through and the end screen looks like the recorded one |
| 1 | the log or the range cannot be replayed at all |
| 2 | the screen was not the one the recording acted on |
| 3 | the device could not be driven |

## What it refuses to replay

A log is read back only when it is exactly one finished, successful run: a truncated log, a failed run, two runs in one file, mixed scenarios, a newer schema version and a missing platform are all refused with the reason. Half a log replays to a screen the scenario never reached, which is worse than refusing up front.

## Deliberate differences from the shell runner

- **Taps and swipes are scaled in pixels, not sent as percentages.** Maestro parses a percent point with `toInt()`, so a percentage quantizes to about 11 px on a 1080 px screen. The recorded header size is scaled against the connected device's size instead.
- **Arrival is stricter.** No recorded end-screen id present exits 2 and an unreadable hierarchy exits 3, where the shell runner printed a warning and exited 0.
- **A command the replay cannot reproduce is a pre-flight refusal (exit 1), not a mid-run divergence**, and only the selected steps are checked, so an unreproducible command outside the chosen range does not block a replay.

## Waiting

`ArbigentReplayWait` holds one definition of the wait rule, shared by the in-run trace replay and this command: poll `device.elements()` until the recorded target is present, and go ahead the moment it is.

The two paths differ only in the budget they get, because ending a wait early does not cost them the same thing.

- `inRunBudgetMillis` (in-scenario): what is left of the recorded gap, capped at a minute, with no floor once the gap is known — the AI stands behind that wait, so a step captured too early is a fallback, not a lost run.
- `standaloneBudgetMillis` (this command): the recorded gap, but never below 10 seconds — here a wait that ends early ends the whole replay with `EXIT_DIVERGED`, since there is no AI to carry on from the screen it stopped on.

A step recorded without a target waits for any of the recorded screen hints instead, and only warns when none appear: the hints say which screen the decision was looking at, not what it acted on, so they are too weak to fail a replay on.

## Tests

- 19 runner tests over a fake device: command order, waiting for a late target, a target that never appears, element-not-found, a device failure, platform mismatch, pixel scaling, the end-screen check, `--no-wait`, and launch arguments keeping their types.
- 11 reader tests for every refusal and for the step selection, including how setup blocks ride with the step that came after them.
- A round-trip test that writes a log with the real recorder and writer and reads it back with the real reader, so a key rename on either side fails in the build rather than on a device.
- 6 CLI tests driving `replay --show` end to end.




## Run on a device

Recorded and replayed on an iOS simulator as well as on Android. The iOS run is what surfaced the exit hang this branch fixes: Maestro's local iOS device opens a scheduled executor for its view-hierarchy timeout warning and never shuts it down, so a successful replay finished its work and then sat there forever instead of handing its exit code back. The command now exits explicitly, the same way `run` does.


A step with neither a target nor a screen hint (what an opaque screen records) now waits out its budget instead of being sent immediately, which is what the in-run replay does for a step with no target. A log whose setup was the whole run — the app launched straight onto the goal screen — replays with `--with-init` instead of being refused, and a launch replays the permissions and keychain reset it recorded.
