### PR TITLE
Add arbigent sort with position comments for scenario order

### DIFF
--- a/README.md
+++ b/README.md
@@ -556,17 +556,18 @@ arbigent tags
 arbigent graph
 ```
 
-**Keep the project file in dependency order** (depth-first: each scenario after the scenario it depends on, together with everything that depends on it, before the next sibling; roots and siblings in their declared order). `sort` also writes a *position comment* above every scenario so that anyone reading one scenario in the flat YAML — including a coding agent — can see its depth, ancestors and dependents without searching the file. Only the scenario blocks are reordered and only these comments are rewritten; quoting, other comments and unknown keys are left as they are. The UI writes the same comments on save; set `settings.positionComments: false` in the project file to turn them off.
+**Keep the project file in dependency order** (depth-first: each scenario after the scenario it depends on, together with everything that depends on it, before the next sibling; roots and siblings in their declared order). `sort` also writes a *position comment* above every scenario so that anyone reading one scenario in the flat YAML — including a coding agent — can see its ancestors and its direct dependents without searching the file. Only the scenario blocks are reordered and only these comments are rewritten; quoting, other comments and unknown keys are left as they are. The UI writes the same comments on save; set `settings.positionComments: false` in the project file to turn them off.
 ```bash
 arbigent sort            # rewrite the project file
 arbigent sort --diff     # CI check: print what would change, exit 1 if anything
 ```
 ```yaml
 scenarios:
-# [depth 0] launch-app | children: open-search, open-settings
+# The "# tree:" lines below are generated from `dependency` by `arbigent sort` (and on UI save); do not edit them, rerun `arbigent sort`.
+# tree: launch-app | children: open-search, open-settings
 - id: "launch-app"
   goal: "Launch the app"
-# [depth 1] launch-app > open-search | children: type-keyword
+# tree: launch-app > open-search | children: type-keyword
 - id: "open-search"
   goal: "Open search"
   dependency: "launch-app"
@@ -599,7 +600,7 @@ The CLI is designed so that AI coding agents (Claude Code, Codex, etc.) can oper
 
 - `arbigent --help` ends with the list of built-in guide topics, and `arbigent guide <topic>` prints an agent-oriented guide (`setup`, `writing-yaml`, `inspecting-project`, `running-scenarios`, `debugging-failures`).
 - `arbigent scenarios`, `arbigent tags`, and `arbigent graph` let an agent inspect a project without an AI API key or a device, and `arbigent run --dry-run` previews which scenarios would run without needing a device.
-- `arbigent sort` keeps the YAML in dependency order and refreshes the `# [depth N] ...` position comment above each scenario, so an agent editing one scenario sees where it sits in the dependency tree; `arbigent sort --diff` in CI catches files that drift after a hand edit.
+- `arbigent sort` keeps the YAML in dependency order and refreshes the `# tree: ...` position comment above each scenario, so an agent editing one scenario sees where it sits in the dependency tree; `arbigent sort --diff` in CI catches files that drift after a hand edit.
 - `arbigent run` writes machine-readable results to `arbigent-result/result.yml` alongside the HTML report and screenshots, so an agent can check the outcome and debug failures.
 
 For example, you can instruct your agent:

--- a/README.md
+++ b/README.md
@@ -556,7 +556,7 @@ arbigent tags
 arbigent graph
 ```
 
-**Keep the project file in dependency order** (each scenario directly after the scenario it depends on, roots and siblings in their declared order). `sort` also writes a *position comment* above every scenario so that anyone reading one scenario in the flat YAML — including a coding agent — can see its depth, ancestors and dependents without searching the file. Only the scenario blocks are reordered and only these comments are rewritten; quoting, other comments and unknown keys are left as they are. The UI writes the same comments on save; set `settings.positionComments: false` in the project file to turn them off.
+**Keep the project file in dependency order** (depth-first: each scenario after the scenario it depends on, together with everything that depends on it, before the next sibling; roots and siblings in their declared order). `sort` also writes a *position comment* above every scenario so that anyone reading one scenario in the flat YAML — including a coding agent — can see its depth, ancestors and dependents without searching the file. Only the scenario blocks are reordered and only these comments are rewritten; quoting, other comments and unknown keys are left as they are. The UI writes the same comments on save; set `settings.positionComments: false` in the project file to turn them off.
 ```bash
 arbigent sort            # rewrite the project file
 arbigent sort --diff     # CI check: print what would change, exit 1 if anything

--- a/README.md
+++ b/README.md
@@ -556,6 +556,22 @@ arbigent tags
 arbigent graph
 ```
 
+**Keep the project file in dependency order** (each scenario directly after the scenario it depends on, roots and siblings in their declared order). `sort` also writes a *position comment* above every scenario so that anyone reading one scenario in the flat YAML — including a coding agent — can see its depth, ancestors and dependents without searching the file. Only the scenario blocks are reordered and only these comments are rewritten; quoting, other comments and unknown keys are left as they are. The UI writes the same comments on save; set `settings.positionComments: false` in the project file to turn them off.
+```bash
+arbigent sort            # rewrite the project file
+arbigent sort --diff     # CI check: print what would change, exit 1 if anything
+```
+```yaml
+scenarios:
+# [depth 0] launch-app | children: open-search, open-settings
+- id: "launch-app"
+  goal: "Launch the app"
+# [depth 1] launch-app > open-search | children: type-keyword
+- id: "open-search"
+  goal: "Open search"
+  dependency: "launch-app"
+```
+
 **Run a one-shot task without a project file:**
 
 `arbigent run task` executes a single ad-hoc goal on the connected device, using the same AI and OS options as `arbigent run`:
@@ -583,6 +599,7 @@ The CLI is designed so that AI coding agents (Claude Code, Codex, etc.) can oper
 
 - `arbigent --help` ends with the list of built-in guide topics, and `arbigent guide <topic>` prints an agent-oriented guide (`setup`, `writing-yaml`, `inspecting-project`, `running-scenarios`, `debugging-failures`).
 - `arbigent scenarios`, `arbigent tags`, and `arbigent graph` let an agent inspect a project without an AI API key or a device, and `arbigent run --dry-run` previews which scenarios would run without needing a device.
+- `arbigent sort` keeps the YAML in dependency order and refreshes the `# [depth N] ...` position comment above each scenario, so an agent editing one scenario sees where it sits in the dependency tree; `arbigent sort --diff` in CI catches files that drift after a hand edit.
 - `arbigent run` writes machine-readable results to `arbigent-result/result.yml` alongside the HTML report and screenshots, so an agent can check the outcome and debug failures.
 
 For example, you can instruct your agent:

--- a/arbigent-cli-reference.md
+++ b/arbigent-cli-reference.md
@@ -149,6 +149,21 @@ Takes a positional `goal` argument (required), the AI-provider group, `--os`,
 
 `--project-file`, `--log-level` (both settings-aware).
 
+### `sort`
+
+Rewrites the project file so each scenario directly follows the scenario it depends on
+(roots and siblings keep their declared order) and refreshes the `# [depth N] root > ... > id | children: ...`
+position comment above each scenario. Only the scenario blocks move and only those comment
+lines change; the rest of the file is left byte for byte. Requires a YAML project file (not a
+Journeys XML source) that passes validation.
+
+| Flag | Settings key | Notes |
+|---|---|---|
+| `--project-file` | `project-file` | |
+| `--log-level` | `log-level` | |
+| `--diff` | | Print a unified diff of what would change and exit `1` if there is any; the file is not written. Exit `0` with `Already sorted` otherwise. |
+| `--comments` / `--no-comments` | | Write or remove the position comments. Default: the project's `settings.positionComments` (`true` unless set). |
+
 ### `instruction`
 
 All settings-aware (keys `scenario-ids`, `include-app-ui-structure`, etc., or

--- a/arbigent-cli-reference.md
+++ b/arbigent-cli-reference.md
@@ -153,9 +153,9 @@ Takes a positional `goal` argument (required), the AI-provider group, `--os`,
 
 Rewrites the project file into depth-first dependency order: each scenario comes after the
 scenario it depends on, and its whole subtree comes before the next sibling (roots and siblings
-keep their declared order). It also refreshes the `# [depth N] root > ... > id | children: ...`
-position comment above each scenario. Only the scenario blocks move and only those comment
-lines change; the rest of the file is left byte for byte. Requires a YAML project file (not a
+keep their declared order). It also refreshes the `# tree: root > ... > id | children: ...`
+position comment above each scenario, plus one header line under `scenarios:` saying the comments
+are generated. Only the scenario blocks move and only those comment lines change; the rest of the file is left byte for byte. Requires a YAML project file (not a
 Journeys XML source) that passes validation.
 
 | Flag | Settings key | Notes |

--- a/arbigent-cli-reference.md
+++ b/arbigent-cli-reference.md
@@ -151,8 +151,9 @@ Takes a positional `goal` argument (required), the AI-provider group, `--os`,
 
 ### `sort`
 
-Rewrites the project file so each scenario directly follows the scenario it depends on
-(roots and siblings keep their declared order) and refreshes the `# [depth N] root > ... > id | children: ...`
+Rewrites the project file into depth-first dependency order: each scenario comes after the
+scenario it depends on, and its whole subtree comes before the next sibling (roots and siblings
+keep their declared order). It also refreshes the `# [depth N] root > ... > id | children: ...`
 position comment above each scenario. Only the scenario blocks move and only those comment
 lines change; the rest of the file is left byte for byte. Requires a YAML project file (not a
 Journeys XML source) that passes validation.

--- a/arbigent-cli/build.gradle.kts
+++ b/arbigent-cli/build.gradle.kts
@@ -114,6 +114,8 @@ dependencies {
   implementation("com.github.ajalt.clikt:clikt:5.0.2")
   implementation("com.jakewharton.mosaic:mosaic-runtime:0.18.0")
   implementation("com.charleskorn.kaml:kaml:0.83.0")
+  // Unified diff output for `arbigent sort --diff`.
+  implementation("io.github.java-diff-utils:java-diff-utils:4.12")
   implementation(project(":arbigent-core"))
   implementation(project(":arbigent-ai-openai"))
   implementation(project(":arbigent-ai-anthropic"))

--- a/arbigent-cli/src/main/kotlin/GuideCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GuideCommand.kt
@@ -266,7 +266,8 @@ the root down to this scenario, then its direct dependents. A header line under 
 says that these lines are generated. They are derived from `dependency` and regenerated on
 every sort or UI save, so never edit them by hand; after adding or moving a `dependency`, run
 `sort` so they are true again. Nothing else in the file is changed: quoting, other comments and
-unknown keys stay as they were.
+unknown keys stay as they were; only a comment starting with `# tree:` right above a scenario is
+treated as the sorter's own.
 
 Because an id also appears in the `# tree:` lines of every scenario below it, grep with the key:
 `grep 'id: "open-search"'` finds the definition and `grep 'dependency: "open-search"'` finds

--- a/arbigent-cli/src/main/kotlin/GuideCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GuideCommand.kt
@@ -266,8 +266,8 @@ the root down to this scenario, then its direct dependents. A header line under 
 says that these lines are generated. They are derived from `dependency` and regenerated on
 every sort or UI save, so never edit them by hand; after adding or moving a `dependency`, run
 `sort` so they are true again. Nothing else in the file is changed: quoting, other comments and
-unknown keys stay as they were; only a comment starting with `# tree:` right above a scenario is
-treated as the sorter's own.
+unknown keys stay as they were; only a comment starting with `# tree:` inside the `scenarios:` list
+(between or after its items) is treated as the sorter's own.
 
 Because an id also appears in the `# tree:` lines of every scenario below it, grep with the key:
 `grep 'id: "open-search"'` finds the definition and `grep 'dependency: "open-search"'` finds

--- a/arbigent-cli/src/main/kotlin/GuideCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GuideCommand.kt
@@ -145,7 +145,7 @@ field name does not fail the load — it just does nothing. After editing, verif
   add guardrails ("Be careful not to open other pages").
 - `dependency`: id of another scenario that must run first (its steps are executed
   before this scenario's goal). Place a new scenario after its dependency (after any earlier siblings and their subtrees) and run
-  `arbigent sort` afterwards: it fixes the order and rewrites the `# [depth N] ...`
+  `arbigent sort` afterwards: it fixes the order and rewrites the `# tree: ...`
   position comments above each scenario (see `arbigent guide inspecting-project`).
 - `initializationMethods`: list of setup actions, each with a `type` field:
   - `type: "LaunchApp"` — `packageName` (required), `launchArguments` (optional map)
@@ -259,12 +259,18 @@ as Mermaid text, ready to embed in Markdown.
     arbigent sort --project-file=path/to/project.yaml
     arbigent sort --diff --project-file=path/to/project.yaml   # CI check, exit 1 if not sorted
 
-`sort` puts the scenarios in depth-first dependency order (each scenario after the scenario it depends on, its subtree before the next sibling) and writes a
-position comment above it, e.g. `# [depth 2] launch-app > log-in > open-search | children: type-keyword`.
-The comment is derived from `dependency` and regenerated on every sort or UI save, so it
-tells you a scenario's depth, ancestors and dependents without searching the file. After
-adding or moving a `dependency`, run `sort` so the comments are true again. Nothing else
-in the file is changed: quoting, other comments and unknown keys stay as they were.
+`sort` puts the scenarios in depth-first dependency order (each scenario after the scenario it
+depends on, its subtree before the next sibling) and writes a position comment above each one,
+e.g. `# tree: launch-app > log-in > open-search | children: type-keyword`: the ancestors from
+the root down to this scenario, then its direct dependents. A header line under `scenarios:`
+says that these lines are generated. They are derived from `dependency` and regenerated on
+every sort or UI save, so never edit them by hand; after adding or moving a `dependency`, run
+`sort` so they are true again. Nothing else in the file is changed: quoting, other comments and
+unknown keys stay as they were.
+
+Because an id also appears in the `# tree:` lines of every scenario below it, grep with the key:
+`grep 'id: "open-search"'` finds the definition and `grep 'dependency: "open-search"'` finds
+the scenarios that build on it.
 
 ## How --project-file is resolved
 

--- a/arbigent-cli/src/main/kotlin/GuideCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GuideCommand.kt
@@ -267,7 +267,9 @@ says that these lines are generated. They are derived from `dependency` and rege
 every sort or UI save, so never edit them by hand; after adding or moving a `dependency`, run
 `sort` so they are true again. Nothing else in the file is changed: quoting, other comments and
 unknown keys stay as they were; only a comment starting with `# tree:` inside the `scenarios:` list
-(between or after its items) is treated as the sorter's own.
+(between or after its items) is treated as the sorter's own. A save from the UI, by contrast,
+regenerates the whole file and drops hand-written comments; notes that must survive belong in
+`noteForHumans`.
 
 Because an id also appears in the `# tree:` lines of every scenario below it, grep with the key:
 `grep 'id: "open-search"'` finds the definition and `grep 'dependency: "open-search"'` finds

--- a/arbigent-cli/src/main/kotlin/GuideCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GuideCommand.kt
@@ -144,7 +144,7 @@ field name does not fail the load — it just does nothing. After editing, verif
 - `goal`: string. Natural-language goal the AI agent tries to achieve. Be specific and
   add guardrails ("Be careful not to open other pages").
 - `dependency`: id of another scenario that must run first (its steps are executed
-  before this scenario's goal). Place a new scenario right after its dependency and run
+  before this scenario's goal). Place a new scenario after its dependency (after any earlier siblings and their subtrees) and run
   `arbigent sort` afterwards: it fixes the order and rewrites the `# [depth N] ...`
   position comments above each scenario (see `arbigent guide inspecting-project`).
 - `initializationMethods`: list of setup actions, each with a `type` field:
@@ -259,7 +259,7 @@ as Mermaid text, ready to embed in Markdown.
     arbigent sort --project-file=path/to/project.yaml
     arbigent sort --diff --project-file=path/to/project.yaml   # CI check, exit 1 if not sorted
 
-`sort` moves each scenario directly after the scenario it depends on and writes a
+`sort` puts the scenarios in depth-first dependency order (each scenario after the scenario it depends on, its subtree before the next sibling) and writes a
 position comment above it, e.g. `# [depth 2] launch-app > log-in > open-search | children: type-keyword`.
 The comment is derived from `dependency` and regenerated on every sort or UI save, so it
 tells you a scenario's depth, ancestors and dependents without searching the file. After

--- a/arbigent-cli/src/main/kotlin/GuideCommand.kt
+++ b/arbigent-cli/src/main/kotlin/GuideCommand.kt
@@ -144,7 +144,9 @@ field name does not fail the load — it just does nothing. After editing, verif
 - `goal`: string. Natural-language goal the AI agent tries to achieve. Be specific and
   add guardrails ("Be careful not to open other pages").
 - `dependency`: id of another scenario that must run first (its steps are executed
-  before this scenario's goal).
+  before this scenario's goal). Place a new scenario right after its dependency and run
+  `arbigent sort` afterwards: it fixes the order and rewrites the `# [depth N] ...`
+  position comments above each scenario (see `arbigent guide inspecting-project`).
 - `initializationMethods`: list of setup actions, each with a `type` field:
   - `type: "LaunchApp"` — `packageName` (required), `launchArguments` (optional map)
   - `type: "CleanupData"` — `packageName` (required); clears app data
@@ -251,6 +253,18 @@ with `run --tags`.
 
 Prints the scenario dependency graph (`dependency` edges and reusable `uses` edges)
 as Mermaid text, ready to embed in Markdown.
+
+## Keep the file in dependency order
+
+    arbigent sort --project-file=path/to/project.yaml
+    arbigent sort --diff --project-file=path/to/project.yaml   # CI check, exit 1 if not sorted
+
+`sort` moves each scenario directly after the scenario it depends on and writes a
+position comment above it, e.g. `# [depth 2] launch-app > log-in > open-search | children: type-keyword`.
+The comment is derived from `dependency` and regenerated on every sort or UI save, so it
+tells you a scenario's depth, ancestors and dependents without searching the file. After
+adding or moving a `dependency`, run `sort` so the comments are true again. Nothing else
+in the file is changed: quoting, other comments and unknown keys stay as they were.
 
 ## How --project-file is resolved
 

--- a/arbigent-cli/src/main/kotlin/SortCommand.kt
+++ b/arbigent-cli/src/main/kotlin/SortCommand.kt
@@ -16,7 +16,7 @@ import java.io.File
 
 /**
  * Rewrites the project file so each scenario follows the scenario it depends on and carries a
- * position comment (`# [depth N] root > ... > id | children: ...`). Text outside the reordered
+ * position comment (`# tree: root > ... > id | children: ...`). Text outside the reordered
  * blocks is left untouched. `--diff` reports what would change instead of writing, for CI.
  */
 class ArbigentSortCommand : CliktCommand(name = "sort") {
@@ -71,7 +71,8 @@ class ArbigentSortCommand : CliktCommand(name = "sort") {
   private fun summarize(result: ArbigentScenarioSorter.Result): String {
     fun count(n: Int, noun: String) = "$n $noun" + if (n == 1) "" else "s"
     return count(result.movedScenarioIds.size, "scenario") + " out of place, " +
-      count(result.staleCommentScenarioIds.size, "position comment") + " stale."
+      count(result.staleCommentScenarioIds.size, "position comment") + " stale" +
+      (if (result.headerStale) ", header comment stale." else ".")
   }
 
   private fun unifiedDiff(path: String, original: String, revised: String): String {

--- a/arbigent-cli/src/main/kotlin/SortCommand.kt
+++ b/arbigent-cli/src/main/kotlin/SortCommand.kt
@@ -31,7 +31,7 @@ class ArbigentSortCommand : CliktCommand(name = "sort") {
   ).switch("--comments" to true, "--no-comments" to false)
 
   override fun help(context: Context): String =
-    "Reorder scenarios so each one follows its dependency and refresh the position comments above them"
+    "Reorder scenarios into depth-first dependency order and refresh the position comments above them"
 
   override fun run() {
     applyLogLevel(logLevel)

--- a/arbigent-cli/src/main/kotlin/SortCommand.kt
+++ b/arbigent-cli/src/main/kotlin/SortCommand.kt
@@ -1,0 +1,84 @@
+@file:OptIn(ArbigentInternalApi::class)
+
+package io.github.takahirom.arbigent.cli
+
+import com.github.ajalt.clikt.core.CliktCommand
+import com.github.ajalt.clikt.core.CliktError
+import com.github.ajalt.clikt.core.Context
+import com.github.ajalt.clikt.core.ProgramResult
+import com.github.ajalt.clikt.parameters.options.flag
+import com.github.ajalt.clikt.parameters.options.option
+import com.github.ajalt.clikt.parameters.options.switch
+import com.github.difflib.DiffUtils
+import com.github.difflib.UnifiedDiffUtils
+import io.github.takahirom.arbigent.*
+import java.io.File
+
+/**
+ * Rewrites the project file so each scenario follows the scenario it depends on and carries a
+ * position comment (`# [depth N] root > ... > id | children: ...`). Text outside the reordered
+ * blocks is left untouched. `--diff` reports what would change instead of writing, for CI.
+ */
+class ArbigentSortCommand : CliktCommand(name = "sort") {
+  private val projectFile by projectFileOption()
+  private val logLevel by logLevelOption()
+  private val diff by option(
+    "--diff",
+    help = "Print a unified diff of what sort would change and exit with status 1 if there is any; the file is not modified"
+  ).flag(default = false)
+  private val comments: Boolean? by option(
+    help = "Write (default) or remove the position comments above each scenario; the default is the project's settings.positionComments"
+  ).switch("--comments" to true, "--no-comments" to false)
+
+  override fun help(context: Context): String =
+    "Reorder scenarios so each one follows its dependency and refresh the position comments above them"
+
+  override fun run() {
+    applyLogLevel(logLevel)
+    val path = requireProjectFile(projectFile)
+    if (isJourneyProjectSource(path)) {
+      throw CliktError("sort only works on an arbigent YAML project file, not on a Journeys XML source: $path")
+    }
+    val file = File(path)
+    if (!file.isFile) throw CliktError("Project file not found: $path")
+    val original = file.readText()
+    // Loading first turns a broken `dependency` graph into the usual validation report.
+    val content = loadArbigentProjectFileContent(path)
+    val result = try {
+      ArbigentScenarioSorter.sort(
+        yamlText = original,
+        content = content,
+        positionComments = comments ?: content.settings.positionComments,
+      )
+    } catch (e: IllegalArgumentException) {
+      throw CliktError("Cannot sort $path: ${e.message}")
+    }
+
+    if (result.yaml == original) {
+      echo("Already sorted: $path")
+      return
+    }
+    val summary = summarize(result)
+    if (diff) {
+      echo(unifiedDiff(path, original, result.yaml))
+      echo("$summary Run `arbigent sort` to apply.")
+      throw ProgramResult(1)
+    }
+    file.writeText(result.yaml)
+    echo("Sorted $path: $summary")
+  }
+
+  private fun summarize(result: ArbigentScenarioSorter.Result): String {
+    fun count(n: Int, noun: String) = "$n $noun" + if (n == 1) "" else "s"
+    return count(result.movedScenarioIds.size, "scenario") + " out of place, " +
+      count(result.staleCommentScenarioIds.size, "position comment") + " stale."
+  }
+
+  private fun unifiedDiff(path: String, original: String, revised: String): String {
+    val originalLines = original.lines()
+    val revisedLines = revised.lines()
+    val patch = DiffUtils.diff(originalLines, revisedLines)
+    return UnifiedDiffUtils.generateUnifiedDiff(path, "$path (sorted)", originalLines, patch, 3)
+      .joinToString("\n")
+  }
+}

--- a/arbigent-cli/src/main/kotlin/main.kt
+++ b/arbigent-cli/src/main/kotlin/main.kt
@@ -77,6 +77,7 @@ fun arbigentCli(): ArbigentCli = ArbigentCli()
     ArbigentScenariosCommand(),
     ArbigentTagsCommand(),
     ArbigentGraphCommand(),
+    ArbigentSortCommand(),
     ArbigentInstructionCommand(),
     ArbigentGuideCommand(),
     ArbigentWrapperCommand(),

--- a/arbigent-cli/src/test/kotlin/SortCommandTest.kt
+++ b/arbigent-cli/src/test/kotlin/SortCommandTest.kt
@@ -44,26 +44,27 @@ scenarios:
     val result = ArbigentSortCommand().test("--project-file=${yaml.absolutePath}")
 
     assertEquals(0, result.statusCode, result.output)
-    assertContains(result.output, "Sorted ${yaml.absolutePath}: 3 scenarios out of place, 5 position comments stale.")
+    assertContains(result.output, "Sorted ${yaml.absolutePath}: 3 scenarios out of place, 5 position comments stale, header comment stale.")
     assertEquals(
       """
 scenarios:
-# [depth 0] launch-app | children: open-search, open-settings
+# The "# tree:" lines below are generated from `dependency` by `arbigent sort` (and on UI save); do not edit them, rerun `arbigent sort`.
+# tree: launch-app | children: open-search, open-settings
 - id: "launch-app"
   goal: "Launch the app"
-# [depth 1] launch-app > open-search | children: type-keyword
+# tree: launch-app > open-search | children: type-keyword
 - id: "open-search"
   goal: "Open search"
   dependency: "launch-app"
-# [depth 2] launch-app > open-search > type-keyword
+# tree: launch-app > open-search > type-keyword
 - id: "type-keyword"
   goal: "Type a keyword"
   dependency: "open-search"
-# [depth 1] launch-app > open-settings | children: toggle-dark-mode
+# tree: launch-app > open-settings | children: toggle-dark-mode
 - id: "open-settings"
   goal: "Open settings"
   dependency: "launch-app"
-# [depth 2] launch-app > open-settings > toggle-dark-mode
+# tree: launch-app > open-settings > toggle-dark-mode
 - id: "toggle-dark-mode"
   goal: "Toggle dark mode"
   dependency: "open-settings"
@@ -92,8 +93,8 @@ scenarios:
     assertEquals(unsorted, yaml.readText())
     assertContains(result.output, "--- ${yaml.absolutePath}")
     assertContains(result.output, "+++ ${yaml.absolutePath} (sorted)")
-    assertContains(result.output, "+# [depth 2] launch-app > open-search > type-keyword")
-    assertContains(result.output, "3 scenarios out of place, 5 position comments stale. Run `arbigent sort` to apply.")
+    assertContains(result.output, "+# tree: launch-app > open-search > type-keyword")
+    assertContains(result.output, "3 scenarios out of place, 5 position comments stale, header comment stale. Run `arbigent sort` to apply.")
   }
 
   @Test
@@ -109,13 +110,13 @@ scenarios:
   @Test
   fun `no-comments sorts without position comments and removes existing ones`() {
     ArbigentSortCommand().test("--project-file=${yaml.absolutePath}")
-    assertTrue(yaml.readText().contains("# [depth"))
+    assertTrue(yaml.readText().contains("# tree:"))
 
     val result = ArbigentSortCommand().test("--project-file=${yaml.absolutePath} --no-comments")
 
     assertEquals(0, result.statusCode, result.output)
-    assertFalse(yaml.readText().contains("# [depth"), yaml.readText())
-    assertContains(result.output, "0 scenarios out of place, 5 position comments stale.")
+    assertFalse(yaml.readText().contains("#"), yaml.readText())
+    assertContains(result.output, "0 scenarios out of place, 5 position comments stale, header comment stale.")
   }
 
   @Test
@@ -134,6 +135,6 @@ scenarios:
     assertEquals(1, result.statusCode, result.output)
     assertContains(result.output, "Invalid project configuration in ${yaml.absolutePath}")
     assertContains(result.output, "'missing'")
-    assertFalse(yaml.readText().contains("# [depth"))
+    assertFalse(yaml.readText().contains("#"))
   }
 }

--- a/arbigent-cli/src/test/kotlin/SortCommandTest.kt
+++ b/arbigent-cli/src/test/kotlin/SortCommandTest.kt
@@ -1,0 +1,139 @@
+@file:OptIn(ArbigentInternalApi::class)
+
+package io.github.takahirom.arbigent.cli
+
+import com.github.ajalt.clikt.testing.test
+import io.github.takahirom.arbigent.ArbigentInternalApi
+import java.io.File
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertContains
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class SortCommandTest {
+  private val yaml = File("build/arbigent/sort-project.yaml")
+
+  private val unsorted = """
+scenarios:
+- id: "launch-app"
+  goal: "Launch the app"
+- id: "open-search"
+  goal: "Open search"
+  dependency: "launch-app"
+- id: "open-settings"
+  goal: "Open settings"
+  dependency: "launch-app"
+- id: "toggle-dark-mode"
+  goal: "Toggle dark mode"
+  dependency: "open-settings"
+- id: "type-keyword"
+  goal: "Type a keyword"
+  dependency: "open-search"
+""".trimStart()
+
+  @BeforeTest
+  fun setup() {
+    yaml.parentFile.mkdirs()
+    yaml.writeText(unsorted)
+  }
+
+  @Test
+  fun `sort rewrites the file in dependency order with position comments`() {
+    val result = ArbigentSortCommand().test("--project-file=${yaml.absolutePath}")
+
+    assertEquals(0, result.statusCode, result.output)
+    assertContains(result.output, "Sorted ${yaml.absolutePath}: 3 scenarios out of place, 5 position comments stale.")
+    assertEquals(
+      """
+scenarios:
+# [depth 0] launch-app | children: open-search, open-settings
+- id: "launch-app"
+  goal: "Launch the app"
+# [depth 1] launch-app > open-search | children: type-keyword
+- id: "open-search"
+  goal: "Open search"
+  dependency: "launch-app"
+# [depth 2] launch-app > open-search > type-keyword
+- id: "type-keyword"
+  goal: "Type a keyword"
+  dependency: "open-search"
+# [depth 1] launch-app > open-settings | children: toggle-dark-mode
+- id: "open-settings"
+  goal: "Open settings"
+  dependency: "launch-app"
+# [depth 2] launch-app > open-settings > toggle-dark-mode
+- id: "toggle-dark-mode"
+  goal: "Toggle dark mode"
+  dependency: "open-settings"
+""".trimStart(),
+      yaml.readText()
+    )
+  }
+
+  @Test
+  fun `a second sort reports the file as already sorted`() {
+    ArbigentSortCommand().test("--project-file=${yaml.absolutePath}")
+    val before = yaml.readText()
+
+    val result = ArbigentSortCommand().test("--project-file=${yaml.absolutePath}")
+
+    assertEquals(0, result.statusCode, result.output)
+    assertEquals("Already sorted: ${yaml.absolutePath}\n", result.output)
+    assertEquals(before, yaml.readText())
+  }
+
+  @Test
+  fun `diff prints a unified diff and exits with 1 without touching the file`() {
+    val result = ArbigentSortCommand().test("--project-file=${yaml.absolutePath} --diff")
+
+    assertEquals(1, result.statusCode, result.output)
+    assertEquals(unsorted, yaml.readText())
+    assertContains(result.output, "--- ${yaml.absolutePath}")
+    assertContains(result.output, "+++ ${yaml.absolutePath} (sorted)")
+    assertContains(result.output, "+# [depth 2] launch-app > open-search > type-keyword")
+    assertContains(result.output, "3 scenarios out of place, 5 position comments stale. Run `arbigent sort` to apply.")
+  }
+
+  @Test
+  fun `diff exits with 0 when nothing would change`() {
+    ArbigentSortCommand().test("--project-file=${yaml.absolutePath}")
+
+    val result = ArbigentSortCommand().test("--project-file=${yaml.absolutePath} --diff")
+
+    assertEquals(0, result.statusCode, result.output)
+    assertEquals("Already sorted: ${yaml.absolutePath}\n", result.output)
+  }
+
+  @Test
+  fun `no-comments sorts without position comments and removes existing ones`() {
+    ArbigentSortCommand().test("--project-file=${yaml.absolutePath}")
+    assertTrue(yaml.readText().contains("# [depth"))
+
+    val result = ArbigentSortCommand().test("--project-file=${yaml.absolutePath} --no-comments")
+
+    assertEquals(0, result.statusCode, result.output)
+    assertFalse(yaml.readText().contains("# [depth"), yaml.readText())
+    assertContains(result.output, "0 scenarios out of place, 5 position comments stale.")
+  }
+
+  @Test
+  fun `a project that fails validation is reported and left alone`() {
+    yaml.writeText(
+      """
+scenarios:
+- id: "a"
+  goal: "A"
+  dependency: "missing"
+""".trimStart()
+    )
+
+    val result = ArbigentSortCommand().test("--project-file=${yaml.absolutePath}")
+
+    assertEquals(1, result.statusCode, result.output)
+    assertContains(result.output, "Invalid project configuration in ${yaml.absolutePath}")
+    assertContains(result.output, "'missing'")
+    assertFalse(yaml.readText().contains("# [depth"))
+  }
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -264,7 +264,7 @@ public data class ArbigentProjectSettings(
   // Retry count for scenarios that do not declare their own. Absent means DefaultMaxRetry.
   public val maxRetry: Int? = null,
   /**
-   * Whether saving writes a `# [depth N] root > ... > id | children: ...` comment above each
+   * Whether saving writes a `# tree: root > ... > id | children: ...` comment above each
    * scenario (see [ArbigentScenarioSorter]). Derived from `dependency` on every save; `false`
    * removes them.
    */

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -673,12 +673,10 @@ public class ArbigentProjectSerializer(
     }
   )
 
+  /** Builds the whole text before opening [file], so a failure while encoding leaves the file as it was. */
   public fun save(projectFileContent: ArbigentProjectFileContent, file: File) {
-    save(projectFileContent, file.outputStream())
-  }
-
-  private fun save(projectFileContent: ArbigentProjectFileContent, outputStream: OutputStream) {
-    fileSystem.writeText(outputStream, encodeToFileText(projectFileContent))
+    val text = encodeToFileText(projectFileContent)
+    file.outputStream().use { fileSystem.writeText(it, text) }
   }
 
   /**
@@ -687,6 +685,7 @@ public class ArbigentProjectSerializer(
    * already writes scenarios in dependency order (callers pass them sorted), so this only adds
    * the comments; [encodeToString] stays the comment-free form used for change tracking.
    */
+  @OptIn(ArbigentInternalApi::class)
   public fun encodeToFileText(projectFileContent: ArbigentProjectFileContent): String {
     val encoded = encodeToString(projectFileContent)
     return ArbigentScenarioSorter.sort(

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentProjectSerializer.kt
@@ -263,6 +263,12 @@ public data class ArbigentProjectSettings(
   public val additionalActions: List<String>? = null,
   // Retry count for scenarios that do not declare their own. Absent means DefaultMaxRetry.
   public val maxRetry: Int? = null,
+  /**
+   * Whether saving writes a `# [depth N] root > ... > id | children: ...` comment above each
+   * scenario (see [ArbigentScenarioSorter]). Derived from `dependency` on every save; `false`
+   * removes them.
+   */
+  public val positionComments: Boolean = true,
 ) {
   public companion object {
     public const val DefaultMcpJson: String = "{}"
@@ -672,9 +678,22 @@ public class ArbigentProjectSerializer(
   }
 
   private fun save(projectFileContent: ArbigentProjectFileContent, outputStream: OutputStream) {
-    val jsonString =
-      yaml.encodeToString(ArbigentProjectFileContent.serializer(), projectFileContent)
-    fileSystem.writeText(outputStream, jsonString)
+    fileSystem.writeText(outputStream, encodeToFileText(projectFileContent))
+  }
+
+  /**
+   * The text [save] writes: the encoded project plus the position comments `arbigent sort` would
+   * add, so a file saved here is already in the form `arbigent sort --diff` accepts. The encoder
+   * already writes scenarios in dependency order (callers pass them sorted), so this only adds
+   * the comments; [encodeToString] stays the comment-free form used for change tracking.
+   */
+  public fun encodeToFileText(projectFileContent: ArbigentProjectFileContent): String {
+    val encoded = encodeToString(projectFileContent)
+    return ArbigentScenarioSorter.sort(
+      yamlText = encoded,
+      content = projectFileContent,
+      positionComments = projectFileContent.settings.positionComments,
+    ).yaml
   }
 
   public fun load(file: File): ArbigentProjectFileContent {

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioSorter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioSorter.kt
@@ -1,8 +1,9 @@
 package io.github.takahirom.arbigent
 
 /**
- * Rewrites the `scenarios:` section of a project YAML so that every scenario sits directly after
- * the scenario it depends on (the same order the UI saves in), and puts a *position comment*
+ * Rewrites the `scenarios:` section of a project YAML into depth-first dependency order: every
+ * scenario comes after the scenario it depends on, and its whole subtree comes before the next
+ * sibling (the same order the UI saves in), and puts a *position comment*
  * above each scenario that spells out where it sits in the dependency tree:
  *
  * ```yaml

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioSorter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioSorter.kt
@@ -94,7 +94,42 @@ public object ArbigentScenarioSorter {
     split.footer.forEach { out.appendLine(it) }
     // splitting on "\n" and re-appending lines adds exactly one newline at the end; drop it.
     out.setLength(out.length - 1)
-    return Result(out.toString(), moved, stale)
+    val yaml = out.toString()
+    if (yaml != yamlText) requireSameProject(content, ordered.map { it.first }, yaml)
+    return Result(yaml, moved, stale)
+  }
+
+  /**
+   * The text split is line based and cannot see every YAML construct (a quoted scalar continuing
+   * at column zero, a `|+` block scalar whose trailing blank lines sit at the end of the list, an
+   * omitted `id` that decodes to a fresh random value each time). Rather than trust the split,
+   * decode the rewritten text and refuse to return it unless it is the same project with the
+   * scenarios in the new order.
+   */
+  private fun requireSameProject(
+    content: ArbigentProjectFileContent,
+    ordered: List<ArbigentScenarioContent>,
+    rewritten: String,
+  ) {
+    val serializer = ArbigentProjectSerializer()
+    val expected = serializer.encodeToString(
+      ArbigentProjectFileContent(
+        scenarioContents = ordered,
+        reusableScenarios = content.reusableScenarios,
+        fixedScenarios = content.fixedScenarios,
+        settings = content.settings,
+      )
+    )
+    val actual = try {
+      serializer.encodeToString(serializer.load(rewritten))
+    } catch (e: Exception) {
+      throw IllegalArgumentException("Reordering the scenarios would produce a project file that no longer parses: ${e.message}", e)
+    }
+    require(actual == expected) {
+      "Reordering the scenarios would change the project, so nothing was rewritten. This happens " +
+        "with scenarios that have no explicit `id`, quoted values that continue at column zero, and " +
+        "`|+` block scalars at the end of the list."
+    }
   }
 
   private fun positionComment(
@@ -114,10 +149,13 @@ public object ArbigentScenarioSorter {
     }
     val children = childrenOf[scenario.id].orEmpty().map { it.id }
     return buildString {
-      append("# [depth ").append(depth).append("] ").append(chain.joinToString(" > "))
-      if (children.isNotEmpty()) append(" | children: ").append(children.joinToString(", "))
+      append("# [depth ").append(depth).append("] ").append(chain.joinToString(" > ") { it.singleLine() })
+      if (children.isNotEmpty()) append(" | children: ").append(children.joinToString(", ") { it.singleLine() })
     }
   }
+
+  /** A comment is one line; an id containing a line break would end it early. */
+  private fun String.singleLine(): String = replace("\r", "\\r").replace("\n", "\\n")
 
   private class Block(val leadingComments: List<String>, val body: List<String>)
 
@@ -158,6 +196,18 @@ public object ArbigentScenarioSorter {
       body = mutableListOf()
     }
 
+    /** Position comments left behind after the last item are rewritten with that item. */
+    fun endList(rest: List<String>): List<String> {
+      closeBlock()
+      val (detached, footer) = pending.partition { POSITION_COMMENT_MARKER.containsMatchIn(it) }
+      pending.clear()
+      if (detached.isNotEmpty() && blocks.isNotEmpty()) {
+        val last = blocks.removeAt(blocks.size - 1)
+        blocks += Block(last.leadingComments + detached, last.body)
+      }
+      return footer + rest
+    }
+
     /** Attach [pending] to the item being read: it is inside the item, not between items. */
     fun flushPendingIntoBody() {
       body += pending
@@ -189,9 +239,10 @@ public object ArbigentScenarioSorter {
           closeBlock()
           // The comment run touching this item leads it; anything before the last blank line
           // belongs to whatever came before.
+          // A position comment separated from its item by a blank line is still ours to rewrite.
           val lastBlank = pending.indexOfLast { it.isBlank() }
-          val before = pending.subList(0, lastBlank + 1).toList()
-          val touching = pending.subList(lastBlank + 1, pending.size).toList()
+          val (detached, before) = pending.subList(0, lastBlank + 1).partition { POSITION_COMMENT_MARKER.containsMatchIn(it) }
+          val touching = detached + pending.subList(lastBlank + 1, pending.size)
           pending.clear()
           if (blocks.isEmpty()) header += before else {
             val last = blocks.removeAt(blocks.size - 1)
@@ -208,18 +259,13 @@ public object ArbigentScenarioSorter {
 
         else -> {
           // A key at or above the item level ends the scenarios list.
-          closeBlock()
-          footer = pending.toList() + lines.subList(i, lines.size)
-          pending.clear()
+          footer = endList(lines.subList(i, lines.size))
           break
         }
       }
       i++
     }
-    if (i >= lines.size) {
-      closeBlock()
-      footer = pending.toList()
-    }
+    if (i >= lines.size) footer = endList(emptyList())
     return Split(header, itemIndent, blocks, footer)
   }
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioSorter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioSorter.kt
@@ -1,3 +1,5 @@
+@file:OptIn(ArbigentInternalApi::class)
+
 package io.github.takahirom.arbigent
 
 /**
@@ -32,17 +34,20 @@ package io.github.takahirom.arbigent
 public object ArbigentScenarioSorter {
 
   /** A position comment this sorter wrote and owns; any such line is replaced on the next sort. */
+  @ArbigentInternalApi
   public val POSITION_COMMENT_MARKER: Regex = Regex("""^\s*#\s*tree:""")
 
   /** The explanatory line written directly under `scenarios:`. */
+  @ArbigentInternalApi
   public const val HEADER_COMMENT: String =
     "# The \"# tree:\" lines below are generated from `dependency` by `arbigent sort` (and on UI save); " +
       "do not edit them, rerun `arbigent sort`."
 
   /** Recognises [HEADER_COMMENT] and earlier wordings of it. */
+  @ArbigentInternalApi
   public val HEADER_COMMENT_MARKER: Regex = Regex("""^\s*#\s*The "# tree:" lines below are generated""")
 
-  public class Result(
+  public class Result internal constructor(
     /** The rewritten YAML. Equal to the input when nothing had to change. */
     public val yaml: String,
     /** Scenarios whose index in the `scenarios:` list changed. */
@@ -67,6 +72,7 @@ public object ArbigentScenarioSorter {
    * Sorts [yamlText], whose decoded form is [content]. [content] must be the decode of exactly this
    * text: its scenarios are matched to the `- id:` blocks by position.
    */
+  @ArbigentInternalApi
   public fun sort(yamlText: String, content: ArbigentProjectFileContent, positionComments: Boolean): Result {
     val scenarios = content.scenarioContents
     if (scenarios.isEmpty()) return Result(yamlText, emptyList(), emptyList(), headerStale = false)
@@ -174,13 +180,21 @@ public object ArbigentScenarioSorter {
     }
     val children = childrenOf[scenario.id].orEmpty().map { it.id }
     return buildString {
-      append("# tree: ").append(chain.joinToString(" > ") { it.singleLine() })
-      if (children.isNotEmpty()) append(" | children: ").append(children.joinToString(", ") { it.singleLine() })
+      append("# tree: ").append(chain.joinToString(" > ") { it.commentToken() })
+      if (children.isNotEmpty()) append(" | children: ").append(children.joinToString(", ") { it.commentToken() })
     }
   }
 
-  /** A comment is one line; an id containing a line break would end it early. */
-  private fun String.singleLine(): String = replace("\r", "\\r").replace("\n", "\\n")
+  /**
+   * An id as written in the comment. Ids are written as they are unless they could be misread:
+   * one containing `>`, `,`, `|`, a quote, or leading/trailing spaces is double-quoted (with `\\` and
+   * `"` escaped), and a line break is escaped so the comment stays one line.
+   */
+  private fun String.commentToken(): String {
+    val oneLine = replace("\\", "\\\\").replace("\r", "\\r").replace("\n", "\\n")
+    val needsQuotes = oneLine != oneLine.trim() || oneLine.any { it in ">,|\"" } || oneLine.isEmpty()
+    return if (needsQuotes) "\"" + oneLine.replace("\"", "\\\"") + "\"" else oneLine
+  }
 
   private class Block(val leadingComments: List<String>, val body: List<String>)
 

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioSorter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioSorter.kt
@@ -8,29 +8,42 @@ package io.github.takahirom.arbigent
  *
  * ```yaml
  * scenarios:
- * # [depth 0] launch-app | children: complete-onboarding
+ * # The "# tree:" lines below are generated from `dependency` by `arbigent sort` ...
+ * # tree: launch-app | children: complete-onboarding
  * - id: launch-app
  *   ...
- * # [depth 2] launch-app > complete-onboarding > open-search | children: type-keyword
+ * # tree: launch-app > complete-onboarding > open-search | children: type-keyword
  * - id: open-search
  *   dependency: complete-onboarding
  * ```
  *
  * The comments are derived from `dependency` on every write and carry no information of their
  * own; `dependency` stays the single source of truth. They exist so that a reader — a person or a
- * coding agent looking at one scenario in a flat file — can see its depth, its ancestors and its
- * direct dependents without searching the rest of the file.
+ * coding agent looking at one scenario in a flat file — can see its ancestors (root first) and
+ * its direct dependents without searching the rest of the file. The header line under
+ * `scenarios:` tells a reader of the whole file that the lines are generated and how to refresh them.
  *
  * The rewrite works on the YAML *text*, not on a decode/encode round trip: each `- id:` item is
  * cut out as a block of lines and the blocks are reordered. Everything inside a block — quoting
  * style, comments, blank lines, keys the serializer does not know — is left byte-for-byte as it
- * was. Only lines matching [POSITION_COMMENT_MARKER] are regenerated. Roots and siblings keep
+ * was. Only lines matching [POSITION_COMMENT_MARKER] or [HEADER_COMMENT_MARKER] are regenerated. Roots and siblings keep
  * their declared order, so a hand-curated grouping of top-level flows survives.
  */
 public object ArbigentScenarioSorter {
 
-  /** A line that this sorter wrote and owns; any such line is replaced on the next sort. */
-  public val POSITION_COMMENT_MARKER: Regex = Regex("""^\s*#\s*\[depth \d+]""")
+  /**
+   * A position comment this sorter wrote and owns; any such line is replaced on the next sort.
+   * `# [depth N]` is the form an earlier build wrote and is recognised so it gets replaced too.
+   */
+  public val POSITION_COMMENT_MARKER: Regex = Regex("""^\s*#\s*(tree:|\[depth \d+])""")
+
+  /** The explanatory line written directly under `scenarios:`. */
+  public const val HEADER_COMMENT: String =
+    "# The \"# tree:\" lines below are generated from `dependency` by `arbigent sort` (and on UI save); " +
+      "do not edit them, rerun `arbigent sort`."
+
+  /** Recognises [HEADER_COMMENT] and earlier wordings of it. */
+  public val HEADER_COMMENT_MARKER: Regex = Regex("""^\s*#\s*The "# tree:" lines below are generated""")
 
   public class Result(
     /** The rewritten YAML. Equal to the input when nothing had to change. */
@@ -39,6 +52,8 @@ public object ArbigentScenarioSorter {
     public val movedScenarioIds: List<String>,
     /** Scenarios whose position comment was missing, outdated, or (when disabled) still present. */
     public val staleCommentScenarioIds: List<String>,
+    /** Whether the header line under `scenarios:` was missing, outdated, or (when disabled) still present. */
+    public val headerStale: Boolean,
   )
 
   /**
@@ -57,7 +72,7 @@ public object ArbigentScenarioSorter {
    */
   public fun sort(yamlText: String, content: ArbigentProjectFileContent, positionComments: Boolean): Result {
     val scenarios = content.scenarioContents
-    if (scenarios.isEmpty()) return Result(yamlText, emptyList(), emptyList())
+    if (scenarios.isEmpty()) return Result(yamlText, emptyList(), emptyList(), headerStale = false)
 
     val split = splitScenarioBlocks(yamlText)
     require(split.blocks.size == scenarios.size) {
@@ -74,18 +89,31 @@ public object ArbigentScenarioSorter {
     val moved = mutableListOf<String>()
     val stale = mutableListOf<String>()
     val out = StringBuilder()
-    split.header.forEach { out.appendLine(it) }
-    ordered.forEachIndexed { newIndex, (scenario, depth) ->
+    // Everything up to and including `scenarios:` stays; our header line goes directly under it.
+    // An existing header may sit in the split header or, when it touches the first item, in that
+    // item's leading comments; either way it is dropped there and rewritten here.
+    val top = split.header.subList(0, split.keyIndex + 1)
+    val afterKey = split.header.subList(split.keyIndex + 1, split.header.size)
+    val oldHeaderLines = (afterKey + split.blocks.flatMap { it.leadingComments })
+      .filter { HEADER_COMMENT_MARKER.containsMatchIn(it) }
+    val expectedHeader = if (positionComments) listOf(HEADER_COMMENT) else emptyList()
+    val headerStale = oldHeaderLines != expectedHeader
+    top.forEach { out.appendLine(it) }
+    expectedHeader.forEach { out.appendLine(it) }
+    afterKey.filterNot { HEADER_COMMENT_MARKER.containsMatchIn(it) }.forEach { out.appendLine(it) }
+    ordered.forEachIndexed { newIndex, (scenario, _) ->
       val oldIndex = scenarios.indexOf(scenario)
       val block = split.blocks[oldIndex]
       if (oldIndex != newIndex) moved += scenario.id
 
       val expected = if (positionComments) {
-        listOf(indent + positionComment(scenario, depth, scenarios, childrenOf))
+        listOf(indent + positionComment(scenario, scenarios, childrenOf))
       } else {
         emptyList()
       }
-      val (ownComments, otherComments) = block.leadingComments.partition { POSITION_COMMENT_MARKER.containsMatchIn(it) }
+      val (ownComments, otherComments) = block.leadingComments
+        .filterNot { HEADER_COMMENT_MARKER.containsMatchIn(it) }
+        .partition { POSITION_COMMENT_MARKER.containsMatchIn(it) }
       if (ownComments != expected) stale += scenario.id
 
       otherComments.forEach { out.appendLine(it) }
@@ -97,7 +125,7 @@ public object ArbigentScenarioSorter {
     out.setLength(out.length - 1)
     val yaml = out.toString()
     if (yaml != yamlText) requireSameProject(content, ordered.map { it.first }, yaml)
-    return Result(yaml, moved, stale)
+    return Result(yaml, moved, stale, headerStale)
   }
 
   /**
@@ -135,7 +163,6 @@ public object ArbigentScenarioSorter {
 
   private fun positionComment(
     scenario: ArbigentScenarioContent,
-    depth: Int,
     scenarios: List<ArbigentScenarioContent>,
     childrenOf: Map<String?, List<ArbigentScenarioContent>>,
   ): String {
@@ -150,7 +177,7 @@ public object ArbigentScenarioSorter {
     }
     val children = childrenOf[scenario.id].orEmpty().map { it.id }
     return buildString {
-      append("# [depth ").append(depth).append("] ").append(chain.joinToString(" > ") { it.singleLine() })
+      append("# tree: ").append(chain.joinToString(" > ") { it.singleLine() })
       if (children.isNotEmpty()) append(" | children: ").append(children.joinToString(", ") { it.singleLine() })
     }
   }
@@ -161,7 +188,9 @@ public object ArbigentScenarioSorter {
   private class Block(val leadingComments: List<String>, val body: List<String>)
 
   private class Split(
+    /** Lines up to and including `scenarios:` (index [keyIndex]), plus comments before the first item. */
     val header: List<String>,
+    val keyIndex: Int,
     val itemIndent: Int,
     val blocks: List<Block>,
     val footer: List<String>,
@@ -267,6 +296,6 @@ public object ArbigentScenarioSorter {
       i++
     }
     if (i >= lines.size) footer = endList(emptyList())
-    return Split(header, itemIndent, blocks, footer)
+    return Split(header, keyIndex, itemIndent, blocks, footer)
   }
 }

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioSorter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioSorter.kt
@@ -1,0 +1,225 @@
+package io.github.takahirom.arbigent
+
+/**
+ * Rewrites the `scenarios:` section of a project YAML so that every scenario sits directly after
+ * the scenario it depends on (the same order the UI saves in), and puts a *position comment*
+ * above each scenario that spells out where it sits in the dependency tree:
+ *
+ * ```yaml
+ * scenarios:
+ * # [depth 0] launch-app | children: complete-onboarding
+ * - id: launch-app
+ *   ...
+ * # [depth 2] launch-app > complete-onboarding > open-search | children: type-keyword
+ * - id: open-search
+ *   dependency: complete-onboarding
+ * ```
+ *
+ * The comments are derived from `dependency` on every write and carry no information of their
+ * own; `dependency` stays the single source of truth. They exist so that a reader — a person or a
+ * coding agent looking at one scenario in a flat file — can see its depth, its ancestors and its
+ * direct dependents without searching the rest of the file.
+ *
+ * The rewrite works on the YAML *text*, not on a decode/encode round trip: each `- id:` item is
+ * cut out as a block of lines and the blocks are reordered. Everything inside a block — quoting
+ * style, comments, blank lines, keys the serializer does not know — is left byte-for-byte as it
+ * was. Only lines matching [POSITION_COMMENT_MARKER] are regenerated. Roots and siblings keep
+ * their declared order, so a hand-curated grouping of top-level flows survives.
+ */
+public object ArbigentScenarioSorter {
+
+  /** A line that this sorter wrote and owns; any such line is replaced on the next sort. */
+  public val POSITION_COMMENT_MARKER: Regex = Regex("""^\s*#\s*\[depth \d+]""")
+
+  public class Result(
+    /** The rewritten YAML. Equal to the input when nothing had to change. */
+    public val yaml: String,
+    /** Scenarios whose index in the `scenarios:` list changed. */
+    public val movedScenarioIds: List<String>,
+    /** Scenarios whose position comment was missing, outdated, or (when disabled) still present. */
+    public val staleCommentScenarioIds: List<String>,
+  )
+
+  /**
+   * Decodes [yamlText] with the project serializer (including validation, so a project with a
+   * cyclic or dangling `dependency` is rejected with the usual report) and sorts it.
+   * [positionComments] null means "as the project's `settings.positionComments` says".
+   */
+  public fun sort(yamlText: String, positionComments: Boolean? = null): Result {
+    val content = ArbigentProjectSerializer().load(yamlText)
+    return sort(yamlText, content, positionComments ?: content.settings.positionComments)
+  }
+
+  /**
+   * Sorts [yamlText], whose decoded form is [content]. [content] must be the decode of exactly this
+   * text: its scenarios are matched to the `- id:` blocks by position.
+   */
+  public fun sort(yamlText: String, content: ArbigentProjectFileContent, positionComments: Boolean): Result {
+    val scenarios = content.scenarioContents
+    if (scenarios.isEmpty()) return Result(yamlText, emptyList(), emptyList())
+
+    val split = splitScenarioBlocks(yamlText)
+    require(split.blocks.size == scenarios.size) {
+      "Found ${split.blocks.size} scenario entries in the YAML text but the project decodes to " +
+        "${scenarios.size} scenarios. Only block-style lists (`- id: ...`) are supported."
+    }
+
+    val ordered = ArbigentScenarioResolver.dependencyForestWithDepth(scenarios) { scenario ->
+      scenario.dependencyId?.let { id -> scenarios.firstOrNull { it.id == id } }
+    }
+    val childrenOf = scenarios.groupBy { it.dependencyId }
+    val indent = " ".repeat(split.itemIndent)
+
+    val moved = mutableListOf<String>()
+    val stale = mutableListOf<String>()
+    val out = StringBuilder()
+    split.header.forEach { out.appendLine(it) }
+    ordered.forEachIndexed { newIndex, (scenario, depth) ->
+      val oldIndex = scenarios.indexOf(scenario)
+      val block = split.blocks[oldIndex]
+      if (oldIndex != newIndex) moved += scenario.id
+
+      val expected = if (positionComments) {
+        listOf(indent + positionComment(scenario, depth, scenarios, childrenOf))
+      } else {
+        emptyList()
+      }
+      val (ownComments, otherComments) = block.leadingComments.partition { POSITION_COMMENT_MARKER.containsMatchIn(it) }
+      if (ownComments != expected) stale += scenario.id
+
+      otherComments.forEach { out.appendLine(it) }
+      expected.forEach { out.appendLine(it) }
+      block.body.forEach { out.appendLine(it) }
+    }
+    split.footer.forEach { out.appendLine(it) }
+    // splitting on "\n" and re-appending lines adds exactly one newline at the end; drop it.
+    out.setLength(out.length - 1)
+    return Result(out.toString(), moved, stale)
+  }
+
+  private fun positionComment(
+    scenario: ArbigentScenarioContent,
+    depth: Int,
+    scenarios: List<ArbigentScenarioContent>,
+    childrenOf: Map<String?, List<ArbigentScenarioContent>>,
+  ): String {
+    // Root-first chain ending at this scenario. A cycle would loop forever; stop at the repeat.
+    val chain = ArrayDeque<String>()
+    val seen = mutableSetOf<String>()
+    var current: ArbigentScenarioContent? = scenario
+    while (current != null && seen.add(current.id)) {
+      chain.addFirst(current.id)
+      val dependencyId = current.dependencyId
+      current = dependencyId?.let { id -> scenarios.firstOrNull { it.id == id } }
+    }
+    val children = childrenOf[scenario.id].orEmpty().map { it.id }
+    return buildString {
+      append("# [depth ").append(depth).append("] ").append(chain.joinToString(" > "))
+      if (children.isNotEmpty()) append(" | children: ").append(children.joinToString(", "))
+    }
+  }
+
+  private class Block(val leadingComments: List<String>, val body: List<String>)
+
+  private class Split(
+    val header: List<String>,
+    val itemIndent: Int,
+    val blocks: List<Block>,
+    val footer: List<String>,
+  )
+
+  private val SCENARIOS_KEY = Regex("""^scenarios:\s*(#.*)?$""")
+  private val LIST_ITEM = Regex("""^( *)-( |$)""")
+  private val BLANK_OR_COMMENT = Regex("""^\s*(#.*)?$""")
+
+  /**
+   * Cuts the `scenarios:` list into one block per item. A block is the item's lines plus the
+   * comment lines directly above it (a comment run that touches the item; blank lines separate it
+   * from the previous item and stay with that item). Comment lines indented deeper than the item
+   * marker are content of the current item, e.g. a `#` line inside a block scalar goal.
+   */
+  private fun splitScenarioBlocks(yamlText: String): Split {
+    val lines = yamlText.split("\n")
+    val keyIndex = lines.indexOfFirst { SCENARIOS_KEY.matches(it) }
+    require(keyIndex >= 0) { "No `scenarios:` block-style list found in the project file." }
+
+    val header = lines.subList(0, keyIndex + 1).toMutableList()
+    val blocks = mutableListOf<Block>()
+    var footer: List<String> = emptyList()
+    var itemIndent = -1
+    var leading = mutableListOf<String>()
+    var body = mutableListOf<String>()
+    // Blank and comment lines not yet attributed to a block.
+    val pending = mutableListOf<String>()
+
+    fun closeBlock() {
+      if (body.isNotEmpty()) blocks += Block(leading, body)
+      leading = mutableListOf()
+      body = mutableListOf()
+    }
+
+    /** Attach [pending] to the item being read: it is inside the item, not between items. */
+    fun flushPendingIntoBody() {
+      body += pending
+      pending.clear()
+    }
+
+    var i = keyIndex + 1
+    while (i < lines.size) {
+      val line = lines[i]
+      val lineIndent = line.length - line.trimStart(' ').length
+      when {
+        BLANK_OR_COMMENT.matches(line) -> {
+          val isComment = line.trimStart().startsWith("#")
+          if (isComment && itemIndent >= 0 && lineIndent > itemIndent && body.isNotEmpty()) {
+            flushPendingIntoBody()
+            body += line
+          } else {
+            pending += line
+          }
+        }
+
+        itemIndent < 0 || (lineIndent == itemIndent && LIST_ITEM.containsMatchIn(line)) -> {
+          if (itemIndent < 0) {
+            require(LIST_ITEM.containsMatchIn(line)) {
+              "Expected a `- id: ...` list item after `scenarios:` but found: $line"
+            }
+            itemIndent = lineIndent
+          }
+          closeBlock()
+          // The comment run touching this item leads it; anything before the last blank line
+          // belongs to whatever came before.
+          val lastBlank = pending.indexOfLast { it.isBlank() }
+          val before = pending.subList(0, lastBlank + 1).toList()
+          val touching = pending.subList(lastBlank + 1, pending.size).toList()
+          pending.clear()
+          if (blocks.isEmpty()) header += before else {
+            val last = blocks.removeAt(blocks.size - 1)
+            blocks += Block(last.leadingComments, last.body + before)
+          }
+          leading = touching.toMutableList()
+          body = mutableListOf(line)
+        }
+
+        lineIndent > itemIndent -> {
+          flushPendingIntoBody()
+          body += line
+        }
+
+        else -> {
+          // A key at or above the item level ends the scenarios list.
+          closeBlock()
+          footer = pending.toList() + lines.subList(i, lines.size)
+          pending.clear()
+          break
+        }
+      }
+      i++
+    }
+    if (i >= lines.size) {
+      closeBlock()
+      footer = pending.toList()
+    }
+    return Split(header, itemIndent, blocks, footer)
+  }
+}

--- a/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioSorter.kt
+++ b/arbigent-core/src/main/java/io/github/takahirom/arbigent/ArbigentScenarioSorter.kt
@@ -31,11 +31,8 @@ package io.github.takahirom.arbigent
  */
 public object ArbigentScenarioSorter {
 
-  /**
-   * A position comment this sorter wrote and owns; any such line is replaced on the next sort.
-   * `# [depth N]` is the form an earlier build wrote and is recognised so it gets replaced too.
-   */
-  public val POSITION_COMMENT_MARKER: Regex = Regex("""^\s*#\s*(tree:|\[depth \d+])""")
+  /** A position comment this sorter wrote and owns; any such line is replaced on the next sort. */
+  public val POSITION_COMMENT_MARKER: Regex = Regex("""^\s*#\s*tree:""")
 
   /** The explanatory line written directly under `scenarios:`. */
   public const val HEADER_COMMENT: String =

--- a/arbigent-core/src/test/java/io/github/takahirom/arbigent/ArbigentScenarioSorterTest.kt
+++ b/arbigent-core/src/test/java/io/github/takahirom/arbigent/ArbigentScenarioSorterTest.kt
@@ -6,6 +6,7 @@ import io.github.takahirom.arbigent.ArbigentScenarioSorter
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class ArbigentScenarioSorterTest {
@@ -33,18 +34,19 @@ scenarios:
     assertEquals(
       """
 scenarios:
-# [depth 0] launch-app | children: open-settings, open-search
+# The "# tree:" lines below are generated from `dependency` by `arbigent sort` (and on UI save); do not edit them, rerun `arbigent sort`.
+# tree: launch-app | children: open-settings, open-search
 - id: "launch-app"
   goal: "Launch the app"
-# [depth 1] launch-app > open-settings | children: toggle-dark-mode
+# tree: launch-app > open-settings | children: toggle-dark-mode
 - id: "open-settings"
   goal: "Open settings"
   dependency: "launch-app"
-# [depth 2] launch-app > open-settings > toggle-dark-mode
+# tree: launch-app > open-settings > toggle-dark-mode
 - id: "toggle-dark-mode"
   goal: "Toggle dark mode"
   dependency: "open-settings"
-# [depth 1] launch-app > open-search
+# tree: launch-app > open-search
 - id: "open-search"
   goal: "Open search"
   dependency: "launch-app"
@@ -66,6 +68,7 @@ scenarios:
     assertEquals(once, twice.yaml)
     assertEquals(emptyList(), twice.movedScenarioIds)
     assertEquals(emptyList(), twice.staleCommentScenarioIds)
+    assertFalse(twice.headerStale)
   }
 
   @Test
@@ -102,15 +105,16 @@ reusableScenarios: []
 settings:
   maxRetry: 2
 scenarios:
+# The "# tree:" lines below are generated from `dependency` by `arbigent sort` (and on UI save); do not edit them, rerun `arbigent sort`.
 
   # The entry point
-  # [depth 0] launch-app | children: open-settings
+  # tree: launch-app | children: open-settings
   - id: launch-app
     goal: >-
       Launch the app
       # not a comment, part of the goal
     unknownKey: kept
-  # [depth 1] launch-app > open-settings
+  # tree: launch-app > open-settings
   - id: open-settings
     # why: settings is the hub
     dependency: launch-app
@@ -166,8 +170,9 @@ scenarios:
 
     val result = ArbigentScenarioSorter.sort(commented, positionComments = false)
 
-    assertTrue(result.yaml.lines().none { ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) }, result.yaml)
+    assertTrue(result.yaml.lines().none { it.startsWith("#") }, result.yaml)
     assertEquals(4, result.staleCommentScenarioIds.size)
+    assertTrue(result.headerStale)
   }
 
   @Test
@@ -215,7 +220,10 @@ scenarios:
 
     assertEquals(
       encoded.lines(),
-      sorted.lines().filterNot { ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) }
+      sorted.lines().filterNot {
+        ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) ||
+          ArbigentScenarioSorter.HEADER_COMMENT_MARKER.containsMatchIn(it)
+      }
     )
     assertEquals(4, sorted.lines().count { ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) })
   }
@@ -243,14 +251,16 @@ scenarios:
     assertEquals(
       """
 scenarios:
+# The "# tree:" lines below are generated from `dependency` by `arbigent sort` (and on UI save); do not edit them, rerun `arbigent sort`.
 
-# [depth 0] launch-app
+# tree: launch-app
 - id: "launch-app"
   goal: "Launch the app"
 """.trimStart(),
       result.yaml
     )
     assertEquals(listOf("launch-app"), result.staleCommentScenarioIds)
+    assertTrue(result.headerStale)
     val removed = ArbigentScenarioSorter.sort(original, positionComments = false).yaml
     assertTrue(removed.lines().none { ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) }, removed)
   }
@@ -268,7 +278,8 @@ scenarios:
     assertEquals(
       """
 scenarios:
-# [depth 0] launch\napp
+# The "# tree:" lines below are generated from `dependency` by `arbigent sort` (and on UI save); do not edit them, rerun `arbigent sort`.
+# tree: launch\napp
 - id: "launch\napp"
   goal: "Launch the app"
 """.trimStart(),

--- a/arbigent-core/src/test/java/io/github/takahirom/arbigent/ArbigentScenarioSorterTest.kt
+++ b/arbigent-core/src/test/java/io/github/takahirom/arbigent/ArbigentScenarioSorterTest.kt
@@ -1,5 +1,8 @@
+@file:OptIn(ArbigentInternalApi::class)
+
 package io.github.takahirom.arbigent.sample.test
 
+import io.github.takahirom.arbigent.ArbigentInternalApi
 import io.github.takahirom.arbigent.ArbigentProjectSerializer
 import io.github.takahirom.arbigent.ArbigentProjectValidationException
 import io.github.takahirom.arbigent.ArbigentScenarioSorter
@@ -286,6 +289,26 @@ scenarios:
       result.yaml
     )
     assertEquals("launch\napp", ArbigentProjectSerializer().load(result.yaml).scenarioContents.single().id)
+  }
+
+  @Test
+  fun `ids that could be misread in the comment are quoted`() {
+    val original = """
+scenarios:
+- id: "a > b"
+  goal: "Root with a separator in its id"
+- id: "c, d"
+  goal: "Child with a comma in its id"
+  dependency: "a > b"
+""".trimStart()
+
+    val result = ArbigentScenarioSorter.sort(original)
+
+    val comments = result.yaml.lines().filter { ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) }
+    assertEquals(
+      listOf("# tree: \"a > b\" | children: \"c, d\"", "# tree: \"a > b\" > \"c, d\""),
+      comments
+    )
   }
 
   @Test

--- a/arbigent-core/src/test/java/io/github/takahirom/arbigent/ArbigentScenarioSorterTest.kt
+++ b/arbigent-core/src/test/java/io/github/takahirom/arbigent/ArbigentScenarioSorterTest.kt
@@ -228,6 +228,105 @@ scenarios:
   }
 
   @Test
+  fun `a stale position comment separated from its scenario by a blank line is still replaced`() {
+    val original = """
+scenarios:
+# [depth 99] stale
+
+- id: "launch-app"
+  goal: "Launch the app"
+# [depth 42] also stale
+""".trimStart()
+
+    val result = ArbigentScenarioSorter.sort(original)
+
+    assertEquals(
+      """
+scenarios:
+
+# [depth 0] launch-app
+- id: "launch-app"
+  goal: "Launch the app"
+""".trimStart(),
+      result.yaml
+    )
+    assertEquals(listOf("launch-app"), result.staleCommentScenarioIds)
+    val removed = ArbigentScenarioSorter.sort(original, positionComments = false).yaml
+    assertTrue(removed.lines().none { ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) }, removed)
+  }
+
+  @Test
+  fun `line breaks in ids are escaped so the comment stays one line`() {
+    val original = """
+scenarios:
+- id: "launch\napp"
+  goal: "Launch the app"
+""".trimStart()
+
+    val result = ArbigentScenarioSorter.sort(original)
+
+    assertEquals(
+      """
+scenarios:
+# [depth 0] launch\napp
+- id: "launch\napp"
+  goal: "Launch the app"
+""".trimStart(),
+      result.yaml
+    )
+    assertEquals("launch\napp", ArbigentProjectSerializer().load(result.yaml).scenarioContents.single().id)
+  }
+
+  @Test
+  fun `a scenario without an explicit id is rejected instead of getting a random comment`() {
+    val original = """
+scenarios:
+- goal: "Launch the app"
+""".trimStart()
+
+    val e = assertFailsWith<IllegalArgumentException> { ArbigentScenarioSorter.sort(original) }
+    assertTrue(e.message!!.contains("explicit `id`"), e.message)
+  }
+
+  @Test
+  fun `a quoted value continuing at column zero is rejected instead of swallowing a scenario`() {
+    val original = """
+scenarios:
+- id: "open-settings"
+  goal: "Open settings"
+  dependency: "launch-app"
+- id: "launch-app"
+  goal: "Launch
+the app"
+""".trimStart()
+
+    val e = assertFailsWith<IllegalArgumentException> { ArbigentScenarioSorter.sort(original) }
+    assertTrue(e.message!!.contains("Reordering the scenarios would"), e.message)
+  }
+
+  @Test
+  fun `a keep-chomping block scalar at the end of the list is rejected instead of losing its blank lines`() {
+    val original = "scenarios:\n- id: \"open-settings\"\n  goal: \"Open settings\"\n  dependency: \"launch-app\"\n" +
+      "- id: \"launch-app\"\n  goal: |+\n    Launch the app\n\n\n"
+
+    val e = assertFailsWith<IllegalArgumentException> { ArbigentScenarioSorter.sort(original) }
+    assertTrue(e.message!!.contains("Reordering the scenarios would"), e.message)
+  }
+
+  @Test
+  fun `a file without a final newline sorts without changing any value`() {
+    val original = appendedChild.trimEnd('\n')
+
+    val result = ArbigentScenarioSorter.sort(original, positionComments = false)
+
+    assertEquals(
+      listOf("launch-app", "open-settings", "toggle-dark-mode", "open-search"),
+      ArbigentProjectSerializer().load(result.yaml).scenarioContents.map { it.id }
+    )
+    assertTrue(!result.yaml.endsWith("\n"), result.yaml)
+  }
+
+  @Test
   fun `a cyclic dependency is rejected with the validation report`() {
     val original = """
 scenarios:

--- a/arbigent-core/src/test/java/io/github/takahirom/arbigent/ArbigentScenarioSorterTest.kt
+++ b/arbigent-core/src/test/java/io/github/takahirom/arbigent/ArbigentScenarioSorterTest.kt
@@ -83,7 +83,7 @@ settings:
 scenarios:
 
   # The entry point
-  # [depth 7] stale > chain
+  # tree: stale > chain
   - id: launch-app
     goal: >-
       Launch the app
@@ -239,11 +239,11 @@ scenarios:
   fun `a stale position comment separated from its scenario by a blank line is still replaced`() {
     val original = """
 scenarios:
-# [depth 99] stale
+# tree: stale
 
 - id: "launch-app"
   goal: "Launch the app"
-# [depth 42] also stale
+# tree: also stale
 """.trimStart()
 
     val result = ArbigentScenarioSorter.sort(original)

--- a/arbigent-core/src/test/java/io/github/takahirom/arbigent/ArbigentScenarioSorterTest.kt
+++ b/arbigent-core/src/test/java/io/github/takahirom/arbigent/ArbigentScenarioSorterTest.kt
@@ -1,0 +1,253 @@
+package io.github.takahirom.arbigent.sample.test
+
+import io.github.takahirom.arbigent.ArbigentProjectSerializer
+import io.github.takahirom.arbigent.ArbigentProjectValidationException
+import io.github.takahirom.arbigent.ArbigentScenarioSorter
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class ArbigentScenarioSorterTest {
+
+  /** A child appended at the end of the file, far from its parent. */
+  private val appendedChild = """
+scenarios:
+- id: "launch-app"
+  goal: "Launch the app"
+- id: "open-settings"
+  goal: "Open settings"
+  dependency: "launch-app"
+- id: "open-search"
+  goal: "Open search"
+  dependency: "launch-app"
+- id: "toggle-dark-mode"
+  goal: "Toggle dark mode"
+  dependency: "open-settings"
+""".trimStart()
+
+  @Test
+  fun `moves a scenario directly after its dependency and comments every scenario`() {
+    val result = ArbigentScenarioSorter.sort(appendedChild)
+
+    assertEquals(
+      """
+scenarios:
+# [depth 0] launch-app | children: open-settings, open-search
+- id: "launch-app"
+  goal: "Launch the app"
+# [depth 1] launch-app > open-settings | children: toggle-dark-mode
+- id: "open-settings"
+  goal: "Open settings"
+  dependency: "launch-app"
+# [depth 2] launch-app > open-settings > toggle-dark-mode
+- id: "toggle-dark-mode"
+  goal: "Toggle dark mode"
+  dependency: "open-settings"
+# [depth 1] launch-app > open-search
+- id: "open-search"
+  goal: "Open search"
+  dependency: "launch-app"
+""".trimStart(),
+      result.yaml
+    )
+    assertEquals(listOf("toggle-dark-mode", "open-search"), result.movedScenarioIds)
+    assertEquals(
+      listOf("launch-app", "open-settings", "toggle-dark-mode", "open-search"),
+      result.staleCommentScenarioIds
+    )
+  }
+
+  @Test
+  fun `sorting is idempotent`() {
+    val once = ArbigentScenarioSorter.sort(appendedChild).yaml
+    val twice = ArbigentScenarioSorter.sort(once)
+
+    assertEquals(once, twice.yaml)
+    assertEquals(emptyList(), twice.movedScenarioIds)
+    assertEquals(emptyList(), twice.staleCommentScenarioIds)
+  }
+
+  @Test
+  fun `only the position comments are rewritten, everything else stays byte for byte`() {
+    // Hand-written styles the serializer would normalize away: a header comment, blank lines,
+    // an unquoted id, a folded goal, an unknown key, a comment inside a block scalar, a comment
+    // between keys, trailing sections, and an outdated position comment.
+    val original = """
+# Project for the example app
+settings:
+  maxRetry: 2
+scenarios:
+
+  # The entry point
+  # [depth 7] stale > chain
+  - id: launch-app
+    goal: >-
+      Launch the app
+      # not a comment, part of the goal
+    unknownKey: kept
+  - id: open-settings
+    # why: settings is the hub
+    dependency: launch-app
+    goal: "Open settings"
+
+reusableScenarios: []
+""".trimStart()
+
+    val result = ArbigentScenarioSorter.sort(original)
+
+    assertEquals(
+      """
+# Project for the example app
+settings:
+  maxRetry: 2
+scenarios:
+
+  # The entry point
+  # [depth 0] launch-app | children: open-settings
+  - id: launch-app
+    goal: >-
+      Launch the app
+      # not a comment, part of the goal
+    unknownKey: kept
+  # [depth 1] launch-app > open-settings
+  - id: open-settings
+    # why: settings is the hub
+    dependency: launch-app
+    goal: "Open settings"
+
+reusableScenarios: []
+""".trimStart(),
+      result.yaml
+    )
+    assertEquals(emptyList(), result.movedScenarioIds)
+    assertEquals(listOf("launch-app", "open-settings"), result.staleCommentScenarioIds)
+  }
+
+  @Test
+  fun `comments stay attached to the scenario they describe when it moves`() {
+    val original = """
+scenarios:
+- id: "launch-app"
+  goal: "Launch the app"
+
+# Dark mode lives under settings
+- id: "toggle-dark-mode"
+  goal: "Toggle dark mode"
+  dependency: "open-settings"
+- id: "open-settings"
+  goal: "Open settings"
+  dependency: "launch-app"
+""".trimStart()
+
+    val sorted = ArbigentScenarioSorter.sort(original, positionComments = false).yaml
+
+    assertEquals(
+      """
+scenarios:
+- id: "launch-app"
+  goal: "Launch the app"
+
+- id: "open-settings"
+  goal: "Open settings"
+  dependency: "launch-app"
+# Dark mode lives under settings
+- id: "toggle-dark-mode"
+  goal: "Toggle dark mode"
+  dependency: "open-settings"
+""".trimStart(),
+      sorted
+    )
+  }
+
+  @Test
+  fun `disabling position comments removes the ones already there`() {
+    val commented = ArbigentScenarioSorter.sort(appendedChild).yaml
+
+    val result = ArbigentScenarioSorter.sort(commented, positionComments = false)
+
+    assertTrue(result.yaml.lines().none { ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) }, result.yaml)
+    assertEquals(4, result.staleCommentScenarioIds.size)
+  }
+
+  @Test
+  fun `settings positionComments false is the default for the file`() {
+    val original = "settings:\n  positionComments: false\n" + appendedChild
+
+    val result = ArbigentScenarioSorter.sort(original)
+
+    assertTrue(result.yaml.lines().none { it.startsWith("#") }, result.yaml)
+    assertEquals(listOf("toggle-dark-mode", "open-search"), result.movedScenarioIds)
+  }
+
+  @Test
+  fun `roots and siblings keep their declared order`() {
+    val original = """
+scenarios:
+- id: "zeta-flow"
+  goal: "Z"
+- id: "alpha-flow"
+  goal: "A"
+- id: "zeta-step"
+  goal: "Z1"
+  dependency: "zeta-flow"
+- id: "alpha-step-b"
+  goal: "AB"
+  dependency: "alpha-flow"
+- id: "alpha-step-a"
+  goal: "AA"
+  dependency: "alpha-flow"
+""".trimStart()
+
+    val ids = ArbigentScenarioSorter.sort(original, positionComments = false).yaml
+      .lines().filter { it.startsWith("- id:") }.map { it.removePrefix("- id: ").trim('"') }
+
+    assertEquals(listOf("zeta-flow", "zeta-step", "alpha-flow", "alpha-step-b", "alpha-step-a"), ids)
+  }
+
+  @Test
+  fun `the serializer output round trips through sort without changes except comments`() {
+    // The UI passes scenarios already in dependency order; mirror that by encoding a sorted project.
+    val content = ArbigentProjectSerializer().load(ArbigentScenarioSorter.sort(appendedChild).yaml)
+    val encoded = ArbigentProjectSerializer().encodeToString(content)
+
+    val sorted = ArbigentScenarioSorter.sort(encoded, content, positionComments = true).yaml
+
+    assertEquals(
+      encoded.lines(),
+      sorted.lines().filterNot { ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) }
+    )
+    assertEquals(4, sorted.lines().count { ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) })
+  }
+
+  @Test
+  fun `a project without scenarios is returned unchanged`() {
+    val original = "scenarios: []\nreusableScenarios: []\n"
+
+    assertEquals(original, ArbigentScenarioSorter.sort(original).yaml)
+  }
+
+  @Test
+  fun `a cyclic dependency is rejected with the validation report`() {
+    val original = """
+scenarios:
+- id: "a"
+  goal: "A"
+  dependency: "b"
+- id: "b"
+  goal: "B"
+  dependency: "a"
+""".trimStart()
+
+    val e = assertFailsWith<ArbigentProjectValidationException> { ArbigentScenarioSorter.sort(original) }
+    assertTrue(e.message!!.contains("cyclic dependency"), e.message)
+  }
+
+  @Test
+  fun `a flow-style scenarios list is rejected instead of being rewritten`() {
+    val original = """scenarios: [{id: "a", goal: "A"}]""" + "\n"
+
+    val e = assertFailsWith<IllegalArgumentException> { ArbigentScenarioSorter.sort(original) }
+    assertTrue(e.message!!.contains("scenarios"), e.message)
+  }
+}

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -315,7 +315,7 @@ class ArbigentAppStateHolder(
   val additionalActionsFlow = MutableStateFlow<List<String>?>(null)
   // Null means "not set": scenarios without their own maxRetry use the built-in default.
   val projectMaxRetryFlow = MutableStateFlow<Int?>(null)
-  // Whether saving writes `# [depth N] ...` position comments above scenarios (settings.positionComments).
+  // Whether saving writes `# tree: ...` position comments above scenarios (settings.positionComments).
   val positionCommentsFlow = MutableStateFlow(true)
   val decisionCache = cacheStrategyFlow
     .map {

--- a/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
+++ b/arbigent-ui/src/main/kotlin/io/github/takahirom/arbigent/ui/ArbigentAppStateHolder.kt
@@ -315,6 +315,8 @@ class ArbigentAppStateHolder(
   val additionalActionsFlow = MutableStateFlow<List<String>?>(null)
   // Null means "not set": scenarios without their own maxRetry use the built-in default.
   val projectMaxRetryFlow = MutableStateFlow<Int?>(null)
+  // Whether saving writes `# [depth N] ...` position comments above scenarios (settings.positionComments).
+  val positionCommentsFlow = MutableStateFlow(true)
   val decisionCache = cacheStrategyFlow
     .map {
       val decisionCacheStrategy = it.aiDecisionCacheStrategy
@@ -534,7 +536,8 @@ class ArbigentAppStateHolder(
         mcpJson = mcpJsonFlow.value,
         deviceFormFactor = defaultDeviceFormFactorFlow.value,
         additionalActions = additionalActionsFlow.value,
-        maxRetry = projectMaxRetryFlow.value
+        maxRetry = projectMaxRetryFlow.value,
+        positionComments = positionCommentsFlow.value,
       ),
       scenarioContents = sortedScenarios.map { it.createArbigentScenarioContent() },
       reusableScenarios = _reusableScenariosFlow.value,
@@ -608,6 +611,7 @@ class ArbigentAppStateHolder(
     defaultDeviceFormFactorFlow.value = projectFile.settings.deviceFormFactor
     additionalActionsFlow.value = projectFile.settings.additionalActions
     projectMaxRetryFlow.value = projectFile.settings.maxRetry
+    positionCommentsFlow.value = projectFile.settings.positionComments
     _fixedScenariosFlow.value = projectFile.fixedScenarios
     _reusableScenariosFlow.value = projectFile.reusableScenarios
     projectStateFlow.value = ArbigentProject(

--- a/arbigent-ui/src/test/kotlin/ScenarioOrderingUiTest.kt
+++ b/arbigent-ui/src/test/kotlin/ScenarioOrderingUiTest.kt
@@ -123,7 +123,8 @@ class ScenarioOrderingUiTest {
     app.saveProjectContents(file)
 
     val commentLines = file.readLines().filter { ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) }
-    assertEquals(listOf("# [depth 0] root | children: child", "# [depth 1] root > child"), commentLines)
+    assertEquals(listOf("# tree: root | children: child", "# tree: root > child"), commentLines)
+    assertTrue(file.readLines().any { ArbigentScenarioSorter.HEADER_COMMENT_MARKER.containsMatchIn(it) }, file.readText())
     // The comments are not part of what the app tracks as content, so a fresh save is not "dirty".
     assertFalse(app.hasUnsavedChanges())
 
@@ -134,7 +135,7 @@ class ScenarioOrderingUiTest {
     app.loadProjectContents(file)
     app.saveProjectContents(file)
 
-    assertFalse(file.readLines().any { ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) }, file.readText())
+    assertFalse(file.readLines().any { it.startsWith("#") }, file.readText())
     assertTrue(file.readText().contains("positionComments: false"), file.readText())
     file.delete()
   }

--- a/arbigent-ui/src/test/kotlin/ScenarioOrderingUiTest.kt
+++ b/arbigent-ui/src/test/kotlin/ScenarioOrderingUiTest.kt
@@ -1,6 +1,9 @@
+@file:OptIn(ArbigentInternalApi::class)
+
 package io.github.takahirom.arbigent.ui
 
 import io.github.takahirom.arbigent.ArbigentProjectSerializer
+import io.github.takahirom.arbigent.ArbigentInternalApi
 import io.github.takahirom.arbigent.ArbigentScenarioSorter
 import io.github.takahirom.arbigent.ArbigentTagManager
 import kotlinx.coroutines.Dispatchers

--- a/arbigent-ui/src/test/kotlin/ScenarioOrderingUiTest.kt
+++ b/arbigent-ui/src/test/kotlin/ScenarioOrderingUiTest.kt
@@ -1,6 +1,7 @@
 package io.github.takahirom.arbigent.ui
 
 import io.github.takahirom.arbigent.ArbigentProjectSerializer
+import io.github.takahirom.arbigent.ArbigentScenarioSorter
 import io.github.takahirom.arbigent.ArbigentTagManager
 import kotlinx.coroutines.Dispatchers
 import org.junit.Before
@@ -105,6 +106,36 @@ class ScenarioOrderingUiTest {
 
     val written = ArbigentProjectSerializer().load(file).scenarioContents.map { it.id }
     assertEquals(listOf("root", "child", "loose"), written)
+    file.delete()
+  }
+
+  /**
+   * The saved file carries the same position comments `arbigent sort` writes, so a UI save never
+   * strips them (which would make `sort --diff` fail in CI after every save). The file's
+   * `settings.positionComments: false` is honoured and survives a load/save cycle.
+   */
+  @Test
+  fun `saving writes position comments unless the project turns them off`() {
+    val (app, holders) = appWith("child", "root")
+    holders.getValue("child").dependencyScenarioStateHolderStateFlow.value = holders.getValue("root")
+    val file = File.createTempFile("arbigent-comments", ".yml")
+
+    app.saveProjectContents(file)
+
+    val commentLines = file.readLines().filter { ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) }
+    assertEquals(listOf("# [depth 0] root | children: child", "# [depth 1] root > child"), commentLines)
+    // The comments are not part of what the app tracks as content, so a fresh save is not "dirty".
+    assertFalse(app.hasUnsavedChanges())
+
+    val withoutComments = file.readText().lines()
+      .filterNot { ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) }
+      .joinToString("\n") + "\nsettings:\n  positionComments: false\n"
+    file.writeText(withoutComments)
+    app.loadProjectContents(file)
+    app.saveProjectContents(file)
+
+    assertFalse(file.readLines().any { ArbigentScenarioSorter.POSITION_COMMENT_MARKER.containsMatchIn(it) }, file.readText())
+    assertTrue(file.readText().contains("positionComments: false"), file.readText())
     file.delete()
   }
 

--- a/arbigent-yaml-reference.md
+++ b/arbigent-yaml-reference.md
@@ -270,6 +270,10 @@ Before writing it re-reads the result and refuses
 to change the file if the project would decode differently, which needs every scenario to have
 an explicit `id`.
 
+Saving from the UI is different: it regenerates the whole YAML from the loaded project, so
+hand-written comments, unknown keys and custom formatting do not survive a UI save; only the
+`# tree:` lines and the header are recreated. Put notes that must survive in `noteForHumans`.
+
 ## Minimal example
 
 ```yaml

--- a/arbigent-yaml-reference.md
+++ b/arbigent-yaml-reference.md
@@ -259,6 +259,11 @@ scenarios:
   dependency: "open-search"
 ```
 
+`arbigent sort` moves whole `- id:` blocks and leaves every other line as it is, so quoting,
+blank lines and your own comments survive. Before writing it re-reads the result and refuses
+to change the file if the project would decode differently, which needs every scenario to have
+an explicit `id`.
+
 ## Minimal example
 
 ```yaml

--- a/arbigent-yaml-reference.md
+++ b/arbigent-yaml-reference.md
@@ -103,6 +103,7 @@ Legacy scenario-level field, tagged by `type:`. Distinct from the `CleanupData`
 | `deviceFormFactor` | [DeviceFormFactor](#deviceformfactor) | `Unspecified` | Default form factor for all scenarios. |
 | `additionalActions` | `List<String>?` | `null` | Project-wide extra actions. |
 | `maxRetry` | Int? | `null` | Default retry count for scenarios that do not set their own. Unset means `3`. |
+| `positionComments` | Boolean | `true` | Whether saving (UI) and `arbigent sort` write a `# [depth N] root > ... > id \| children: ...` comment above each scenario. The comment is derived from `dependency` and regenerated on every write; `false` removes it. See [Scenario order and position comments](#scenario-order-and-position-comments). |
 
 ### Prompt
 
@@ -228,6 +229,35 @@ Values in `launchArguments`, tagged by `type:`.
 ## DeviceFormFactor
 
 Tagged by `type:`: `Mobile`, `Tv`, or `Unspecified` (default). No other fields.
+
+## Scenario order and position comments
+
+The order of `scenarios` is the order `arbigent run` runs them in and the order `--shard`
+splits them by. The UI saves scenarios in dependency order: each scenario directly after
+the scenario it depends on, roots and siblings in their declared order. `arbigent sort`
+brings a hand-edited file back to that order and `arbigent sort --diff` fails in CI when
+a file has drifted.
+
+Both also write a *position comment* above each scenario. It is not a field: it is a
+YAML comment derived from `dependency`, rewritten on every save or sort, and safe to
+delete (set `settings.positionComments: false` to stop writing it). It exists so that a
+reader of one scenario can see its depth, its ancestors and its direct dependents without
+searching the file:
+
+```yaml
+scenarios:
+# [depth 0] launch-app | children: open-search
+- id: "launch-app"
+  goal: "Launch the app"
+# [depth 1] launch-app > open-search | children: type-keyword
+- id: "open-search"
+  goal: "Open the search screen"
+  dependency: "launch-app"
+# [depth 2] launch-app > open-search > type-keyword
+- id: "type-keyword"
+  goal: "Type a keyword into the search box"
+  dependency: "open-search"
+```
 
 ## Minimal example
 

--- a/arbigent-yaml-reference.md
+++ b/arbigent-yaml-reference.md
@@ -233,8 +233,9 @@ Tagged by `type:`: `Mobile`, `Tv`, or `Unspecified` (default). No other fields.
 ## Scenario order and position comments
 
 The order of `scenarios` is the order `arbigent run` runs them in and the order `--shard`
-splits them by. The UI saves scenarios in dependency order: each scenario directly after
-the scenario it depends on, roots and siblings in their declared order. `arbigent sort`
+splits them by. The UI saves scenarios in dependency order (depth-first): a scenario comes after the
+scenario it depends on, and its whole subtree comes before the next sibling. Roots and
+siblings keep their declared order. `arbigent sort`
 brings a hand-edited file back to that order and `arbigent sort --diff` fails in CI when
 a file has drifted.
 

--- a/arbigent-yaml-reference.md
+++ b/arbigent-yaml-reference.md
@@ -263,7 +263,9 @@ scenarios:
 ```
 
 `arbigent sort` moves whole `- id:` blocks and leaves every other line as it is, so quoting,
-blank lines and your own comments survive. Before writing it re-reads the result and refuses
+blank lines and your own comments survive. The one reserved form is a comment starting with
+`# tree:` right above a scenario: the sorter treats it as its own and rewrites or removes it.
+Before writing it re-reads the result and refuses
 to change the file if the project would decode differently, which needs every scenario to have
 an explicit `id`.
 

--- a/arbigent-yaml-reference.md
+++ b/arbigent-yaml-reference.md
@@ -264,7 +264,8 @@ scenarios:
 
 `arbigent sort` moves whole `- id:` blocks and leaves every other line as it is, so quoting,
 blank lines and your own comments survive. The one reserved form is a comment starting with
-`# tree:` right above a scenario: the sorter treats it as its own and rewrites or removes it.
+`# tree:` inside the `scenarios:` list (above a scenario, even with blank lines in between, or after
+the last one): the sorter treats it as its own and rewrites or removes it.
 Before writing it re-reads the result and refuses
 to change the file if the project would decode differently, which needs every scenario to have
 an explicit `id`.

--- a/arbigent-yaml-reference.md
+++ b/arbigent-yaml-reference.md
@@ -103,7 +103,7 @@ Legacy scenario-level field, tagged by `type:`. Distinct from the `CleanupData`
 | `deviceFormFactor` | [DeviceFormFactor](#deviceformfactor) | `Unspecified` | Default form factor for all scenarios. |
 | `additionalActions` | `List<String>?` | `null` | Project-wide extra actions. |
 | `maxRetry` | Int? | `null` | Default retry count for scenarios that do not set their own. Unset means `3`. |
-| `positionComments` | Boolean | `true` | Whether saving (UI) and `arbigent sort` write a `# [depth N] root > ... > id \| children: ...` comment above each scenario. The comment is derived from `dependency` and regenerated on every write; `false` removes it. See [Scenario order and position comments](#scenario-order-and-position-comments). |
+| `positionComments` | Boolean | `true` | Whether saving (UI) and `arbigent sort` write a `# tree: root > ... > id \| children: ...` comment above each scenario. The comment is derived from `dependency` and regenerated on every write; `false` removes it. See [Scenario order and position comments](#scenario-order-and-position-comments). |
 
 ### Prompt
 
@@ -242,19 +242,21 @@ a file has drifted.
 Both also write a *position comment* above each scenario. It is not a field: it is a
 YAML comment derived from `dependency`, rewritten on every save or sort, and safe to
 delete (set `settings.positionComments: false` to stop writing it). It exists so that a
-reader of one scenario can see its depth, its ancestors and its direct dependents without
-searching the file:
+reader of one scenario can see its ancestors and its direct dependents without
+searching the file. One header line directly under `scenarios:` says that these lines are
+generated and how to refresh them:
 
 ```yaml
 scenarios:
-# [depth 0] launch-app | children: open-search
+# The "# tree:" lines below are generated from `dependency` by `arbigent sort` (and on UI save); do not edit them, rerun `arbigent sort`.
+# tree: launch-app | children: open-search
 - id: "launch-app"
   goal: "Launch the app"
-# [depth 1] launch-app > open-search | children: type-keyword
+# tree: launch-app > open-search | children: type-keyword
 - id: "open-search"
   goal: "Open the search screen"
   dependency: "launch-app"
-# [depth 2] launch-app > open-search > type-keyword
+# tree: launch-app > open-search > type-keyword
 - id: "type-keyword"
   goal: "Type a keyword into the search box"
   dependency: "open-search"


### PR DESCRIPTION
## Summary

Adds `arbigent sort`, which puts the `scenarios:` list of a project file into dependency order and writes a *position comment* above every scenario, and makes the UI save the same comments.

The motivation is readability for whoever reads the YAML directly, increasingly coding agents. In a flat file with dozens of scenarios it is hard to tell, from one scenario, where it sits in the dependency tree. The comment spells it out without adding a new field: the chain of ancestors down to the scenario itself, then its direct dependents. A header line under `scenarios:` says the lines are generated and how to refresh them:

```yaml
scenarios:
# The "# tree:" lines below are generated from `dependency` by `arbigent sort` (and on UI save); do not edit them, rerun `arbigent sort`.
# tree: launch-app | children: open-search, open-settings
- id: "launch-app"
  goal: "Launch the app"
# tree: launch-app > open-search | children: type-keyword
- id: "open-search"
  goal: "Open search"
  dependency: "launch-app"
# tree: launch-app > open-search > type-keyword
- id: "type-keyword"
  goal: "Type a keyword"
  dependency: "open-search"
```

## What changes

- **`arbigent sort`** (new CLI command). Each scenario is moved directly after its `dependency`; roots and siblings keep their declared order (never id-sorted), so hand-curated grouping survives. The order is the one the UI already saves in (`dependencyForestWithDepth`), so run order and `--shard` assignment stay consistent between UI and CLI edits.
  - `--diff` prints a unified diff plus a summary and exits 1 without writing, for CI. Exit 0 and `Already sorted` when nothing would change.
  - `--comments` / `--no-comments` override the project setting; `--no-comments` also removes comments already present.
- **Text-based rewrite.** The sorter cuts the `scenarios:` list into `- id:` blocks and reorders the blocks. Everything else stays byte-for-byte: quoting style, blank lines, unknown keys, your own comments (they move with their scenario). Only the `# tree:` lines and the one header line under `scenarios:` are regenerated. Flow-style lists are rejected rather than rewritten.
- **Safety guard.** Before returning, the sorter decodes the rewritten text and refuses to change the file if the project would decode differently (e.g. a scenario without an explicit `id`, a quoted value continuing at column zero, a `|+` block scalar at the end of the list). Ids that could be misread in the comment (containing `>`, `,`, `|`, a quote, or line breaks) are quoted or escaped. `save` builds the whole text before opening the file, so a rejected rewrite leaves the file untouched.
- **`settings.positionComments`** (default `true`) controls whether the UI save and `arbigent sort` write the comments.
- **UI save** goes through the same core code (`encodeToFileText`), so `sort --diff` in CI does not go red after a UI save. Comments are not part of dirty tracking.
- **Docs**: README, CLI reference, YAML reference, and the `inspecting-project` / `writing-yaml` guides now describe the order and the comment.
- Adds `java-diff-utils` to arbigent-cli for the unified diff.

## Testing

- New `ArbigentScenarioSorterTest` (18 tests): DFS move, idempotency, byte-for-byte preservation, comments travelling with a moved scenario, `--no-comments` removal, detached stale comments, `settings.positionComments`, sibling order, serializer round trip, empty list, cycle rejection, flow-style rejection, escaped and quoted ids, and the guard cases (missing id, column-zero quoted continuation, `|+` at end of list, no final newline).
- New `SortCommandTest` (6 tests): write, already sorted, `--diff` exit code and output, `--no-comments`, validation failure.
- `ScenarioOrderingUiTest` gained a save test for the comments and the setting.
- Full `arbigent-core`, `arbigent-cli`, `arbigent-ui` test suites pass locally.
- Ran the built CLI against 40 historical revisions of a real project file: every non-comment line was preserved and a second run reported `Already sorted`.
