### PR TITLE
Add settings.maxRetry as a project-wide retry default

### DIFF
--- a/arbigent-cli/src/main/kotlin/GuideCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GuideCommand.kt
@@ -153,7 +153,8 @@ field name does not fail the load — it just does nothing. After editing, verif
   - `type: "OpenLink"` — `link` (required)
   - `type: "MaestroYaml"` — `scenarioId` referencing an entry in `fixedScenarios`
 - `tags`: list of `- name: "TagName"` entries; used by `run --tags`.
-- `maxStep` (default 10): max AI steps per attempt. `maxRetry` (default 3): retries on failure.
+- `maxStep` (default 10): max AI steps per attempt. `maxRetry`: retries on failure,
+  falling back to `settings.maxRetry` and then to 3.
 - `deviceFormFactor`: `type: "Mobile"` or `type: "Tv"` (default Mobile).
 - `imageAssertions`: list of `assertionPrompt` (required) +
   `requiredFulfillmentPercent` (default 80). Checked against the final screenshot by the AI.
@@ -385,8 +386,8 @@ you suspect the wrong scenarios were selected.
   `Back`) so each attempt starts from a known state.
 - Image assertion failed — check the final screenshot in the report, then reword
   `assertionPrompt` or adjust `requiredFulfillmentPercent`.
-- Flakiness — `maxRetry` (default 3) already retries; prefer fixing the goal or
-  initialization over raising it.
+- Flakiness — `maxRetry` (default 3, or `settings.maxRetry` project-wide) already
+  retries; prefer fixing the goal or initialization over raising it.
 
 Done when: you can state the root cause (selection, environment, starting state, goal
 wording, or assertion), not just that the run went red.

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -261,9 +261,12 @@ public data class ArbigentProjectSettings(
   public val mcpJson: String = DefaultMcpJson,
   public val deviceFormFactor: ArbigentScenarioDeviceFormFactor = ArbigentScenarioDeviceFormFactor.Unspecified,
   public val additionalActions: List<String>? = null,
+  // Retry count for scenarios that do not declare their own. Absent means DefaultMaxRetry.
+  public val maxRetry: Int? = null,
 ) {
   public companion object {
     public const val DefaultMcpJson: String = "{}"
+    public const val DefaultMaxRetry: Int = 3
   }
 }
 
@@ -493,7 +496,7 @@ public fun List<ArbigentScenarioContent>.createArbigentScenario(
   return ArbigentScenario(
     id = scenario.id,
     agentTasks = result,
-    maxRetry = scenario.maxRetry,
+    maxRetry = scenario.maxRetry ?: projectSettings.maxRetry ?: ArbigentProjectSettings.DefaultMaxRetry,
     replayWithFallback = replayWithFallback,
     maxStepCount = scenario.maxStep,
     tags = scenario.tags,
@@ -538,7 +541,8 @@ public class ArbigentScenarioContent @OptIn(ExperimentalUuidApi::class) construc
   public val initializeMethods: InitializationMethod = InitializationMethod.Noop,
   @YamlMultiLineStringStyle(MultiLineStringStyle.Literal)
   public val noteForHumans: String = "",
-  public val maxRetry: Int = 3,
+  // Absent means the project setting, and DefaultMaxRetry when that is absent too.
+  public val maxRetry: Int? = null,
   public val maxStep: Int = 10,
   public val tags: ArbigentContentTags = setOf(),
   public val deviceFormFactor: ArbigentScenarioDeviceFormFactor = ArbigentScenarioDeviceFormFactor.Unspecified,

--- a/arbigent-core/src/test/java/ArbigentProjectFileContentTest.kt
+++ b/arbigent-core/src/test/java/ArbigentProjectFileContentTest.kt
@@ -390,6 +390,22 @@ Previous steps:
   }
 
   @Test
+  fun testMaxRetryRoundTrip() {
+    val serializer = ArbigentProjectSerializer()
+    val reloaded = serializer.load(serializer.encodeToString(projectWithMaxRetry))
+    assertEquals(1, reloaded.settings.maxRetry, "Project maxRetry should survive a round trip")
+    assertNull(
+      reloaded.scenarioContents[0].maxRetry,
+      "A scenario without its own value should stay unset"
+    )
+    assertEquals(
+      5,
+      reloaded.scenarioContents[1].maxRetry,
+      "An explicit scenario maxRetry should survive a round trip"
+    )
+  }
+
+  @Test
   fun testUnsetMaxRetryIsNotSerialized() {
     val serializer = ArbigentProjectSerializer()
     val saved = serializer.encodeToString(projectWithoutMaxRetry)

--- a/arbigent-core/src/test/java/ArbigentProjectFileContentTest.kt
+++ b/arbigent-core/src/test/java/ArbigentProjectFileContentTest.kt
@@ -337,6 +337,87 @@ Previous steps:
     )
   }
 
+  private val projectWithMaxRetry = ArbigentProjectSerializer().load(
+    """
+    settings:
+      maxRetry: 1
+    scenarios:
+    - id: "using-project-max-retry"
+      goal: "Test project max retry"
+    - id: "own-max-retry"
+      goal: "Test scenario max retry"
+      maxRetry: 5
+    """
+  )
+
+  private val projectWithoutMaxRetry = ArbigentProjectSerializer().load(
+    """
+    scenarios:
+    - id: "no-max-retry-anywhere"
+      goal: "Test built-in default"
+    """
+  )
+
+  @Test
+  fun testProjectMaxRetry() {
+    assertEquals(1, projectWithMaxRetry.settings.maxRetry)
+
+    val usingProjectDefault = projectWithMaxRetry.scenarioContents.createArbigentScenario(
+      projectSettings = projectWithMaxRetry.settings,
+      scenario = projectWithMaxRetry.scenarioContents[0],
+      aiFactory = { FakeAi() },
+      deviceFactory = { FakeDevice() },
+      aiDecisionCache = AiDecisionCacheStrategy.InMemory().toCache()
+    )
+    assertEquals(
+      1,
+      usingProjectDefault.maxRetry,
+      "Scenario without maxRetry should use the project setting"
+    )
+
+    val withOwnValue = projectWithMaxRetry.scenarioContents.createArbigentScenario(
+      projectSettings = projectWithMaxRetry.settings,
+      scenario = projectWithMaxRetry.scenarioContents[1],
+      aiFactory = { FakeAi() },
+      deviceFactory = { FakeDevice() },
+      aiDecisionCache = AiDecisionCacheStrategy.InMemory().toCache()
+    )
+    assertEquals(
+      5,
+      withOwnValue.maxRetry,
+      "Scenario maxRetry should override the project setting"
+    )
+  }
+
+  @Test
+  fun testUnsetMaxRetryIsNotSerialized() {
+    val serializer = ArbigentProjectSerializer()
+    val saved = serializer.encodeToString(projectWithoutMaxRetry)
+    assertFalse(
+      saved.contains("maxRetry"),
+      "An unset maxRetry must not be written back, otherwise saving would pin the scenario"
+    )
+  }
+
+  @Test
+  fun testDefaultMaxRetryWhenUnset() {
+    assertNull(projectWithoutMaxRetry.settings.maxRetry)
+    assertNull(projectWithoutMaxRetry.scenarioContents[0].maxRetry)
+
+    val scenario = projectWithoutMaxRetry.scenarioContents.createArbigentScenario(
+      projectSettings = projectWithoutMaxRetry.settings,
+      scenario = projectWithoutMaxRetry.scenarioContents[0],
+      aiFactory = { FakeAi() },
+      deviceFactory = { FakeDevice() },
+      aiDecisionCache = AiDecisionCacheStrategy.InMemory().toCache()
+    )
+    assertEquals(
+      ArbigentProjectSettings.DefaultMaxRetry,
+      scenario.maxRetry,
+      "Scenario should fall back to the built-in default"
+    )
+  }
+
   private val projectWithAdditionalActions = ArbigentProjectSerializer().load(
     """
     settings:

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -313,6 +313,8 @@ class ArbigentAppStateHolder(
   val defaultDeviceFormFactorFlow =
     MutableStateFlow<ArbigentScenarioDeviceFormFactor>(ArbigentScenarioDeviceFormFactor.Unspecified)
   val additionalActionsFlow = MutableStateFlow<List<String>?>(null)
+  // Null means "not set": scenarios without their own maxRetry use the built-in default.
+  val projectMaxRetryFlow = MutableStateFlow<Int?>(null)
   val decisionCache = cacheStrategyFlow
     .map {
       val decisionCacheStrategy = it.aiDecisionCacheStrategy
@@ -423,7 +425,8 @@ class ArbigentAppStateHolder(
         aiOptions = aiOptionsFlow.value,
         mcpJson = mcpJsonFlow.value,
         deviceFormFactor = defaultDeviceFormFactorFlow.value,
-        additionalActions = additionalActionsFlow.value
+        additionalActions = additionalActionsFlow.value,
+        maxRetry = projectMaxRetryFlow.value
       ),
       initialScenarios = allScenarioStateHoldersStateFlow.value.map { scenario ->
         scenario.createScenario(allScenarioStateHoldersStateFlow.value)
@@ -453,7 +456,8 @@ class ArbigentAppStateHolder(
           aiOptions = this@ArbigentAppStateHolder.aiOptionsFlow.value,
           mcpJson = this@ArbigentAppStateHolder.mcpJsonFlow.value,
           deviceFormFactor = this@ArbigentAppStateHolder.defaultDeviceFormFactorFlow.value,
-          additionalActions = this@ArbigentAppStateHolder.additionalActionsFlow.value
+          additionalActions = this@ArbigentAppStateHolder.additionalActionsFlow.value,
+          maxRetry = this@ArbigentAppStateHolder.projectMaxRetryFlow.value
         ),
         scenario = createArbigentScenarioContent(),
         aiFactory = aiFactory,
@@ -529,7 +533,8 @@ class ArbigentAppStateHolder(
         aiOptions = aiOptionsFlow.value,
         mcpJson = mcpJsonFlow.value,
         deviceFormFactor = defaultDeviceFormFactorFlow.value,
-        additionalActions = additionalActionsFlow.value
+        additionalActions = additionalActionsFlow.value,
+        maxRetry = projectMaxRetryFlow.value
       ),
       scenarioContents = sortedScenarios.map { it.createArbigentScenarioContent() },
       reusableScenarios = _reusableScenariosFlow.value,
@@ -602,6 +607,7 @@ class ArbigentAppStateHolder(
     mcpJsonFlow.value = projectFile.settings.mcpJson
     defaultDeviceFormFactorFlow.value = projectFile.settings.deviceFormFactor
     additionalActionsFlow.value = projectFile.settings.additionalActions
+    projectMaxRetryFlow.value = projectFile.settings.maxRetry
     _fixedScenariosFlow.value = projectFile.fixedScenarios
     _reusableScenariosFlow.value = projectFile.reusableScenarios
     projectStateFlow.value = ArbigentProject(
@@ -712,6 +718,10 @@ class ArbigentAppStateHolder(
 
   fun onAdditionalActionsChanged(actions: List<String>?) {
     additionalActionsFlow.value = actions
+  }
+
+  fun onProjectMaxRetryChanged(maxRetry: Int?) {
+    projectMaxRetryFlow.value = maxRetry
   }
 
   fun scenarioCountById(newScenarioId: String): Int {

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentScenarioStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentScenarioStateHolder.kt
@@ -46,7 +46,8 @@ constructor(
   val goal get() = goalState.text.toString()
   val noteForHumans = TextFieldState("")
   val userUserPromptTemplateState = TextFieldState(UserPromptTemplate.DEFAULT_TEMPLATE)
-  val maxRetryState: TextFieldState = TextFieldState("3")
+  // Empty means "not set": the project setting decides, or the built-in default.
+  val maxRetryState: TextFieldState = TextFieldState("")
   val maxStepState: TextFieldState = TextFieldState("10")
   private val cleanupDataStateFlow: MutableStateFlow<ArbigentScenarioContent.CleanupData> =
     MutableStateFlow(
@@ -254,7 +255,7 @@ constructor(
         withValues = steps.singleOrNull()?.withValues ?: emptyMap(),
         steps = if (steps.size == 1) emptyList() else steps,
         noteForHumans = noteForHumans.text.toString(),
-        maxRetry = maxRetryState.text.toString().toIntOrNull() ?: 3,
+        maxRetry = maxRetryState.text.toString().toIntOrNull(),
         tags = tagManager.tagsForScenario(this),
         deviceFormFactor = deviceFormFactorStateFlow.value,
         inputs = reusableInputsStateFlow.value.filter { it.first.isNotBlank() }.toMap(),
@@ -268,7 +269,7 @@ constructor(
       initializationMethods = initializationMethodStateFlow.value
         .filter { it !is ArbigentScenarioContent.InitializationMethod.Noop },
       noteForHumans = noteForHumans.text.toString(),
-      maxRetry = maxRetryState.text.toString().toIntOrNull() ?: 3,
+      maxRetry = maxRetryState.text.toString().toIntOrNull(),
       maxStep = maxStepState.text.toString().toIntOrNull() ?: 10,
       tags = tagManager.tagsForScenario(this),
       deviceFormFactor = deviceFormFactorStateFlow.value,
@@ -293,7 +294,7 @@ constructor(
     reusableInputsStateFlow.value = scenarioContent.inputs.toList()
     onGoalChanged(scenarioContent.goal)
     maxRetryState.edit {
-      replace(0, length, scenarioContent.maxRetry.toString())
+      replace(0, length, scenarioContent.maxRetry?.toString() ?: "")
     }
     maxStepState.edit {
       replace(0, length, scenarioContent.maxStep.toString())

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentScenarioStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentScenarioStateHolder.kt
@@ -48,6 +48,21 @@ constructor(
   val userUserPromptTemplateState = TextFieldState(UserPromptTemplate.DEFAULT_TEMPLATE)
   // Empty means "not set": the project setting decides, or the built-in default.
   val maxRetryState: TextFieldState = TextFieldState("")
+  private var lastValidMaxRetry: Int? = null
+
+  /**
+   * Only a blank field means "not set". Text that is not a number is a partial edit, so it keeps
+   * the last valid value instead of dropping the scenario's override.
+   */
+  private fun currentMaxRetry(): Int? {
+    val input = maxRetryState.text.toString()
+    if (input.isBlank()) {
+      lastValidMaxRetry = null
+      return null
+    }
+    input.toIntOrNull()?.let { lastValidMaxRetry = it }
+    return lastValidMaxRetry
+  }
   val maxStepState: TextFieldState = TextFieldState("10")
   private val cleanupDataStateFlow: MutableStateFlow<ArbigentScenarioContent.CleanupData> =
     MutableStateFlow(
@@ -255,7 +270,7 @@ constructor(
         withValues = steps.singleOrNull()?.withValues ?: emptyMap(),
         steps = if (steps.size == 1) emptyList() else steps,
         noteForHumans = noteForHumans.text.toString(),
-        maxRetry = maxRetryState.text.toString().toIntOrNull(),
+        maxRetry = currentMaxRetry(),
         tags = tagManager.tagsForScenario(this),
         deviceFormFactor = deviceFormFactorStateFlow.value,
         inputs = reusableInputsStateFlow.value.filter { it.first.isNotBlank() }.toMap(),
@@ -269,7 +284,7 @@ constructor(
       initializationMethods = initializationMethodStateFlow.value
         .filter { it !is ArbigentScenarioContent.InitializationMethod.Noop },
       noteForHumans = noteForHumans.text.toString(),
-      maxRetry = maxRetryState.text.toString().toIntOrNull(),
+      maxRetry = currentMaxRetry(),
       maxStep = maxStepState.text.toString().toIntOrNull() ?: 10,
       tags = tagManager.tagsForScenario(this),
       deviceFormFactor = deviceFormFactorStateFlow.value,
@@ -293,6 +308,7 @@ constructor(
     reusableStepsStateFlow.value = scenarioContent.callSteps()
     reusableInputsStateFlow.value = scenarioContent.inputs.toList()
     onGoalChanged(scenarioContent.goal)
+    lastValidMaxRetry = scenarioContent.maxRetry
     maxRetryState.edit {
       replace(0, length, scenarioContent.maxRetry?.toString() ?: "")
     }

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ProjectSettingsDialog.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ProjectSettingsDialog.kt
@@ -9,6 +9,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.foundation.text.input.TextFieldState
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -280,6 +282,32 @@ fun ProjectSettingsDialog(appStateHolder: ArbigentAppStateHolder, onCloseRequest
               .testTag("mcp_json"),
             placeholder = { Text("MCP JSON Configuration") },
             decorationBoxModifier = Modifier.padding(horizontal = 8.dp),
+          )
+
+          GroupHeader("Max Retry")
+          val maxRetry: TextFieldState = remember {
+            TextFieldState(appStateHolder.projectMaxRetryFlow.value?.toString() ?: "")
+          }
+          LaunchedEffect(Unit) {
+            snapshotFlow { maxRetry.text }.collect { text ->
+              val input = text.toString()
+              // Only an empty field means "unset". Text that is not a number keeps the last
+              // valid value, so a typo cannot silently drop the setting.
+              if (input.isBlank()) {
+                appStateHolder.onProjectMaxRetryChanged(null)
+              } else {
+                input.toIntOrNull()?.let { appStateHolder.onProjectMaxRetryChanged(it) }
+              }
+            }
+          }
+          TextField(
+            state = maxRetry,
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+            modifier = Modifier
+              .padding(8.dp)
+              .testTag("project_max_retry"),
+            // Empty falls back to the built-in default for scenarios that do not set their own.
+            placeholder = { Text("Default (3)") },
           )
 
           GroupHeader("Additional Actions")

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/Scenario.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/Scenario.kt
@@ -503,6 +503,8 @@ internal fun ScenarioFundamentalOptions(
         TextField(
           state = updatedScenarioStateHolder.maxRetryState,
           keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Number),
+          // Empty falls back to the project setting, then to the built-in default.
+          placeholder = { Text("Project") },
           modifier = Modifier
             .padding(4.dp),
         )

--- a/arbigent-yaml-reference.md
+++ b/arbigent-yaml-reference.md
@@ -51,7 +51,7 @@ Used both in `scenarios` and `reusableScenarios`.
 | `initializationMethods` | list of [InitializationMethod](#initializationmethod) | `[]` | Setup actions run before the goal. |
 | `initializeMethods` | [InitializationMethod](#initializationmethod) | `Noop` | **Deprecated**; use `initializationMethods`. |
 | `noteForHumans` | String (multiline) | `""` | Free-form note; not sent to the AI. |
-| `maxRetry` | Int | `3` | Retries on failure. |
+| `maxRetry` | Int? | `null` | Retries on failure. Unset falls back to `settings.maxRetry`, then to `3`. |
 | `maxStep` | Int | `10` | Max AI steps per attempt. |
 | `tags` | Set of [Tag](#tag) | `[]` | Tags for `run --tags` (serialized as a sequence). |
 | `deviceFormFactor` | [DeviceFormFactor](#deviceformfactor) | `Unspecified` | Target form factor. |
@@ -102,6 +102,7 @@ Legacy scenario-level field, tagged by `type:`. Distinct from the `CleanupData`
 | `mcpJson` | String (multiline) | `"{}"` | MCP server configuration as a JSON string. |
 | `deviceFormFactor` | [DeviceFormFactor](#deviceformfactor) | `Unspecified` | Default form factor for all scenarios. |
 | `additionalActions` | `List<String>?` | `null` | Project-wide extra actions. |
+| `maxRetry` | Int? | `null` | Default retry count for scenarios that do not set their own. Unset means `3`. |
 
 ### Prompt
 


### PR DESCRIPTION
## Why

A project with many scenarios has no way to set a retry policy once. `maxRetry`
exists only per scenario, so changing the policy means editing every leaf
scenario, and there is no place to express "this project retries less".

## What

`settings.maxRetry` is a new project-level default. Resolution at scenario
construction time:

    scenario.maxRetry ?: settings.maxRetry ?: 3

`ArbigentScenario.maxRetry` (the runtime type) stays non-null — the fallback is
resolved in `createArbigentScenario`, so the executor is untouched.

## Compatibility notes

- `ArbigentScenarioContent.maxRetry` is now `Int?` (was `Int = 3`). This is
  required: with a non-null default, a decoded scenario cannot distinguish
  "field omitted" from "explicitly 3", which would make the project setting dead
  code. It is source- and binary-breaking for library consumers — the Kotlin
  type, the JVM getter, and the constructor/`copy` signatures all change. The
  new `ArbigentProjectSettings` parameter likewise changes its constructor and
  `copy` signatures. There is no apiValidation/binary-compatibility plugin in
  the repo, so nothing flags this automatically.
- Existing project files behave the same: `encodeDefaults = false` means
  `maxRetry: 3` was never written out, so existing files decode as `null` and
  resolve to the same `3`.
- One consequence of that: a scenario that was *explicitly* set to `3` before
  was still omitted on save, so it is indistinguishable from an unset one and
  will now inherit a project value if one is configured. Saves made after this
  change do record an explicit `3`, because the declared default is `null`.

## UI

The scenario field is empty when unset and shows a `Project` placeholder;
Project Settings gained a `Max Retry` field with a `Default (3)` placeholder.
Without this the UI would have written an explicit value on every save and
defeated the project default. An empty field means unset; text that is not a
number keeps the last valid value rather than clearing the setting.

## Not in scope

`--max-retry` on `run` (only `run-task` has one today). Adding it would force a
precedence decision against explicit scenario values; happy to follow up if you
want it.

## Tests

- `testProjectMaxRetry` — a scenario without `maxRetry` uses the project
  setting; a scenario with its own value overrides it.
- `testDefaultMaxRetryWhenUnset` — falls back to `3` when neither is set.
- `testUnsetMaxRetryIsNotSerialized` — an unset value is not written back.

Docs updated in `arbigent-yaml-reference.md` and the `guide` command output.
