### PR TITLE
Skip initializers for the agent replacing a fallen-back task

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -39,6 +39,10 @@ public class ArbigentAgent internal constructor(
   // degrade to normal execution, and the failed attempt would then purge the AI-decision cache as
   // if it were an ordinary failure. Null means normal AI-driven execution.
   private val replayTrace: ArbigentReplayTrace?,
+  // False for the agent that replaces a task which fell back from replay: that task's initializers
+  // already ran for the replay attempt, and running them again would undo the device state the
+  // replayed actions produced, which is exactly what the replacement carries on from.
+  private val runInitializers: Boolean = true,
 ) {
   private val attemptMode: ArbigentAttemptMode = if (replayTrace != null) {
     ArbigentAttemptMode.ReplayWithFallback
@@ -81,6 +85,11 @@ public class ArbigentAgent internal constructor(
       }
     }
   )
+  // Whether this agent's initializers got through. A task whose initializer failed left the device
+  // wherever the failure did, so there is nothing for a replacement agent to carry on from.
+  internal var initializerCompleted: Boolean = false
+    private set
+
   private val stepInterceptors: List<ArbigentStepInterceptor> = buildList {
     if (replayTrace != null) {
       add(ArbigentReplayPacingStepInterceptor(replayTrace))
@@ -253,6 +262,8 @@ public class ArbigentAgent internal constructor(
       updateIsRunning = { value -> _isRunningStateFlow.value = value },
       updateCurrentGoal = { value -> currentGoalStateFlow.value = value },
       initializerChain = initializerChain,
+      runInitializers = runInitializers,
+      updateInitializerCompleted = { value -> initializerCompleted = value },
       stepChain = stepChain,
       decisionChain = decisionChain,
       imageAssertionChain = imageAssertionChain,
@@ -291,6 +302,8 @@ public class ArbigentAgent internal constructor(
     val executeActionChain: suspend (ExecuteActionsInput) -> ExecuteActionsOutput,
     val mcpClient: MCPClient? = null,
     val mcpOptions: ArbigentMcpOptions? = null,
+    val runInitializers: Boolean = true,
+    val updateInitializerCompleted: (Boolean) -> Unit = {},
   )
 
   public sealed interface ExecutionResult {
@@ -702,8 +715,6 @@ public fun AgentConfigBuilder(
 
       is ArbigentScenarioContent.InitializationMethod.LaunchApp -> {
         addInterceptor(object : ArbigentInitializerInterceptor {
-          override val resetsDeviceState: Boolean = true
-
           override fun intercept(
             device: ArbigentDevice,
             chain: ArbigentInitializerInterceptor.Chain
@@ -728,8 +739,6 @@ public fun AgentConfigBuilder(
 
       is ArbigentScenarioContent.InitializationMethod.CleanupData -> {
         addInterceptor(object : ArbigentInitializerInterceptor {
-          override val resetsDeviceState: Boolean = true
-
           override fun intercept(
             device: ArbigentDevice,
             chain: ArbigentInitializerInterceptor.Chain
@@ -750,8 +759,6 @@ public fun AgentConfigBuilder(
 
       is ArbigentScenarioContent.InitializationMethod.OpenLink -> {
         addInterceptor(object : ArbigentInitializerInterceptor {
-          override val resetsDeviceState: Boolean = true
-
           override fun intercept(
             device: ArbigentDevice,
             chain: ArbigentInitializerInterceptor.Chain
@@ -775,8 +782,6 @@ public fun AgentConfigBuilder(
           // A flow can do anything, so it is read as resetting: taking a trace from the wrong
           // starting point costs a diverged replay, replaying actions the flow already undid can
           // repeat them for real.
-          override val resetsDeviceState: Boolean = true
-
           override fun intercept(
             device: ArbigentDevice,
             chain: ArbigentInitializerInterceptor.Chain
@@ -859,18 +864,6 @@ public interface ArbigentInterceptor
 public interface ArbigentInitializerInterceptor : ArbigentInterceptor {
   public fun intercept(device: ArbigentDevice, chain: Chain)
 
-  /**
-   * Whether this initializer puts the device somewhere known regardless of where it was, the way
-   * launching an app or clearing its data does. Backing out or waiting does not.
-   *
-   * A recorded trace only replays correctly from the state it was recorded from. Initializers run
-   * again at the start of every run of their task, so a task that resets is back at the same place
-   * each time and what the AI did after the reset is a trace on its own. A task that does not reset
-   * starts wherever the previous task left off, so a run that fell back mid-task only makes sense
-   * as a trace together with the actions it had already replayed.
-   */
-  public val resetsDeviceState: Boolean
-    get() = false
   public fun interface Chain {
     public fun proceed(device: ArbigentDevice)
   }
@@ -1212,24 +1205,28 @@ private suspend fun executeDefault(input: ExecuteInput): ExecutionResult {
     val contextHolder = input.createContextHolder(input.goal, input.maxStep)
     input.addContextHolder(contextHolder)
 
-    try {
-      ArbigentGlobalStatus.onInitializing {
-        input.initializerChain(input.device)
-      }
-    } catch (e: MaestroException.AssertionFailure) {
-      arbigentInfoLog { "Initialization failed: ${e.stackTraceToString()}" }
-      val stepId = contextHolder.generateStepId()
-      contextHolder.addStep(
-        ArbigentContextHolder.Step(
-          stepId = stepId,
-          feedback = "Failed to assert in initialization: ${e.message}",
-          cacheKey = "init-failure $stepId",
-          screenshotFilePath = ""
+    input.updateInitializerCompleted(false)
+    if (input.runInitializers) {
+      try {
+        ArbigentGlobalStatus.onInitializing {
+          input.initializerChain(input.device)
+        }
+      } catch (e: MaestroException.AssertionFailure) {
+        arbigentInfoLog { "Initialization failed: ${e.stackTraceToString()}" }
+        val stepId = contextHolder.generateStepId()
+        contextHolder.addStep(
+          ArbigentContextHolder.Step(
+            stepId = stepId,
+            feedback = "Failed to assert in initialization: ${e.message}",
+            cacheKey = "init-failure $stepId",
+            screenshotFilePath = ""
+          )
         )
-      )
-      ArbigentGlobalStatus.onFinished()
-      return ExecutionResult.Failed(contextHolder)
+        ArbigentGlobalStatus.onFinished()
+        return ExecutionResult.Failed(contextHolder)
+      }
     }
+    input.updateInitializerCompleted(true)
 
     var stepRemain = input.maxStep
     while (stepRemain-- > 0 && !contextHolder.isGoalAchieved()) {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -779,9 +779,6 @@ public fun AgentConfigBuilder(
 
       is ArbigentScenarioContent.InitializationMethod.MaestroYaml -> {
         addInterceptor(object : ArbigentInitializerInterceptor {
-          // A flow can do anything, so it is read as resetting: taking a trace from the wrong
-          // starting point costs a diverged replay, replaying actions the flow already undid can
-          // repeat them for real.
           override fun intercept(
             device: ArbigentDevice,
             chain: ArbigentInitializerInterceptor.Chain

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgent.kt
@@ -43,6 +43,7 @@ public class ArbigentAgent internal constructor(
   // already ran for the replay attempt, and running them again would undo the device state the
   // replayed actions produced, which is exactly what the replacement carries on from.
   private val runInitializers: Boolean = true,
+  private val precedingSteps: List<ArbigentContextHolder.Step> = emptyList(),
 ) {
   private val attemptMode: ArbigentAttemptMode = if (replayTrace != null) {
     ArbigentAttemptMode.ReplayWithFallback
@@ -62,7 +63,9 @@ public class ArbigentAgent internal constructor(
     .filterIsInstance<ArbigentExecutionInterceptor>()
 
   private val executeChain: suspend (ExecuteInput) -> ExecutionResult = { input ->
-    var chain: suspend (ExecuteInput) -> ExecutionResult = { executeInput -> executeDefault(executeInput) }
+    var chain: suspend (ExecuteInput) -> ExecutionResult = { executeInput ->
+      executeDefault(executeInput, precedingSteps)
+    }
     executeInterceptors.reversed().forEach { interceptor ->
       val previousChain = chain
       chain = { currentInput ->
@@ -1194,13 +1197,42 @@ private suspend fun executeActions(
   return ExecuteActionsOutput()
 }
 
-private suspend fun executeDefault(input: ExecuteInput): ExecutionResult {
+private fun ArbigentContextHolder.Step.asPrecedingFeedback(): ArbigentContextHolder.Step {
+  val action = agentAction ?: return this
+  return ArbigentContextHolder.Step(
+    stepId = stepId,
+    agentAction = null,
+    feedback = "This action was already performed before this attempt, replayed from a recording: ${action.stepLogText()}",
+    memo = memo,
+    imageDescription = imageDescription,
+    cacheKey = cacheKey,
+    screenshotFilePath = screenshotFilePath,
+    timestamp = timestamp,
+    stepSource = stepSource,
+  )
+}
+
+private suspend fun executeDefault(
+  input: ExecuteInput,
+  precedingSteps: List<ArbigentContextHolder.Step>,
+): ExecutionResult {
   val nullableContextHolder: ArbigentContextHolder? = null
   try {
     input.updateIsRunning(true)
     input.updateCurrentGoal(input.goal)
     val contextHolder = input.createContextHolder(input.goal, input.maxStep)
     input.addContextHolder(contextHolder)
+
+    // A replacement after a replay fallback continues from the screen the replayed actions left,
+    // and with an empty context the AI would take that screen for the start of the task and repeat
+    // them. The history goes in as feedback: a step without an action is shown to the AI but is not
+    // counted against this attempt's action budget and is not written to the trace a second time.
+    val seededActionStepIds = mutableSetOf<String>()
+    precedingSteps.forEach { step ->
+      if (step.agentAction == null || seededActionStepIds.add(step.stepId)) {
+        contextHolder.addStep(step.asPrecedingFeedback())
+      }
+    }
 
     input.updateInitializerCompleted(false)
     if (input.runInitializers) {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgentTask.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentAgentTask.kt
@@ -14,11 +14,3 @@ public data class ArbigentAgentTask(
   // from a reusable scenario; null for ordinary goal-based tasks.
   val callBreadcrumb: String? = null,
 )
-
-/**
- * Whether running this task starts by putting the device somewhere known, whatever state it was
- * left in. See [ArbigentInitializerInterceptor.resetsDeviceState].
- */
-internal fun ArbigentAgentTask.resetsDeviceState(): Boolean =
-  agentConfig.interceptors.filterIsInstance<ArbigentInitializerInterceptor>()
-    .any { it.resetsDeviceState }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -271,6 +271,9 @@ public class ArbigentScenarioExecutor internal constructor(
             // falls back the same way. Restarting the whole scenario instead would throw away
             // every task already replayed, which is the entire saving the mode exists for.
             if (attemptMode == ArbigentAttemptMode.ReplayWithFallback &&
+              // An initializer that failed left the device wherever the failure did, and the
+              // replacement skips initializers, so there is no state for it to carry on from.
+              agent.initializerCompleted &&
               fellBackTaskIndexes.add(index)
             ) {
               arbigentInfoLog(
@@ -278,13 +281,10 @@ public class ArbigentScenarioExecutor internal constructor(
                   "${replayFailureReason(agent)}. Re-running this task in normal mode and keeping the " +
                   "tasks before it.",
               )
-              // A task that starts by resetting the device resets again when it is re-run here, so
-              // the AI ran from the same place a replay of this task would start from and its steps
-              // stand alone as a trace. Only a task that carries on from the previous one needs the
-              // actions it had already replayed put back in front of them.
-              if (!task.resetsDeviceState()) {
-                replayedPrefixes[index] = agent.latestArbigentContext()?.steps().orEmpty()
-              }
+              // The replacement carries on from the device state the replayed actions produced, so
+              // its own steps do not stand alone: the actions already replayed go back in front of
+              // them, or the trace would not be replayable from the start of the task.
+              replayedPrefixes[index] = agent.latestArbigentContext()?.steps().orEmpty()
               agent.cancel()
               _taskAssignmentsStateFlow.value = taskAssignments().toMutableList().also {
                 it[index] = ArbigentTaskAssignment(
@@ -293,6 +293,7 @@ public class ArbigentScenarioExecutor internal constructor(
                     agentConfig = task.agentConfig,
                     dispatcher = dispatcher,
                     replayTrace = null,
+                    runInitializers = false,
                   ),
                 )
               }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -294,6 +294,7 @@ public class ArbigentScenarioExecutor internal constructor(
                     dispatcher = dispatcher,
                     replayTrace = null,
                     runInitializers = false,
+                    precedingSteps = replayedPrefixes[index].orEmpty(),
                   ),
                 )
               }

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/sample/test/TaskLevelReplayFallbackTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/sample/test/TaskLevelReplayFallbackTest.kt
@@ -155,7 +155,9 @@ class TaskLevelReplayFallbackTest {
         id = "scenario",
         agentTasks = listOf(
           ArbigentAgentTask("task-1", "goal1", firstTaskConfig),
-          ArbigentAgentTask("task-2", "goal2", secondTaskConfig, maxStep = 3),
+          // Wide enough for the replayed and the replacement actions together, so the trace written
+          // after the fallback stays within what the task allows.
+          ArbigentAgentTask("task-2", "goal2", secondTaskConfig, maxStep = 5),
         ),
         maxStepCount = 10,
         tags = setOf(),
@@ -211,7 +213,7 @@ class TaskLevelReplayFallbackTest {
       replayFeedback.forEach { assertTrue(replacementPrompt.contains(it.feedback!!)) }
       assertTrue(replacementPrompt.contains("Current step: 1\n"))
       assertEquals(listOf(0, 1, 2), replacementActionCounts,
-        "the replacement should retain all three actions of its maxStep budget")
+        "the replayed history must not count toward the replacement's step number")
       val replacement = executor.taskAssignments()[1].agent
       assertTrue(replacement.isGoalAchieved())
       val replacementActions = replacement.latestArbigentContext()!!.steps()

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/sample/test/TaskLevelReplayFallbackTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/sample/test/TaskLevelReplayFallbackTest.kt
@@ -1,9 +1,11 @@
 package io.github.takahirom.arbigent.sample.test
 
 import io.github.takahirom.arbigent.*
+import io.github.takahirom.arbigent.result.ArbigentStepSource
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
 import maestro.MaestroException
 import maestro.TreeNode
 import java.nio.file.Files
@@ -23,6 +25,60 @@ class TaskLevelReplayFallbackTest {
   @AfterTest
   fun restoreTraceDir() {
     ArbigentFiles.traceDir = originalTraceDir
+  }
+
+  @Test
+  fun `preceding actions are deduplicated while feedback and history metadata are preserved`() = runTest {
+    val action = ArbigentContextHolder.Step(
+      stepId = "replayed-action",
+      agentAction = ClickWithTextAgentAction("text"),
+      memo = "Opened the menu",
+      imageDescription = "The menu button is visible",
+      cacheKey = "replayed-cache",
+      screenshotFilePath = "replayed-screenshot.png",
+      timestamp = 123L,
+      stepSource = ArbigentStepSource.Replay,
+    )
+    val assertionFeedback = action.copy(agentAction = null, feedback = "Image assertion failed.")
+    val divergence = action.copy(agentAction = null, feedback = "Replay diverged: the target is absent")
+    var firstPrompt = ""
+    var seeds = emptyList<ArbigentContextHolder.Step>()
+    val config = AgentConfig {
+      deviceFactory { FakeDevice() }
+      aiFactory { FakeAi() }
+      addInterceptor(object : ArbigentDecisionInterceptor {
+        override suspend fun intercept(
+          decisionInput: ArbigentAi.DecisionInput,
+          chain: ArbigentDecisionInterceptor.Chain,
+        ): ArbigentAi.DecisionOutput {
+          if (firstPrompt.isEmpty()) {
+            seeds = decisionInput.contextHolder.steps()
+            firstPrompt = decisionInput.contextHolder.prompt("", "", ArbigentAiOptions())
+          }
+          return chain.proceed(decisionInput).withStepIdOf(decisionInput)
+        }
+      })
+    }
+    val agent = ArbigentAgent(
+      config,
+      coroutineContext[CoroutineDispatcher]!!,
+      replayTrace = null,
+      runInitializers = false,
+      precedingSteps = listOf(action, assertionFeedback, action, divergence),
+    )
+    agent.execute("scenario", "goal", maxStep = 3, mcpClient = MCPClient())
+    advanceUntilIdle()
+
+    assertEquals(3, seeds.size)
+    assertEquals(action.copy(
+      agentAction = null,
+      feedback = "This action was already performed before this attempt, replayed from a recording: ${action.agentAction!!.stepLogText()}",
+    ), seeds.first())
+    assertEquals(listOf(assertionFeedback, divergence), seeds.drop(1))
+    assertTrue(firstPrompt.contains(divergence.feedback!!))
+    assertTrue(firstPrompt.contains("Current step: 1\n"))
+    assertTrue(agent.isGoalAchieved())
+    assertEquals(3, agent.latestArbigentContext()!!.countMeaningfulActions())
   }
 
   @Test
@@ -60,6 +116,10 @@ class TaskLevelReplayFallbackTest {
       // Fails the assertion once, which is what a replayed task that ends on the wrong screen
       // looks like. The re-run under the AI then passes.
       var failNextAssertion = false
+      var captureReplacement = false
+      val replacementActionCounts = mutableListOf<Int>()
+      var replacementPrompt = ""
+      var replacementSeeds = emptyList<ArbigentContextHolder.Step>()
       val secondTaskConfig = AgentConfig {
         deviceFactory { FakeDevice() }
         aiFactory { FakeAi() }
@@ -67,7 +127,17 @@ class TaskLevelReplayFallbackTest {
           override suspend fun intercept(
             decisionInput: ArbigentAi.DecisionInput,
             chain: ArbigentDecisionInterceptor.Chain,
-          ): ArbigentAi.DecisionOutput = chain.proceed(decisionInput).withStepIdOf(decisionInput)
+          ): ArbigentAi.DecisionOutput {
+            if (captureReplacement) {
+              val holder = decisionInput.contextHolder
+              if (replacementActionCounts.isEmpty()) {
+                replacementSeeds = holder.steps()
+                replacementPrompt = holder.prompt("", "", ArbigentAiOptions())
+              }
+              replacementActionCounts += holder.countMeaningfulActions()
+            }
+            return chain.proceed(decisionInput).withStepIdOf(decisionInput)
+          }
         })
         addInterceptor(object : ArbigentImageAssertionInterceptor {
           override fun intercept(
@@ -85,7 +155,7 @@ class TaskLevelReplayFallbackTest {
         id = "scenario",
         agentTasks = listOf(
           ArbigentAgentTask("task-1", "goal1", firstTaskConfig),
-          ArbigentAgentTask("task-2", "goal2", secondTaskConfig),
+          ArbigentAgentTask("task-2", "goal2", secondTaskConfig, maxStep = 3),
         ),
         maxStepCount = 10,
         tags = setOf(),
@@ -105,8 +175,10 @@ class TaskLevelReplayFallbackTest {
       firstTaskExecutions = 0
       firstTaskDecisions = 0
       failNextAssertion = true
+      captureReplacement = true
 
-      ArbigentScenarioExecutor(testDispatcher).execute(scenario(), MCPClient())
+      val executor = ArbigentScenarioExecutor(testDispatcher)
+      executor.execute(scenario(), MCPClient())
       advanceUntilIdle()
 
       assertEquals(
@@ -118,6 +190,39 @@ class TaskLevelReplayFallbackTest {
         0,
         firstTaskDecisions,
         "the first task should have replayed without asking the AI anything",
+      )
+
+      val replayedSteps = executor.taskAssignmentsHistory().first()[1].agent
+        .latestArbigentContext()!!.steps()
+      val replayedActions = replayedSteps.filter { it.agentAction != null }.distinctBy { it.stepId }
+      assertEquals(2, replayedActions.size)
+      assertTrue(replacementSeeds.all { it.agentAction == null })
+      assertEquals(replayedSteps.map { it.stepId }, replacementSeeds.map { it.stepId })
+      replayedActions.forEach { step ->
+        assertTrue(replacementPrompt.contains(
+          "This action was already performed before this attempt, replayed from a recording: ${step.agentAction!!.stepLogText()}",
+        ))
+      }
+      val replayFeedback = replayedSteps.filter { it.agentAction == null }
+      assertTrue(replayFeedback.any { it.feedback!!.startsWith("Failed replay image assertion") })
+      replayedSteps.zip(replacementSeeds).forEach { (original, seed) ->
+        if (original.agentAction == null) assertEquals(original, seed)
+      }
+      replayFeedback.forEach { assertTrue(replacementPrompt.contains(it.feedback!!)) }
+      assertTrue(replacementPrompt.contains("Current step: 1\n"))
+      assertEquals(listOf(0, 1, 2), replacementActionCounts,
+        "the replacement should retain all three actions of its maxStep budget")
+      val replacement = executor.taskAssignments()[1].agent
+      assertTrue(replacement.isGoalAchieved())
+      val replacementActions = replacement.latestArbigentContext()!!.steps()
+        .filter { it.agentAction != null }.distinctBy { it.stepId }
+      assertEquals(3, replacementActions.size)
+      val traceSteps = secondTaskTrace().steps.map { it.decisionOutput.step }
+      assertEquals((replayedActions + replacementActions).map { it.stepId }, traceSteps.map { it.stepId })
+      assertEquals(traceSteps.size, traceSteps.distinctBy { it.stepId }.size)
+      assertEquals(
+        (replayedActions + replacementActions).map { it.agentAction!!.stepLogText() },
+        traceSteps.map { it.agentAction!!.stepLogText() },
       )
 
       // The replacement agent starts from the device state the replayed actions left behind, so
@@ -312,10 +417,14 @@ class TaskLevelReplayFallbackTest {
   )
 
   private fun secondTaskTraceStepCount(): Int {
+    return secondTaskTrace().steps.size
+  }
+
+  private fun secondTaskTrace(): ArbigentReplayTrace {
     val trace = ArbigentFiles.traceDir.listFiles().orEmpty()
       .map { it.readText() }
       .single { """"taskIndex"\s*:\s*1""".toRegex().containsMatchIn(it) }
-    return """"decisionOutput"""".toRegex().findAll(trace).count()
+    return Json { useArrayPolymorphism = true }.decodeFromString<ArbigentReplayTrace>(trace)
   }
 
   /**

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/sample/test/TaskLevelReplayFallbackTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/sample/test/TaskLevelReplayFallbackTest.kt
@@ -4,10 +4,13 @@ import io.github.takahirom.arbigent.*
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
+import maestro.MaestroException
+import maestro.TreeNode
 import java.nio.file.Files
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertTrue
 
 /**
  * A replayed task that fails costs only itself: the tasks before it keep what they replayed, and
@@ -73,16 +76,7 @@ class TaskLevelReplayFallbackTest {
           ): ArbigentAi.ImageAssertionOutput {
             if (!failNextAssertion) return chain.proceed(imageAssertionInput)
             failNextAssertion = false
-            return ArbigentAi.ImageAssertionOutput(
-              listOf(
-                ArbigentAi.ImageAssertionResult(
-                  assertionPrompt = "prompt",
-                  isPassed = false,
-                  fulfillmentPercent = 0,
-                  explanation = "explanation",
-                ),
-              ),
-            )
+            return failedAssertion()
           }
         })
       }
@@ -138,17 +132,17 @@ class TaskLevelReplayFallbackTest {
     }
 
   /**
-   * A task that begins by resetting the device begins the same way when it is re-run, so what the
-   * AI did after the reset is a trace on its own. Keeping the actions replayed before the reset
-   * would have the next run replay them again on top of it.
+   * The replacement agent carries on from where the replay left the device, so re-running the
+   * task's initializers would undo exactly the state it is meant to continue from.
    */
   @Test
-  fun `a task that resets the device records only what it did after the reset`() = runTest {
+  fun `the agent replacing a task that fell back does not run the initializers again`() = runTest {
     ArbigentFiles.traceDir =
-      Files.createTempDirectory("arbigent-task-level-fallback-reset").toFile()
+      Files.createTempDirectory("arbigent-task-level-fallback-initializer").toFile()
     val testDispatcher = coroutineContext[CoroutineDispatcher]!!
 
     var failNextAssertion = false
+    var secondTaskInitializations = 0
     val firstTaskConfig = AgentConfig {
       deviceFactory { FakeDevice() }
       aiFactory { FakeAi() }
@@ -163,9 +157,8 @@ class TaskLevelReplayFallbackTest {
       deviceFactory { FakeDevice() }
       aiFactory { FakeAi() }
       addInterceptor(object : ArbigentInitializerInterceptor {
-        override val resetsDeviceState: Boolean = true
-
         override fun intercept(device: ArbigentDevice, chain: ArbigentInitializerInterceptor.Chain) {
+          secondTaskInitializations++
           chain.proceed(device)
         }
       })
@@ -182,16 +175,7 @@ class TaskLevelReplayFallbackTest {
         ): ArbigentAi.ImageAssertionOutput {
           if (!failNextAssertion) return chain.proceed(imageAssertionInput)
           failNextAssertion = false
-          return ArbigentAi.ImageAssertionOutput(
-            listOf(
-              ArbigentAi.ImageAssertionResult(
-                assertionPrompt = "prompt",
-                isPassed = false,
-                fulfillmentPercent = 0,
-                explanation = "explanation",
-              ),
-            ),
-          )
+          return failedAssertion()
         }
       })
     }
@@ -211,16 +195,121 @@ class TaskLevelReplayFallbackTest {
     ArbigentScenarioExecutor(testDispatcher).execute(scenario(), MCPClient())
     advanceUntilIdle()
 
+    secondTaskInitializations = 0
     failNextAssertion = true
     ArbigentScenarioExecutor(testDispatcher).execute(scenario(), MCPClient())
     advanceUntilIdle()
 
     assertEquals(
-      3,
+      1,
+      secondTaskInitializations,
+      "the initializers should run for the replay attempt only, not again for the replacement",
+    )
+    // Two replayed actions plus the three the replacement decided: the count says the task really
+    // did fall back, and that a task with an initializer keeps what it replayed all the same.
+    assertEquals(
+      5,
       secondTaskTraceStepCount(),
-      "a task that resets should record its re-run alone, without the replayed prefix",
+      "the fallback trace should keep what the task replayed before it fell back",
     )
   }
+
+  /**
+   * An initializer that failed left the device wherever the failure did, so there is no replayed
+   * state for a replacement to carry on from. Such a task is not given a task-level fallback: the
+   * whole scenario restarts in normal mode, initializers included.
+   */
+  @Test
+  fun `a task whose initializer fails while replaying restarts the whole scenario`() = runTest {
+    ArbigentFiles.traceDir =
+      Files.createTempDirectory("arbigent-task-level-fallback-init-failure").toFile()
+    val testDispatcher = coroutineContext[CoroutineDispatcher]!!
+
+    var failNextInitialization = false
+    var firstTaskDecisions = 0
+    var secondTaskInitializations = 0
+    val firstTaskConfig = AgentConfig {
+      deviceFactory { FakeDevice() }
+      aiFactory { FakeAi() }
+      addInterceptor(object : ArbigentDecisionInterceptor {
+        override suspend fun intercept(
+          decisionInput: ArbigentAi.DecisionInput,
+          chain: ArbigentDecisionInterceptor.Chain,
+        ): ArbigentAi.DecisionOutput {
+          firstTaskDecisions++
+          return chain.proceed(decisionInput).withStepIdOf(decisionInput)
+        }
+      })
+    }
+    val secondTaskConfig = AgentConfig {
+      deviceFactory { FakeDevice() }
+      aiFactory { FakeAi() }
+      addInterceptor(object : ArbigentInitializerInterceptor {
+        override fun intercept(device: ArbigentDevice, chain: ArbigentInitializerInterceptor.Chain) {
+          secondTaskInitializations++
+          if (failNextInitialization) {
+            failNextInitialization = false
+            throw MaestroException.AssertionFailure(
+              "initializer failed",
+              TreeNode(),
+              "initializer failed",
+            )
+          }
+          chain.proceed(device)
+        }
+      })
+      addInterceptor(object : ArbigentDecisionInterceptor {
+        override suspend fun intercept(
+          decisionInput: ArbigentAi.DecisionInput,
+          chain: ArbigentDecisionInterceptor.Chain,
+        ): ArbigentAi.DecisionOutput = chain.proceed(decisionInput).withStepIdOf(decisionInput)
+      })
+    }
+
+    fun scenario() = ArbigentScenario(
+      id = "scenario",
+      agentTasks = listOf(
+        ArbigentAgentTask("task-1", "goal1", firstTaskConfig),
+        ArbigentAgentTask("task-2", "goal2", secondTaskConfig),
+      ),
+      maxStepCount = 10,
+      maxRetry = 0,
+      tags = setOf(),
+      isLeaf = true,
+      replayWithFallback = true,
+    )
+
+    ArbigentScenarioExecutor(testDispatcher).execute(scenario(), MCPClient())
+    advanceUntilIdle()
+
+    firstTaskDecisions = 0
+    secondTaskInitializations = 0
+    failNextInitialization = true
+    ArbigentScenarioExecutor(testDispatcher).execute(scenario(), MCPClient())
+    advanceUntilIdle()
+
+    assertTrue(
+      firstTaskDecisions > 0,
+      "the scenario should restart under the AI; a task-level fallback would have kept the first " +
+        "task replayed",
+    )
+    assertEquals(
+      2,
+      secondTaskInitializations,
+      "the initializers should run for the failed replay attempt and again for the restart",
+    )
+  }
+
+  private fun failedAssertion(): ArbigentAi.ImageAssertionOutput = ArbigentAi.ImageAssertionOutput(
+    listOf(
+      ArbigentAi.ImageAssertionResult(
+        assertionPrompt = "prompt",
+        isPassed = false,
+        fulfillmentPercent = 0,
+        explanation = "explanation",
+      ),
+    ),
+  )
 
   private fun secondTaskTraceStepCount(): Int {
     val trace = ArbigentFiles.traceDir.listFiles().orEmpty()


### PR DESCRIPTION
The agent that replaces a task which fell back from replay re-ran that task's
initializers. The replacement is meant to carry on from the device state the
replayed actions produced, so re-initializing undoes exactly the state it is
supposed to continue from. On a real run this shows up as an extra
`Status: Initializing..` right after the fallback log line, with the
`Initializing..` count coming to task count + 1 instead of task count.

Now initializers run once per task attempt, and the replacement skips them.
If the task's initializer itself failed, the device is wherever the failure
left it and there is nothing to carry on from, so that task gets no task-level
fallback: the existing ladder restarts the whole scenario in normal mode,
initializers included.

## Breaking change

`ArbigentInitializerInterceptor.resetsDeviceState` is removed. A custom
interceptor that overrides it no longer compiles — delete the override.

It was a heuristic that could not be made right. `MaestroYaml` was hard-coded
`true`, but a YAML initializer can do anything: a "press back" or "scroll" YAML
neither resets nor is idempotent. A custom interceptor was `false` regardless of
what it actually did. Rather than keep classifying initializers, the rule is now
uniform.

The tradeoff this invites feedback on: the replacement recovers from wherever
the replay left the device instead of from a clean re-init. If it cannot within
`maxStep`, the whole-scenario normal restart still catches it.

`ArbigentAgent.ExecuteInput` gained `runInitializers` and
`updateInitializerCompleted`, both defaulted and appended at the end, so
existing construction keeps working.

## What the replacement sees

Skipping the initializers is only half of continuing from the replayed state: the replacement also needs to know what already happened, or it starts from a screen it cannot explain. The replayed actions are seeded into the replacement's context as feedback entries ("This action was already performed before this attempt, replayed from a recording: ..."), with their memo, image description and screenshot. They carry no `agentAction`, so they are not counted against `maxStep`, are not written to the trace again, and `Current step` for the replacement starts at 1. The trace written after a fallback is the replayed prefix followed by the replacement's own actions, with no duplicates.

## Verification

`:arbigent-core:test` green, including a test that the replacement does not
re-initialize and one that an initializer failure restarts the scenario.

On a device, a 3-task scenario replayed with one tampered trace step: the
divergence and fallback lines appear, and `Initializing..` is now 3 (task
count) where it was 4 before this change. Exit code 0.

