### PR TITLE
Say in the sort help that it rewrites the project YAML

### DIFF
--- a/arbigent-cli/src/main/kotlin/SortCommand.kt
+++ b/arbigent-cli/src/main/kotlin/SortCommand.kt
@@ -31,7 +31,7 @@ class ArbigentSortCommand : CliktCommand(name = "sort") {
   ).switch("--comments" to true, "--no-comments" to false)
 
   override fun help(context: Context): String =
-    "Reorder scenarios into depth-first dependency order and refresh the position comments above them"
+    "Rewrite the project YAML: order scenarios by dependency and refresh the \"# tree:\" comments above them"
 
   override fun run() {
     applyLogLevel(logLevel)


### PR DESCRIPTION
The one-line help for `arbigent sort` said it reorders scenarios, but not that it rewrites the project file. Read in the `arbigent --help` list, that leaves open whether it changes the run order, the `graph` output or the UI list. This makes the command list say what it actually does:

```
  sort         Rewrite the project YAML: order scenarios by dependency and
               refresh the "# tree:" comments above them
```

Help text only; behavior is unchanged.