### PR TITLE
Reject a replay trace longer than the task's step limit

### DIFF
--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentReplayTrace.kt
@@ -419,6 +419,14 @@ internal data class ArbigentReplayTrace(
     if (steps.last().decisionOutput.agentActions.none { it is GoalAchievedAgentAction }) {
       return "it does not end by reaching the goal"
     }
+    // A replayed step costs an iteration just like a step the AI decides, so a trace longer than
+    // the task allows can never replay to its goal: it would run out of steps every time, fall
+    // back to the AI every time, and pay for the AI every time. A task that fell back records
+    // what it replayed plus what the replacement decided, which is how a trace grows past the
+    // limit. Rejecting it lets the next run record one that fits.
+    if (steps.size > key.maxStep) {
+      return "it has ${steps.size} steps, more than the ${key.maxStep} the task allows"
+    }
     return null
   }
 
@@ -468,6 +476,7 @@ internal data class ArbigentReplayTraceKey(
   val taskIndex: Int,
   val taskIdentity: String,
   val goal: String,
+  val maxStep: Int,
 ) {
   val goalHash: String = goal.sha256()
 
@@ -478,6 +487,9 @@ internal data class ArbigentReplayTraceKey(
    * component has on ext4 and APFS, and every write failed with FileNotFoundException so no
    * scenario could ever replay. Nothing is lost by not naming the parts: the trace file itself
    * carries the scenario id, task index and goal hash, and reading one validates them again.
+   *
+   * [maxStep] is left out on purpose: it is a limit the trace is checked against, not part of
+   * which trace this is. Lowering it has to reject the stored trace, not look past it for another.
    */
   val storageKey: String = listOf(
     version,
@@ -501,8 +513,14 @@ internal class ArbigentReplayTraceStore(
     val file = fileFor(key)
     if (!file.isFile) return null
     return try {
-      json.decodeFromString<ArbigentReplayTrace>(file.readText())
-        .takeIf { it.isValidFor(key) }
+      val trace = json.decodeFromString<ArbigentReplayTrace>(file.readText())
+      val reason = trace.invalidReasonFor(key)
+      if (reason != null) {
+        arbigentInfoLog("Not replaying the stored trace for task ${key.taskIndex + 1}: $reason")
+        null
+      } else {
+        trace
+      }
     } catch (exception: Exception) {
       arbigentErrorLog("Failed to read replay trace ${key.storageKey}: $exception")
       null

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioExecutor.kt
@@ -448,6 +448,7 @@ private fun ArbigentScenario.replayTraceKeys(): List<ArbigentReplayTraceKey> =
         }
       },
       goal = task.agentConfig.resolveGoal(task.goal),
+      maxStep = task.maxStep,
     )
   }
 

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
@@ -108,6 +108,7 @@ class ArbigentReplayTraceTest {
     taskIndex = 0,
     taskIdentity = "scenario",
     goal = "goal",
+    maxStep = 10,
   )
 
   private fun timestampedSteps(timestamps: List<Long>): List<ArbigentContextHolder.Step> {

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
@@ -28,6 +28,7 @@ class ArbigentReplayTraceTest {
       taskIndex = 0,
       taskIdentity = "open-model-page",
       goal = "Open the model page",
+      maxStep = 10,
     )
     val action = ClickWithIndex(2)
     val trace = ArbigentReplayTrace(
@@ -100,6 +101,7 @@ class ArbigentReplayTraceTest {
       taskIndex = 3,
       taskIdentity = "\u3042".repeat(400),
       goal = "\u3042".repeat(30),
+      maxStep = 10,
     )
 
     store.write(key, minimalTrace(key))
@@ -122,6 +124,7 @@ class ArbigentReplayTraceTest {
       taskIndex = 0,
       taskIdentity = "identity",
       goal = "Goal",
+      maxStep = 10,
     )
     val second = first.copy(taskIndex = 1)
 
@@ -450,6 +453,52 @@ class ArbigentReplayTraceTest {
   )
 
   /** The smallest trace [ArbigentReplayTrace.isValidFor] accepts: one step that reaches the goal. */
+  /**
+   * A replayed step costs an iteration just like one the AI decides, so a trace with more steps
+   * than the task allows would run out of steps before its goal on every run. Lowering the limit
+   * has to reject an already stored trace, which is why the limit is checked on read and is not
+   * part of the file name.
+   */
+  @Test
+  fun `a trace with more steps than the task allows is not replayed`() {
+    val directory = Files.createTempDirectory("arbigent-replay-trace-over-max-step").toFile()
+    val store = ArbigentReplayTraceStore { directory }
+    val key = ArbigentReplayTraceKey(
+      version = "1.2.3",
+      scenarioId = "scenario",
+      taskIndex = 0,
+      taskIdentity = "scenario",
+      goal = "Goal",
+      maxStep = 2,
+    )
+    val click = ClickWithIndex(0)
+    val trace = minimalTrace(key).let { goalOnly ->
+      goalOnly.copy(
+        steps = listOf(
+          ArbigentReplayTraceStep(
+            decisionOutput = ArbigentAi.DecisionOutput(
+              agentActions = listOf(click),
+              step = ArbigentContextHolder.Step(
+                stepId = "step-0",
+                agentAction = click,
+                cacheKey = "cache-key",
+                screenshotFilePath = "screenshot.png",
+              ),
+            ),
+          ),
+        ) + goalOnly.steps,
+      )
+    }
+
+    store.write(key, trace)
+
+    assertNotNull(store.read(key), "a trace that fits the limit should be replayed")
+    assertNull(
+      store.read(key.copy(maxStep = 1)),
+      "a trace that cannot finish within the limit should not be replayed",
+    )
+  }
+
   private fun minimalTrace(key: ArbigentReplayTraceKey): ArbigentReplayTrace {
     val action = GoalAchievedAgentAction()
     return ArbigentReplayTrace(
@@ -484,6 +533,7 @@ class ArbigentReplayTraceTest {
       taskIndex = 0,
       taskIdentity = "scenario",
       goal = "Goal",
+      maxStep = 10,
     )
     val action = GoalAchievedAgentAction()
     val trace = ArbigentReplayTrace(

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/ArbigentReplayTraceTest.kt
@@ -579,7 +579,6 @@ class ArbigentReplayTraceTest {
     },
   )
 
-  /** The smallest trace [ArbigentReplayTrace.isValidFor] accepts: one step that reaches the goal. */
   /**
    * A replayed step costs an iteration just like one the AI decides, so a trace with more steps
    * than the task allows would run out of steps before its goal on every run. Lowering the limit
@@ -626,6 +625,7 @@ class ArbigentReplayTraceTest {
     )
   }
 
+  /** The smallest trace [ArbigentReplayTrace.isValidFor] accepts: one step that reaches the goal. */
   private fun minimalTrace(key: ArbigentReplayTraceKey): ArbigentReplayTrace {
     val action = GoalAchievedAgentAction()
     return ArbigentReplayTrace(

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/sample/test/TaskLevelReplayFallbackTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/sample/test/TaskLevelReplayFallbackTest.kt
@@ -494,7 +494,7 @@ class TaskLevelReplayFallbackTest {
 
   private fun taskTraceStepCount(): Int {
     val trace = ArbigentFiles.traceDir.listFiles().orEmpty().single().readText()
-    return """"decisionOutput"""".toRegex().findAll(trace).count()
+    return Json { useArrayPolymorphism = true }.decodeFromString<ArbigentReplayTrace>(trace).steps.size
   }
 
   private fun secondTaskTraceStepCount(): Int {

--- a/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/sample/test/TaskLevelReplayFallbackTest.kt
+++ b/arbigent-core/src/test/kotlin/io/github/takahirom/arbigent/sample/test/TaskLevelReplayFallbackTest.kt
@@ -300,6 +300,80 @@ class TaskLevelReplayFallbackTest {
     )
   }
 
+  /**
+   * A replayed step costs an iteration just like one the AI decides, so the concatenated trace a
+   * fallback would record can be longer than the task's own step limit. Storing it would make the
+   * task fall back, and pay for the AI, on every run from then on.
+   */
+  @Test
+  fun `a fallback does not store a trace longer than the task allows`() = runTest {
+    ArbigentFiles.traceDir =
+      Files.createTempDirectory("arbigent-task-level-fallback-max-step").toFile()
+    val testDispatcher = coroutineContext[CoroutineDispatcher]!!
+
+    var failNextAssertion = false
+    val taskConfig = AgentConfig {
+      deviceFactory { FakeDevice() }
+      aiFactory { FakeAi() }
+      addInterceptor(object : ArbigentDecisionInterceptor {
+        override suspend fun intercept(
+          decisionInput: ArbigentAi.DecisionInput,
+          chain: ArbigentDecisionInterceptor.Chain,
+        ): ArbigentAi.DecisionOutput = chain.proceed(decisionInput).withStepIdOf(decisionInput)
+      })
+      addInterceptor(object : ArbigentImageAssertionInterceptor {
+        override fun intercept(
+          imageAssertionInput: ArbigentAi.ImageAssertionInput,
+          chain: ArbigentImageAssertionInterceptor.Chain,
+        ): ArbigentAi.ImageAssertionOutput {
+          if (!failNextAssertion) return chain.proceed(imageAssertionInput)
+          failNextAssertion = false
+          return failedAssertion()
+        }
+      })
+    }
+
+    // The Fake AI decides two actions and then the goal, which is exactly the limit: a fallback
+    // would concatenate the two it replayed with the three the replacement decided.
+    fun scenario() = ArbigentScenario(
+      id = "scenario",
+      agentTasks = listOf(
+        ArbigentAgentTask("task-1", "goal1", taskConfig, maxStep = 3),
+      ),
+      maxStepCount = 3,
+      tags = setOf(),
+      isLeaf = true,
+      replayWithFallback = true,
+    )
+
+    ArbigentScenarioExecutor(testDispatcher).execute(scenario(), MCPClient())
+    advanceUntilIdle()
+    assertEquals(
+      3,
+      taskTraceStepCount(),
+      "the recording run should have written the three steps the AI decided",
+    )
+
+    failNextAssertion = true
+    ArbigentScenarioExecutor(testDispatcher).execute(scenario(), MCPClient())
+    advanceUntilIdle()
+
+    assertEquals(
+      0,
+      ArbigentFiles.traceDir.listFiles().orEmpty().size,
+      "a trace that could never replay within the step limit should have been discarded",
+    )
+
+    // The next run has no trace, so it runs under the AI and records one that fits again.
+    ArbigentScenarioExecutor(testDispatcher).execute(scenario(), MCPClient())
+    advanceUntilIdle()
+    assertEquals(
+      3,
+      taskTraceStepCount(),
+      "the run after the discard should have recorded a replayable trace again",
+    )
+  }
+
   private fun failedAssertion(): ArbigentAi.ImageAssertionOutput = ArbigentAi.ImageAssertionOutput(
     listOf(
       ArbigentAi.ImageAssertionResult(
@@ -310,6 +384,11 @@ class TaskLevelReplayFallbackTest {
       ),
     ),
   )
+
+  private fun taskTraceStepCount(): Int {
+    val trace = ArbigentFiles.traceDir.listFiles().orEmpty().single().readText()
+    return """"decisionOutput"""".toRegex().findAll(trace).count()
+  }
 
   private fun secondTaskTraceStepCount(): Int {
     val trace = ArbigentFiles.traceDir.listFiles().orEmpty()


### PR DESCRIPTION
## Problem

A replayed step consumes a step iteration exactly like a step the AI decides
(`ArbigentAgent`: `var stepRemain = input.maxStep; while (stepRemain-- > 0 && ...)`).

When a task falls back mid-replay, the trace it records is the concatenation of what it
replayed and what the replacement agent decided. That concatenation can be longer than the
task's own `maxStep`. Such a trace can never replay to its goal again: every later run runs
out of steps before the goal, falls back to the AI, and re-records the same over-long trace —
so the task pays for the AI on every run, forever, while looking like it has a cached replay.

With `maxStep = 3`: replay `[A, B, Goal]` fails its assertion after `A, B`; the replacement
succeeds with `[C, D, Goal]`; the stored trace is `[A, B, C, D, Goal]`, which exhausts its
budget at `C` on the next run.

This is pre-existing: keeping the replayed prefix in a fallback's trace came in with #423
(`0603018d`). #434 widens which tasks can reach it, by removing the exemption that used to
skip the prefix for tasks with resetting initializers.

## Fix

`ArbigentReplayTraceKey` carries the task's `maxStep`, and `invalidReasonFor` rejects a trace
with more steps than that. The existing "why was this trace rejected" plumbing then handles
both directions:

- at the write site, the executor logs the reason and deletes the stale trace, so the next run
  runs under the AI and records a trace that fits;
- at the read site, an already-stored over-long trace (or one that became over-long because
  `maxStep` was lowered) is not replayed. `read()` now logs its reason too, which it previously
  discarded.

`maxStep` is deliberately **not** part of `storageKey`: it is a limit the trace is checked
against, not part of which trace this is. Lowering it must reject the stored trace, not look
past it for a different file.

## Tests

- `ArbigentReplayTraceTest`: a two-step trace reads back under `maxStep = 2` and is refused
  under `maxStep = 1`.
- `TaskLevelReplayFallbackTest`: a task with `maxStep = 3` records a 3-step trace, falls back on
  a failed assertion, and the would-be 5-step trace is discarded rather than stored; the run
  after that records a replayable 3-step trace again.

Both fail without the fix. `:arbigent-core:test` is green.


