### PR TITLE
Improve web report readability and collapse YAML

### DIFF
--- a/arbigent-core-web-report/src/jsMain/kotlin/Main.kt
+++ b/arbigent-core-web-report/src/jsMain/kotlin/Main.kt
@@ -8,6 +8,46 @@ import org.jetbrains.compose.web.dom.*
 import org.jetbrains.compose.web.renderComposableInBody
 import org.w3c.dom.HTMLDivElement
 
+private val reportText = Color("#1e293b")
+private val reportMuted = Color("#64748b")
+private val reportBorder = Color("#e2e8f0")
+private val reportAccent = Color("#2563eb")
+private val reportSuccess = Color("#15803d")
+private val reportFailure = Color("#b91c1c")
+
+private fun StyleScope.heading(size: Int) {
+  fontSize(size.px)
+  fontWeight(600)
+  color(reportText)
+  property("line-height", "1.4")
+  marginBottom(8.px)
+}
+
+private fun StyleScope.metadata() {
+  fontSize(13.px)
+  color(reportMuted)
+  marginBottom(4.px)
+}
+
+private fun StyleScope.outcome(success: Boolean) {
+  fontWeight(600)
+  color(if (success) reportSuccess else reportFailure)
+}
+
+private fun StyleScope.badge() {
+  alignSelf(AlignSelf.FlexStart)
+  margin(0.px, 0.px, 8.px)
+  padding(2.px, 8.px)
+  borderRadius(6.px)
+  fontFamily("inherit")
+  fontSize(12.px)
+  fontWeight(600)
+  whiteSpace("pre-wrap")
+  color(Color("#475569"))
+  backgroundColor(Color("#f1f5f9"))
+  border(1.px, LineStyle.Solid, reportBorder)
+}
+
 @JsExport
 public abstract class ArbigentReportAppController {
   public abstract fun dispose()
@@ -33,8 +73,15 @@ private fun ArbigentReportComposeApp(reportString: String) {
 
   Div({
     style {
-      display(DisplayStyle.Flex) // Use Flexbox for layout
+      display(DisplayStyle.Flex)
       flexDirection(FlexDirection.Row)
+      fontFamily("system-ui", "-apple-system", "BlinkMacSystemFont", "Segoe UI", "sans-serif")
+      fontSize(14.px)
+      property("line-height", "1.6")
+      property("overflow-wrap", "anywhere")
+      color(reportText)
+      backgroundColor(Color("#f8fafc"))
+      minHeight(100.vh)
     }
   }) {
     var selectedScenario by remember { mutableStateOf<ArbigentScenarioResult?>(null) }
@@ -47,18 +94,20 @@ private fun ArbigentReportComposeApp(reportString: String) {
           width(300.px)
           minWidth(300.px)
           flexShrink(0)
-          padding(10.px)
+          padding(24.px, 16.px)
+          property("box-sizing", "border-box")
+          property("border-right", "1px solid #e2e8f0")
         }
       }
     ) {
       val startTimestamp = result.startTimestamp()
       val endTimestamp = result.endTimestamp()
       if (startTimestamp != null && endTimestamp != null) {
-        Div {
+        Div({ style { metadata(); marginBottom(16.px) } }) {
           Text("Duration: ${(endTimestamp.toDouble() - startTimestamp) / 1000}s")
         }
       }
-      Div {
+      Div({ style { heading(16); marginBottom(16.px) } }) {
         Text("Scenarios")
       }
       ScenarioList(result.scenarios, selectedScenario) { scenario ->
@@ -81,21 +130,16 @@ private fun ScenarioList(
   scenarios.forEach { scenario ->
     Div({
       style {
-        padding(8.px)
-        marginBottom(5.px)
-        cursor("pointer") // Change cursor to pointer on hover
-        border {
-          width(1.px)
-          style(LineStyle.Solid)
-          color(Color.gray)
-        }
-        borderRadius(4.px)
+        padding(14.px)
+        marginBottom(10.px)
+        cursor("pointer")
+        border(1.px, LineStyle.Solid, reportBorder)
+        borderRadius(10.px)
+        backgroundColor(Color.white)
         if (scenario == selectedScenario) {
-          backgroundColor(Color.lightgray)
+          backgroundColor(Color("#eff6ff"))
+          border(1.px, LineStyle.Solid, reportAccent)
         }
-//        hover {
-//          backgroundColor(Color.lightgray)
-//        }
       }
       onClick {
         onScenarioSelected(scenario)
@@ -103,9 +147,7 @@ private fun ScenarioList(
     }) {
       Div({
         style {
-          fontWeight("bold")
-          fontSize(14.px)
-          marginBottom(4.px)
+          heading(14)
         }
       }) {
         Text("${scenario.goal ?: scenario.id}")
@@ -114,6 +156,7 @@ private fun ScenarioList(
         style {
           fontSize(12.px)
           marginBottom(2.px)
+          color(reportMuted)
         }
       }) {
         Text("Status: ${scenario.executionStatus ?: "N/A"}")
@@ -122,7 +165,7 @@ private fun ScenarioList(
         style {
           fontSize(12.px)
           marginBottom(2.px)
-          color(if (scenario.isSuccess) Color.green else Color.red)
+          outcome(scenario.isSuccess)
         }
       }) {
         Text("Success: ${scenario.isSuccess}")
@@ -133,7 +176,7 @@ private fun ScenarioList(
         Div({
           style {
             fontSize(12.px)
-            color(Color.gray)
+            color(reportMuted)
           }
         }) {
           Text("Duration: ${(endTimestamp.toDouble() - startTimestamp) / 1000}s")
@@ -150,23 +193,26 @@ private fun ScenarioDetails(scenario: ArbigentScenarioResult) {
       style {
         display(DisplayStyle.Flex)
         flexDirection(FlexDirection.Column)
-        padding(10.px)
+        flexGrow(1)
+        minWidth(0.px)
+        padding(28.px, 32.px)
+        backgroundColor(Color.white)
       }
     }
   ) {
-    Div {
+    Div({ style { heading(26); marginBottom(16.px) } }) {
       Text("Goal: ${scenario.goal ?: "N/A"}")
     }
-    Div {
+    Div({ style { metadata() } }) {
       Text("Status: ${scenario.executionStatus ?: "N/A"}")
     }
-    Div {
+    Div({ style { outcome(scenario.isSuccess); marginBottom(4.px) } }) {
       Text("Success: ${scenario.isSuccess}")
     }
     val startTimestamp = scenario.startTimestamp()
     val endTimestamp = scenario.endTimestamp()
     if (startTimestamp != null && endTimestamp != null) {
-      Div {
+      Div({ style { metadata() } }) {
         Text("Duration: ${(endTimestamp.toDouble() - startTimestamp) / 1000}s")
       }
     }
@@ -184,17 +230,19 @@ private fun AgentResultsView(agentResults: ArbigentAgentResults) {
       style {
         display(DisplayStyle.Flex)
         flexDirection(FlexDirection.Column)
-        marginTop(10.px)
+        marginTop(32.px)
+        paddingTop(24.px)
+        property("border-top", "1px solid #e2e8f0")
       }
     }
   ) {
-    Div {
+    Div({ style { heading(20) } }) {
       Text("Retry History Status: ${agentResults.status}")
     }
     val startTimestamp = agentResults.startTimestamp()
     val endTimestamp = agentResults.endTimestamp()
     if (startTimestamp != null && endTimestamp != null) {
-      Div {
+      Div({ style { metadata() } }) {
         Text("Duration: ${(endTimestamp.toDouble() - startTimestamp) / 1000}s")
       }
     }
@@ -210,38 +258,46 @@ private fun AgentResultView(taskIndex: Int, agentResult: ArbigentAgentResult) {
     style {
       display(DisplayStyle.Flex)
       flexDirection(FlexDirection.Column)
-      border(1.px, LineStyle.Solid, Color.gray)
-      padding(5.px)
-      marginTop(5.px)
+      border(1.px, LineStyle.Solid, reportBorder)
+      borderRadius(12.px)
+      padding(20.px)
+      marginTop(16.px)
     }
   }) {
-    Div {
+    Div({ style { heading(17); marginBottom(12.px) } }) {
       Text("Task($taskIndex) Goal: ${agentResult.goal}")
     }
     agentResult.callBreadcrumb?.let { breadcrumb ->
-      Div {
+      Div({ style { metadata() } }) {
         Text("Called via: $breadcrumb")
       }
     }
-    Div {
+    Div({ style { metadata() } }) {
       Text("Max Steps: ${agentResult.maxStep}")
     }
-    Div {
+    Div({ style { metadata() } }) {
       Text("Device(Form Factor): ${agentResult.deviceName}(${agentResult.deviceFormFactor})")
     }
-    Div {
+    Div({ style { outcome(agentResult.isGoalAchieved); marginBottom(4.px) } }) {
       Text("Goal Achieved: ${agentResult.isGoalAchieved}")
     }
     val startTimestamp = agentResult.startTimestamp
     val endTimestamp = agentResult.endTimestamp
     if (startTimestamp != null && endTimestamp != null) {
-      Div {
+      Div({ style { metadata() } }) {
         Text("Duration: ${(endTimestamp.toDouble() - startTimestamp) / 1000}s")
       }
     }
 
     agentResult.steps.forEachIndexed { index, step ->
-      Div {
+      Div({
+        style {
+          heading(14)
+          marginTop(24.px)
+          paddingTop(16.px)
+          property("border-top", "1px solid #e2e8f0")
+        }
+      }) {
         Text("Step(${(index + 1)}/${agentResult.steps.size})")
       }
       StepView(step)
@@ -261,7 +317,8 @@ private fun StepView(step: ArbigentAgentTaskStepResult) {
     style {
       display(DisplayStyle.Flex)
       flexDirection(FlexDirection.Row)
-      marginTop(5.px)
+      marginTop(8.px)
+      property("gap", "20px")
     }
   }) {
     Div(
@@ -270,14 +327,15 @@ private fun StepView(step: ArbigentAgentTaskStepResult) {
           display(DisplayStyle.Flex)
           flexDirection(FlexDirection.Column)
           flexGrow(1)
+          property("flex-basis", "0")
+          minWidth(0.px)
         }
       }
     ) {
       if (step.stepSource != ArbigentStepSource.Ai) {
         Pre({
           style {
-            whiteSpace("pre-wrap")
-            backgroundColor(Color.lightgreen)
+            badge()
           }
         }) {
           Text(
@@ -292,8 +350,9 @@ private fun StepView(step: ArbigentAgentTaskStepResult) {
       if (step.agentAction?.contains("MCP") == true) {
         Pre({
           style {
-            whiteSpace("pre-wrap")
-            backgroundColor(Color.lightblue)
+            badge()
+            color(Color("#1d4ed8"))
+            backgroundColor(Color("#eff6ff"))
           }
         }) {
           Text("MCP")
@@ -302,6 +361,9 @@ private fun StepView(step: ArbigentAgentTaskStepResult) {
       Pre({
         style {
           whiteSpace("pre-wrap")
+          fontFamily("inherit")
+          fontSize(14.px)
+          margin(0.px, 0.px, 12.px)
         }
       }) {
         Text("${step.summary} (Time: ${formatTimestamp(step.timestamp)})")
@@ -330,7 +392,8 @@ private fun StepView(step: ArbigentAgentTaskStepResult) {
                 attr("target", "_blank")
                 attr("rel", "noopener noreferrer")
                 style {
-                  color(Color.blue)
+                  color(reportAccent)
+                  fontSize(12.px)
                   textDecoration("underline")
                 }
               }
@@ -354,10 +417,11 @@ private fun StepView(step: ArbigentAgentTaskStepResult) {
     Div({
       style {
         width(40.percent)
-        minWidth(20.percent)
+        minWidth(0.px)
+        flexShrink(0)
         display(DisplayStyle.Flex)
         flexDirection(FlexDirection.Column)
-        alignItems(AlignItems.Center)
+        alignItems(AlignItems.Stretch)
       }
     }) {
       if (step.screenshotFilePath.isNotEmpty()) {
@@ -396,7 +460,9 @@ public fun ExpandableSection(
       style {
         display(DisplayStyle.Flex)
         flexDirection(FlexDirection.Column)
-        marginBottom(10.px)
+        marginBottom(12.px)
+        minWidth(0.px)
+        property("gap", "8px")
       }
     }
   ) {
@@ -404,10 +470,18 @@ public fun ExpandableSection(
       style {
         display(DisplayStyle.Flex)
         flexDirection(FlexDirection.Row)
-        justifyContent(JustifyContent.SpaceBetween)
+        alignItems(AlignItems.Center)
+        alignSelf(AlignSelf.FlexStart)
+        property("gap", "8px")
         cursor("pointer")
-        padding(5.px)
-        backgroundColor(Color.lightgray)
+        padding(4.px, 8.px)
+        fontSize(12.px)
+        fontWeight(500)
+        property("line-height", "1.4")
+        color(reportMuted)
+        backgroundColor(Color("#f8fafc"))
+        border(1.px, LineStyle.Solid, reportBorder)
+        borderRadius(6.px)
       }
       onClick {
         expanded = !expanded
@@ -434,7 +508,9 @@ public fun AsyncImage(
       style {
         maxWidth(100.percent)
         maxHeight(400.px)
-//        objectFit(ObjectFit.Contain) // Maintain aspect ratio while fitting within bounds
+        alignSelf(AlignSelf.FlexStart)
+        property("object-fit", "contain")
+        borderRadius(6.px)
       }
     }
   )

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReportHtml.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ReportHtml.kt
@@ -21,9 +21,12 @@ public const val arbigentReportHtml: String = """
     <title>Report</title>
 </head>
 <body>
-<pre id="result">
+<details style="margin:12px 0; padding:12px 16px; border:1px solid #e2e8f0; border-radius:8px; background:#f8fafc; color:#1e293b; font-family:system-ui, sans-serif; font-size:13px;">
+<summary style="cursor:pointer; font-weight:600;">Report YAML</summary>
+<pre id="result" style="margin:12px 0 0; white-space:pre-wrap; overflow-wrap:anywhere;">
 $arbigentReportTemplateString
 </pre>
+</details>
 <div id="container" style="padding-top:20px;"></div>
 <script type="application/javascript" src="arbigent-core-web-report.js"></script>
 <script type="application/javascript">


### PR DESCRIPTION
# What

Improve Arbigent web report readability with scenario cards, clearer headings, consistent outcome colors, compact badges and screenshot toggles, and collapsible YAML. Preserve report data and JSONL links.

Validation: `:arbigent-core-web-report:jsBrowserDistribution` passed. HTML report tests were blocked during configuration by the version plugin's Git worktree handling.

# Why

Make execution results easier to scan while keeping detailed diagnostics accessible.
