### PR TITLE
Use the preinstalled Temurin JDK where no runtime is bundled

### DIFF
--- a/.github/workflows/benchmark-android-world.yaml
+++ b/.github/workflows/benchmark-android-world.yaml
@@ -53,12 +53,13 @@ jobs:
 
       - uses: actions/checkout@v4
 
+      # Temurin 17 is in the runner's tool cache, so this resolves locally instead of
+      # downloading a JDK. Nothing built here bundles a runtime, so it does not need the
+      # JetBrains Runtime that arbigent-ui packages with jpackage.
       - uses: actions/setup-java@v4
         with:
-          distribution: 'jetbrains'
+          distribution: 'temurin'
           java-version: '17'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-python@v5
         with:

--- a/.github/workflows/build-cli.yaml
+++ b/.github/workflows/build-cli.yaml
@@ -25,13 +25,13 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      # Temurin 17 is in the runner's tool cache, so this resolves locally instead of
+      # downloading a JDK. Nothing built here bundles a runtime, so it does not need the
+      # JetBrains Runtime that arbigent-ui packages with jpackage.
       - uses: actions/setup-java@v4
         with:
-          distribution: 'jetbrains'
+          distribution: 'temurin'
           java-version: '17'
-          java-package: 'jdk' # optional (jdk, jre, jdk+jcef, jre+jcef, jdk+ft, or jre+ft) - defaults to jdk
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -104,13 +104,13 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      # Temurin 17 is in the runner's tool cache, so this resolves locally instead of
+      # downloading a JDK. Nothing built here bundles a runtime, so it does not need the
+      # JetBrains Runtime that arbigent-ui packages with jpackage.
       - uses: actions/setup-java@v4
         with:
-          distribution: 'jetbrains'
+          distribution: 'temurin'
           java-version: '17'
-          java-package: 'jdk' # optional (jdk, jre, jdk+jcef, jre+jcef, jdk+ft, or jre+ft) - defaults to jdk
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
@@ -173,13 +173,13 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      # Temurin 17 is in the runner's tool cache, so this resolves locally instead of
+      # downloading a JDK. Nothing built here bundles a runtime, so it does not need the
+      # JetBrains Runtime that arbigent-ui packages with jpackage.
       - uses: actions/setup-java@v4
         with:
-          distribution: 'jetbrains'
+          distribution: 'temurin'
           java-version: '17'
-          java-package: 'jdk' # optional (jdk, jre, jdk+jcef, jre+jcef, jdk+ft, or jre+ft) - defaults to jdk
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
         with:

--- a/.github/workflows/web-test.yaml
+++ b/.github/workflows/web-test.yaml
@@ -25,13 +25,13 @@ jobs:
         with:
           fetch-depth: 0
           fetch-tags: true
+      # Temurin 17 is in the runner's tool cache, so this resolves locally instead of
+      # downloading a JDK. Nothing built here bundles a runtime, so it does not need the
+      # JetBrains Runtime that arbigent-ui packages with jpackage.
       - uses: actions/setup-java@v4
         with:
-          distribution: 'jetbrains'
+          distribution: 'temurin'
           java-version: '17'
-          java-package: 'jdk'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4


### PR DESCRIPTION
## Why

`actions/setup-java` fails intermittently while fetching a JDK:

```
Installed distributions
  Trying to resolve the latest version from remote
  Error: read ECONNRESET
```

That line only appears for a distribution the runner does not already have. The JetBrains Runtime is not in the runner tool cache, so every job asking for `distribution: 'jetbrains'` resolves a release list and downloads a JDK over the network before it can do anything, and a dropped connection there fails the job in its fifth step.

Measured over the last 80 workflow runs: 2 of 109 `setup-java` steps failed this way (~1.8%). Both were on JetBrains-distribution jobs. `build-cli` asks for it three times and runs a matrix, so a per-step rate that low still costs a job fairly often.

## What

Only `arbigent-ui` needs the JetBrains Runtime: it is the one module with `nativeDistributions`, and `jpackage` bundles that JDK into the shipped app (Jewel also requires 21 there). `build-ui.yaml` keeps `distribution: 'jetbrains'` unchanged.

The other three workflows build nothing that carries a runtime — `build-cli` runs `arbigent-cli:assemble` (a tar/zip), `web-test` runs `arbigent-cli:installDist`, and `benchmark-android-world` just runs the CLI — so they now ask for `temurin` 17, which ships in the runner's tool cache. Those five steps stop touching the network, which removes the failure and saves the download.

The `GITHUB_TOKEN` env on those steps went with it: it was there so the JetBrains distribution could query GitHub releases.

## What this does not do

Nothing here changes `build-ui`, which still downloads the JetBrains Runtime and is still exposed to the same flake — that download is load-bearing, since the JDK ends up inside the released app.

Upgrading to `actions/setup-java@v5` is worth doing separately for the deprecation warning, but it does not fix this: the v5 release notes document no retry or network error handling for distribution resolution.
